### PR TITLE
Add missing flag to FLEDGE OT details doc #275

### DIFF
--- a/Proposed_First_FLEDGE_OT_Details.md
+++ b/Proposed_First_FLEDGE_OT_Details.md
@@ -165,7 +165,7 @@ The plan is for the FOT#1 to include support for multi-seller/SSP auctions. This
 
 To make Chrome’s FLEDGE implementation function as described in this document, use a very recent version of Chrome, e.g. Chrome Canary, and pass this parameter to Chrome on the command line:
 
-`--enable-features=InterestGroupStorage,AdInterestGroupAPI,Fledge,AllowURNsInIframes`
+`--enable-features=InterestGroupStorage,AdInterestGroupAPI,Fledge,AllowURNsInIframes,BiddingAndScoringDebugReportingAPI`
 
 #### Privacy Limitations of FOT#1
 


### PR DESCRIPTION
The BiddingAndScoringDebugReportingAPI flag was missing from the list of flags required to make Chrome's behavior mimic the details in this doc.