### PR TITLE
Update example to use serialized JSON string for eventData

### DIFF
--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -68,6 +68,14 @@ window.fence.reportEvent({
 });
 ```
 
+```
+window.fence.reportEvent({
+  'eventType': 'click',
+  'eventData': 'an example string',
+  'destination':['buyer', 'seller']
+});
+```
+
 Note `window.fence` here is a new namepsace for APIs that are only available from within a fenced frame. 
 
 ## registerAdBeacon

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -63,7 +63,7 @@ Browser will process this similar to how the existing [navigator.sendBeacon](htt
 ```
 window.fence.reportEvent({
   'eventType': 'click',
-  'eventData': {'clickX': '123', 'clickY': '456'},
+  'eventData': JSON.stringify({'clickX': '123', 'clickY': '456'}),
   'destination':['buyer', 'seller']
 });
 ```


### PR DESCRIPTION
reportEvent API accepts a DOMString for eventData.