### PR TITLE
placeholder is in reporting URL's query string now

### DIFF
--- a/Proposed_First_FLEDGE_OT_Details.md
+++ b/Proposed_First_FLEDGE_OT_Details.md
@@ -56,7 +56,7 @@ As the FLEDGE explainer talks about, the FOT#1 will include event-level reportin
 
   
 
-The FOT#1 will include event-level reporting for both winning and losing bids. Implementations of the `generateBid()` and `scoreAd()` worklets, provided by the buyers and sellers respectively in the auction, may call a `forDebuggingOnly.reportAdAuctionLoss()` API which takes a single string argument representing a URL. The text placeholders below will be replaced with the corresponding value from the auction when found in the reporting URL (right now this replacement only happens in the path of the URL, but when http://crbug.com/1338233 is fixed the replacement should only happen in the query parameters of the URL).
+The FOT#1 will include event-level reporting for both winning and losing bids. Implementations of the `generateBid()` and `scoreAd()` worklets, provided by the buyers and sellers respectively in the auction, may call a `forDebuggingOnly.reportAdAuctionLoss()` API which takes a single string argument representing a URL. The text placeholders below will be replaced with the corresponding value from the auction when found in the reporting URL's query parameters.
 
 *   “${winningBid}” - The value of the winning bid.  In component auctions, this value comes from the component auction and not the top-level auction.
 *   “${madeWinningBid}” - A boolean value representing whether the owner of this interest group made the winning bid, either via this interest group, or another interest group with the same owner.  In component auctions, this value comes from the component auction and not the top-level auction.

--- a/Proposed_First_FLEDGE_OT_Details.md
+++ b/Proposed_First_FLEDGE_OT_Details.md
@@ -56,7 +56,7 @@ As the FLEDGE explainer talks about, the FOT#1 will include event-level reportin
 
   
 
-The FOT#1 will include event-level reporting for both winning and losing bids. Implementations of the `generateBid()` and `scoreAd()` worklets, provided by the buyers and sellers respectively in the auction, may call a `forDebuggingOnly.reportAdAuctionLoss()` API which takes a single string argument representing a URL. The text placeholders below will be replaced with the corresponding value from the auction when found in the reporting URL's query parameters.
+The FOT#1 will include event-level reporting for both winning and losing bids. Implementations of the `generateBid()` and `scoreAd()` worklets, provided by the buyers and sellers respectively in the auction, may call a `forDebuggingOnly.reportAdAuctionLoss()` API which takes a single string argument representing a URL. The text placeholders below will be replaced with the corresponding value from the auction when found in the reporting URL's query parameters (note that due to http://crbug.com/1338233, prior to Chrome version 107.0.5286.0, the replacements only took place in the path of the URL)
 
 *   “${winningBid}” - The value of the winning bid.  In component auctions, this value comes from the component auction and not the top-level auction.
 *   “${madeWinningBid}” - A boolean value representing whether the owner of this interest group made the winning bid, either via this interest group, or another interest group with the same owner.  In component auctions, this value comes from the component auction and not the top-level auction.

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,6 +1,14 @@
 # FLEDGE Release Notes
 
 
+## Chrome M107
+
+
+
+*   Bug fixes:
+    *   Placeholder replacement of post-auction signals in FLEDGE 'forDebuggingOnly' URLs only takes place in query parameters now, instead of path.
+
+
 ## Chrome M104
 
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -6,7 +6,7 @@
 
 
 *   Bug fixes:
-    *   ['forDebuggingOnly' URLs only replaces post-auction signals placeholders in query parameters now, instead of path](http://crbug.com/1338233).
+    *   [The `forDebuggingOnly.reportAdAuctionLoss()` and `forDebuggingOnly.reportAdAuctionWin()` APIs were fixed to perform post-auction signal parameter replacement on URL query parameters instead of the URL path](http://crbug.com/1338233).
 
 
 ## Chrome M104

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -6,7 +6,7 @@
 
 
 *   Bug fixes:
-    *   Placeholder replacement of post-auction signals in FLEDGE 'forDebuggingOnly' URLs only takes place in query parameters now, instead of path.
+    *   ['forDebuggingOnly' URLs only replaces post-auction signals placeholders in query parameters now, instead of path](http://crbug.com/1338233).
 
 
 ## Chrome M104


### PR DESCRIPTION
http://crbug.com/1338233 is fixed.
FLEDGE 'forDebuggingOnly' only replaces ${} placeholders in report URL's query parameters now, instead of path.