### PR TITLE
Update the Key Value Server API explainer.

### DIFF
--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -234,11 +234,12 @@ decision on a best-effort basis to use versions as new as possible.
 The server does not guarantee that the version will always be returned. It’s
 much more likely when the number of keys in a request is small.
 
-## Server Internal APIs
-The system would provide multiple private APIs, primarily for loading data and user-defined functions whose model is described in detail in the [Key/Value server design explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md#support-for-user-defined-functions-udfs), and possibly more in the future.
+## Server Internal APIs and procedures
 
-These all are private processes with ACLs controlled by the ad tech operator of the system, for only the operator (and their designated parties) to use.
+The system will provide multiple private APIs and procedures, for loading data and user-defined functions whose model is described in detail in the [Key/Value server design explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md#support-for-user-defined-functions-udfs).
 
-The key/value server code is available on its [Privacy Sandbox github repo](https://github.com/privacysandbox/fledge-key-value-service) which reflects the most recent API and processes. As an example, the [data loading guide](https://github.com/privacysandbox/fledge-key-value-service/blob/main/docs/loading_data.md) has specific instructions on how to integrate with the data ingestion process. The process may be based on the actual storage medium of the dataset, e.g., the server can read data from data files in a prespecified location.
+These APIs and procedures are ACLs controlled by the ad tech operator of the system, for only the operator (and their designated parties) to use.
 
-As the [FLEDGE API](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) describes the client side flow, the APIs and processes related to the server system design and implementation will have the specification posted and updated in the key/value server’s [github repo](https://github.com/privacysandbox/fledge-key-value-service).
+The key/value server code is available on its [Privacy Sandbox github repo](https://github.com/privacysandbox/fledge-key-value-service) which reflects the most recent API and procedures. As an example, the [data loading guide](https://github.com/privacysandbox/fledge-key-value-service/blob/main/docs/loading_data.md) has specific instructions on integrating with the data ingestion procedure. The procedure may be based on the actual storage medium of the dataset, e.g., the server can read data from data files from a prespecified location.
+
+As the [FLEDGE API](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) describes the client side flow, the APIs and procedures related to the server system design and implementation will have the specification posted and updated in the key/value server’s [github repo](https://github.com/privacysandbox/fledge-key-value-service).

--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -2,8 +2,7 @@
 
 ## Summary
 
-[FLEDGE](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) provides a
-privacy advancing API to facilitate interest group based advertising. Trusted
+[FLEDGE](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) is a privacy-preserving API that facilitates interest group based advertising. Trusted
 servers in FLEDGE are used to add real-time signals into ad selection for both
 buyers and sellers. The FLEDGE proposal specifies that these trusted servers
 should provide basic key-value lookups to facilitate fetching these signals but
@@ -12,9 +11,6 @@ do no event-level logging or have other side effects.
 This explainer proposes APIs for trusted servers. Future explainers will cover
 trusted servers in more detail, including threat models, trust models, and
 system design.
-
-The APIs presented here are a proposal for the initial version “v1” of these
-servers.
 
 ## Concepts
 
@@ -46,7 +42,7 @@ query to a particular subkey does not match any existing entry, the server
 system can automatically fallback to a default value for the key, specified by
 not setting the subkey during data updates.
 
-## Read API
+## Query API Version 1
 
 ### Description
 
@@ -238,230 +234,11 @@ decision on a best-effort basis to use versions as new as possible.
 The server does not guarantee that the version will always be returned. It’s
 much more likely when the number of keys in a request is small.
 
-## Mutating API
+## Server Internal APIs
+The system would provide multiple private APIs, primarily for loading data and user-defined functions whose model is described in detail in the [Key/Value server design explainer](https://github.com/privacysandbox/fledge-docs/blob/main/key_value_service_trust_model.md#support-for-user-defined-functions-udfs), and possibly more in the future.
 
-### Description
+These all are private processes with ACLs controlled by the ad tech operator of the system, for only the operator (and their designated parties) to use.
 
-This is an internal API with ACLs controlled by the ad tech operator of the
-system, for only the operator (and their designated parties) to use.
+The key/value server code is available on its [Privacy Sandbox github repo](https://github.com/privacysandbox/fledge-key-value-service) which reflects the most recent API and processes. As an example, the [data loading guide](https://github.com/privacysandbox/fledge-key-value-service/blob/main/docs/loading_data.md) has specific instructions on how to integrate with the data ingestion process. The process may be based on the actual storage medium of the dataset, e.g., the server can read data from data files in a prespecified location.
 
-This is the only API that can write data to the system. Details will be defined
-in the future on the mechanism to bootstrap the system state.
-
-The ad tech platform will need to decide when to invoke the Mutating API for
-data updates. The API supports writing key-value objects in batches but it is
-not required to group all updates in one call.
-
-The API is synchronous. When it returns successfully, the update data is
-guaranteed to be persisted but might not necessarily be served immediately.
-
-A small amount of staleness (*O(minutes*)) may be expected before updated data
-can be returned by the server for queries (“becomes live”). As mentioned in the
-[data version](#data-version-response-header) section, data newly written will
-be assigned a version. Repeated updates on the same namespace + key + subkey in
-a short amount of time before the data is live will result in only one of the
-updates being assigned a version. The others will be overwritten and discarded.
-
-### Form
-
-```
-[endpoint internal to the ad tech operator]/v1/setvalues
-```
-
-There will be configuration options for setting up the endpoint. The
-configuration is not considered API.
-
-### Protocol
-
-For usability, HTTPS POST will be the default protocol. Streaming protocols
-could be evaluated for support based on demand.
-
-### Body JSON schema
-
-A list of JSON objects where each object contains the following:
-
-<table>
-  <tr>
-   <td style="background-color: #cfe2f3">Field
-   </td>
-   <td style="background-color: #cfe2f3">Value Description
-   </td>
-   <td style="background-color: #cfe2f3">Mode
-   </td>
-   <td style="background-color: #cfe2f3">Required
-   </td>
-   <td style="background-color: #cfe2f3">Type
-   </td>
-  </tr>
-  <tr>
-   <td>namespace
-   </td>
-   <td>See the <a href="#namespace">namespace</a> concept.
-   </td>
-   <td><code>keys</code> is available for the DSP and <code>renderUrls</code> and <code>adComponentRenderUrls</code> are for the SSP.
-   </td>
-   <td>Required
-   </td>
-   <td>String
-   </td>
-  </tr>
-  <tr>
-   <td>key
-   </td>
-   <td>Value of the key itself.
-   </td>
-   <td>DSP, SSP
-   </td>
-   <td>Required
-   </td>
-   <td>String
-   </td>
-  </tr>
-  <tr>
-   <td>subkey
-   </td>
-   <td>If set, the value being updated will only be returned when the Read API parameters include this subkey. If unset, the value will become the default value for the key. When a lookup of a particular subkey returns no result, the default value will serve as the result.
-   </td>
-   <td>DSP, SSP
-   </td>
-   <td>Optional
-   </td>
-   <td>String
-   </td>
-  </tr>
-  <tr>
-   <td>update
-   </td>
-   <td>If set, it indicates that this entry should be created/updated with given information.
-   </td>
-   <td>DSP, SSP
-   </td>
-   <td>Optional
-   </td>
-   <td><a href="#update-json-schema">JSON object</a>
-   </td>
-  </tr>
-  <tr>
-   <td>delete
-   </td>
-   <td>If set, it indicates that this key should be deleted.
-   </td>
-   <td>DSP, SSP
-   </td>
-   <td>Optional
-   </td>
-   <td>Bool
-   </td>
-  </tr>
-</table>
-
-Note:`update` and `delete` are mutually exclusive. Only one must be set.
-
-### Update JSON schema
-
-<table>
-  <tr>
-   <td style="background-color: #cfe2f3">Field
-   </td>
-   <td style="background-color: #cfe2f3">Value Description
-   </td>
-   <td style="background-color: #cfe2f3">Required
-   </td>
-   <td style="background-color: #cfe2f3">Type
-   </td>
-  </tr>
-  <tr>
-   <td>value
-   </td>
-   <td>Actual value corresponding to the key. If set, the current value will be updated to this new value.
-   </td>
-   <td>Optional
-   </td>
-   <td>Any JSON type
-   </td>
-  </tr>
-  <tr>
-   <td>expiration
-   </td>
-   <td>Specification of the key expiration configuration. If not set, the key will not be garbage collected.
-   </td>
-   <td>Optional
-   </td>
-   <td><a href="#expiration-json-schema">JSON object</a>
-   </td>
-  </tr>
-</table>
-
-### Expiration JSON schema
-
-The fields are mutually exclusive. Only one can be set.
-
-<table>
-  <tr>
-   <td style="background-color: #cfe2f3">Field
-   </td>
-   <td style="background-color: #cfe2f3">Value Description
-   </td>
-   <td style="background-color: #cfe2f3">Required
-   </td>
-   <td style="background-color: #cfe2f3">Type
-   </td>
-  </tr>
-  <tr>
-   <td>time
-   </td>
-   <td>Absolute time after which the key will be expired.
-   </td>
-   <td>Optional
-   </td>
-   <td>String. In RFC 3339 time format
-   </td>
-  </tr>
-  <tr>
-   <td>hours
-   </td>
-   <td>Hours since the current server time as of processing of this request.
-   </td>
-   <td>Optional
-   </td>
-   <td>Number (integer)
-   </td>
-  </tr>
-</table>
-
-### Example request body
-
-```
-[
-  {
-    "namespace": "renderUrls",
-    "key": "https://cdn.com/render_url_of_some_bid",
-    "update": {
-      "value": "foo",
-      "expiration": {"hours": 10}
-    }
-  },
-  {
-    "namespace": "adComponentRenderUrls",
-    "key": "https://cdn.com/ad_component_of_a_bid",
-    "update": {
-      "value": "bar",
-      "expiration": {"time": "2039-12-31T22:33:44Z"}
-    }
-  }
-]
-```
-
-### Response
-
-If the operation succeeds, an HTTP 200 response is returned. If the server
-fails, an appropriate error code (e.g., HTTP 500) will be returned.
-
-The request body is a list of JSON objects where each object represents a change
-to be applied. When a request includes more than one change (such as multiple
-updates) and one of the changes encounters an error during processing (such as
-having an invalid expiration format), the other changes in the same request may
-or may not be applied on the server side.
-
-If the protocol is bi-directional streaming, the server will return a status for
-each request.
+As the [FLEDGE API](https://github.com/WICG/turtledove/blob/main/FLEDGE.md) describes the client side flow, the APIs and processes related to the server system design and implementation will have the specification posted and updated in the key/value server’s [github repo](https://github.com/privacysandbox/fledge-key-value-service).


### PR DESCRIPTION
The server internal API section now refers to the server code repo to prevent out-of-date information.