### PR TITLE
Add renderUrl and adComponents to scoreAd's bidding signals

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -195,7 +195,10 @@ The function gets called once for each candidate ad in the auction.  The argumen
     ```
     { 'topWindowHostname': 'www.example-publisher.com',
       'interestGroupOwner': 'www.example-dsp.com',
-      'interestGroupName': 'womens-running-shoes',
+      'renderUrl': 'https://cdn.com/render_url_of_bid',
+      'adComponents': ['https://cdn.com/ad_component_of_bid',
+                       'https://cdn.com/next_ad_component_of_bid',
+                       ...],
       'adRenderFingerprint': 'M0rNy1D5RVowjnpa',
       'biddingDurationMsec': 12
     }


### PR DESCRIPTION
Add renderUrl and adComponents to scoreAd's bidding signals. We're passing these to the trusted server when fetching trusted scoring, so we should provide them here as well so if a scripts wants them without using a trusted server, it can do so.  Unclear how useful they are here, though.

Also remove interestGroupName, since this was removed from the implementation during privacy/security review.