### PR TITLE
Rename debug functions to match Chrome implementation

### DIFF
--- a/Proposed_First_FLEDGE_OT_Details.md
+++ b/Proposed_First_FLEDGE_OT_Details.md
@@ -56,7 +56,7 @@ As the FLEDGE explainer talks about, the FOT#1 will include event-level reportin
 
   
 
-The FOT#1 will include event-level reporting for both winning and losing bids. Implementations of the `generateBid()` and `scoreAd()` worklets, provided by the buyers and sellers respectively in the auction, may call a `debug.sendReportOnLoss()` API which takes a single string argument representing a URL. If the bid being generated or scored loses the auction, the URL will be fetched. These worklets may also call a `debug.sendReportOnWin()` API which operates similarly to `debug.sendReportOnLoss()` API but only fetches the URL after a winning bid or score.
+The FOT#1 will include event-level reporting for both winning and losing bids. Implementations of the `generateBid()` and `scoreAd()` worklets, provided by the buyers and sellers respectively in the auction, may call a `forDebuggingOnly.reportAdAuctionLoss()` API which takes a single string argument representing a URL. If the bid being generated or scored loses the auction, the URL will be fetched. These worklets may also call a `forDebuggingOnly.reportAdAuctionWin()` API which operates similarly to `forDebuggingOnly.reportAdAuctionLoss()` API but only fetches the URL after a winning bid or score.
 
   
 


### PR DESCRIPTION
As implemented in https://source.chromium.org/chromium/chromium/src/+/48590763ecb8ca825e3957437e9deddbd1c35ed7 these are under different names than originally planned.  Update documentation to match.