### PR TITLE
registerAdBeacon parameters to match the implementation

### DIFF
--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -85,18 +85,14 @@ A similar API was initially discussed here: https://github.com/WICG/turtledove/i
 
 ### Parameters
 
-**Event type:** E.g. click. This corresponds to the event type in reportEvent. This is for enabling buyers/ sellers to register distinct beacon URLs for different event types.
-
-**URL:** The URL to which a beacon will be sent by the browser on receiving events from the fenced frame via reportEvent
-The worklet is able to add the buyerEventId/sellerEventId and any other relevant information via this API.
-
+A map from event type to reporting url, where the event type corresponds to the event type in reportEvent. Event type enables the worklets (for buyer, seller or component seller) to register distinct beacon URLs for different event types. The reporting url is the url to which a beacon will be sent by the browser on receiving events from the fenced frame via reportEvent. The worklet is able to add the buyerEventId/sellerEventId and any other relevant information by adding to this url.
 
 ### Example
 
 
 ```
 registerAdBeacon({
- 'click': {'url': 'https://adtech.example/click?buyer_event_id=123'},
+ 'click': 'https://adtech.example/click?buyer_event_id=123',
 });
 ```
 

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -85,7 +85,9 @@ A similar API was initially discussed here: https://github.com/WICG/turtledove/i
 
 ### Parameters
 
-A map from event type to reporting url, where the event type corresponds to the event type in reportEvent. Event type enables the worklets (for buyer, seller or component seller) to register distinct beacon URLs for different event types. The reporting url is the url to which a beacon will be sent by the browser on receiving events from the fenced frame via reportEvent. The worklet can add the buyerEventId/sellerEventId or any other relevant information as query parameters to this url.
+A map from event type to reporting url, where the event type corresponds to the value of reportEvent. The event type enables worklets (for buyer, seller, or component seller) to register distinct beacon URLs for different event types. The reporting url is the location where a beacon is sent once the fenced frame delivers an event via reportEvent.
+
+Worklets can add the buyerEventId, sellerEventId, or any other relevant information as query parameters to this url.
 
 ### Example
 

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -87,7 +87,7 @@ A similar API was initially discussed here: https://github.com/WICG/turtledove/i
 
 A map from event type to reporting URL, where the event type corresponds to the `eventType` value passed to  `reportEvent()`. The event type enables worklets (for buyer, seller, or component seller) to register distinct reporting URLs for different event types. The reporting URL is the location where a beacon is sent once the fenced frame delivers the corresponding event via `reportEvent()`.
 
-Worklets can add the buyerEventId, sellerEventId, or any other relevant information as query parameters to this url.
+Worklets can add a buyer event identifier, seller event identifier, or any other relevant information as query parameters to this URL.
 
 ### Example
 

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -85,7 +85,7 @@ A similar API was initially discussed here: https://github.com/WICG/turtledove/i
 
 ### Parameters
 
-A map from event type to reporting url, where the event type corresponds to the value of reportEvent. The event type enables worklets (for buyer, seller, or component seller) to register distinct beacon URLs for different event types. The reporting url is the location where a beacon is sent once the fenced frame delivers an event via reportEvent.
+A map from event type to reporting URL, where the event type corresponds to the `eventType` value passed to  `reportEvent()`. The event type enables worklets (for buyer, seller, or component seller) to register distinct reporting URLs for different event types. The reporting URL is the location where a beacon is sent once the fenced frame delivers the corresponding event via `reportEvent()`.
 
 Worklets can add the buyerEventId, sellerEventId, or any other relevant information as query parameters to this url.
 

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -54,7 +54,7 @@ Browser will process this similar to how the existing [navigator.sendBeacon](htt
 
 **Event type and data:** Includes the event type and data associated with an event. When an event type e.g. click matches to the event type registered in registerAdBeacon, the data will be used by the browser as the data sent in the beacon sent to the registered URL.
 
-**Destination type:** List of values to determine whether this event needs to be reported to buyer, seller or component seller or any combination of those.
+**Destination type:** List of values to determine whose registered beacons are reported, can be a combination of 'buyer', 'seller', or 'component-seller'.
 
 
 ### Example
@@ -72,7 +72,7 @@ window.fence.reportEvent({
 window.fence.reportEvent({
   'eventType': 'click',
   'eventData': 'an example string',
-  'destination':['buyer', 'seller']
+  'destination':['component-seller']
 });
 ```
 

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -54,7 +54,7 @@ Browser will process this similar to how the existing [navigator.sendBeacon](htt
 
 **Event type and data:** Includes the event type and data associated with an event. When an event type e.g. click matches to the event type registered in registerAdBeacon, the data will be used by the browser as the data sent in the beacon sent to the registered URL.
 
-**Destination type:** List of values to determine whether this event needs to be reported to both buyer and seller, only buyer or only seller.
+**Destination type:** List of values to determine whether this event needs to be reported to buyer, seller or component seller or any combination of those.
 
 
 ### Example
@@ -85,7 +85,7 @@ A similar API was initially discussed here: https://github.com/WICG/turtledove/i
 
 ### Parameters
 
-A map from event type to reporting url, where the event type corresponds to the event type in reportEvent. Event type enables the worklets (for buyer, seller or component seller) to register distinct beacon URLs for different event types. The reporting url is the url to which a beacon will be sent by the browser on receiving events from the fenced frame via reportEvent. The worklet is able to add the buyerEventId/sellerEventId and any other relevant information by adding to this url.
+A map from event type to reporting url, where the event type corresponds to the event type in reportEvent. Event type enables the worklets (for buyer, seller or component seller) to register distinct beacon URLs for different event types. The reporting url is the url to which a beacon will be sent by the browser on receiving events from the fenced frame via reportEvent. The worklet can add the buyerEventId/sellerEventId or any other relevant information as query parameters to this url.
 
 ### Example
 


### PR DESCRIPTION
Updates registerAdBeacon's description and arguments to match the implementation.
Reference issue: Similar to changes proposed in https://github.com/WICG/turtledove/pull/297 but that one just changed the example while this changes the text as well as the example.