### PR TITLE
Remove an ambiguous word in the trusted server API spec

### DIFF
--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -344,7 +344,7 @@ A list of JSON objects where each object contains the following:
   <tr>
    <td>delete
    </td>
-   <td>If set, it indicates that this key should be deleted immediately.
+   <td>If set, it indicates that this key should be deleted.
    </td>
    <td>DSP, SSP
    </td>


### PR DESCRIPTION
"Immediately" may indicate a lower latency than we originally thought it to have.