### PR TITLE
fix build error caused by empty spec.bs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1,0 +1,2 @@
+<pre class="metadata">
+</pre>

--- a/spec.bs
+++ b/spec.bs
@@ -1,2 +1,19 @@
 <pre class="metadata">
+Title: FLEDGE
+Shortname: fledge
+Repository: WICG/turtledove
+Inline Github Issues: true
+Group: WICG
+Status: CG-DRAFT
+Level: 1
+URL: https://wicg.github.io/fledge/
+Boilerplate: omit conformance, omit feedback-header
+Editor: Paul Jensen, Google https://www.google.com/, pauljensen@google.com
+!Participate: <a href="https://github.com/WICG/turtledove">GitHub WICG/turtledove</a> (<a href="https://github.com/WICG/turtledove/issues/new">new issue</a>, <a href="https://github.com/WICG/turtledove/issues?state=open">open issues</a>)
+!Commits: <a href="https://github.com/WICG/turtledove/commits/main/spec.bs">GitHub spec.bs commits</a>
+Complain About: accidental-2119 yes, missing-example-ids yes
+Indent: 2
+Default Biblio Status: current
+Markup Shorthands: markdown yes
+Assume Explicit For: yes
 </pre>

--- a/spec.bs
+++ b/spec.bs
@@ -9,6 +9,7 @@ Level: 1
 URL: https://wicg.github.io/fledge/
 Boilerplate: omit conformance, omit feedback-header
 Editor: Paul Jensen, Google https://www.google.com/, pauljensen@google.com
+Abstract: Provides a privacy advancing API to facilitate interest group based advertising.
 !Participate: <a href="https://github.com/WICG/turtledove">GitHub WICG/turtledove</a> (<a href="https://github.com/WICG/turtledove/issues/new">new issue</a>, <a href="https://github.com/WICG/turtledove/issues?state=open">open issues</a>)
 !Commits: <a href="https://github.com/WICG/turtledove/commits/main/spec.bs">GitHub spec.bs commits</a>
 Complain About: accidental-2119 yes, missing-example-ids yes


### PR DESCRIPTION
All builds now failed with the error below:

FATAL ERROR: The document requires at least one &lt;pre class=metadata> block.
 ✘  Did not generate, due to fatal errors
make[1]: *** [Makefile:10: spec.html] Error 22
make: *** [Makefile:26: ci] Error 2

It seems to be due to the spec.bs being empty, but at least one pre class="metadata" block is required.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 13, 2022, 8:49 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fturtledove%2F4eb829b882136c6f44992358ec158c7642e3317c%2Fspec.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: The document requires at least one &lt;pre class=metadata> block.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/turtledove%23347.)._
</details>
