### PR TITLE
registerAdBeacon: as implemented in Chrome, 'url' is not required

### DIFF
--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -88,7 +88,7 @@ The worklet is able to add the buyerEventId/sellerEventId and any other relevant
 
 ```
 registerAdBeacon({
- 'click': {'url': 'https://adtech.example/click?buyer_event_id=123'},
+ 'click': 'https://adtech.example/click?buyer_event_id=123',
 });
 ```
 


### PR DESCRIPTION
For an example, see: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/interest_group/auction_runner_unittest.cc;drc=9c37c816537202ef21e9447ddfe081093d292c97;l=308

```
      registerAdBeacon({
        "click": "https://buyer-reporting.example.com/" + 2*bid,
      });
```