### PR TITLE
Add IDL to spec for the API calls and parameter types

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -23,10 +23,9 @@ Assume Explicit For: yes
 
 <em>This section is non-normative</em>
 
-FLEDGE serves remarketing and custom audience use cases and is designed so that it cannot be used by third parties 
-to track user browsing behavior across sites.
+The FLEDGE API facilitates selecting an advertisement to display to a user based on a previous interaction with the advertiser or advertising network.
 
-The FLEDGE API enables on-device auctions in the browser to choose relevant ads from websites the user has previously visited.
+When a user's interactions with an advertiser indicate an interest in something, the advertiser can ask the browser to record this interest on-device by calling {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}.  Later, when a website wants to select an advertisement to show to the user, the website can call {{Window/navigator}}.{{Navigator/runAdAuction()}} to ask the browser to conduct an auction where each of these on-device recorded interests are given the chance to calculate a bid to display their advertisement.
 
 
 <h2 id="joining-interest-groups">Joining Interest Groups</h2>

--- a/spec.bs
+++ b/spec.bs
@@ -23,6 +23,7 @@ Assume Explicit For: yes
 <h2 id="join-ad-interest-group">joinAdInterestGroup</h2>
 
 <xmp class="idl">
+[SecureContext]
 partial interface Navigator {
   Promise<undefined> joinAdInterestGroup(AuctionAdInterestGroup group, double durationSeconds);
 };
@@ -32,6 +33,7 @@ partial interface Navigator {
 <h2 id="run-ad-auction">runAdAuction</h2>
 
 <xmp class="idl">
+[SecureContext]
 partial interface Navigator {
   Promise<USVString?> runAdAuction(AuctionAdConfig config);
 };

--- a/spec.bs
+++ b/spec.bs
@@ -73,7 +73,7 @@ dictionary AuctionAdInterestGroup {
 </xmp>
 
 
-<h2 id="run-ad-auction">runAdAuction</h2>
+<h2 id="running-ad-auctions">Running Ad Auctions</h2>
 
 An ad space seller for a site that displays ads (most likely the site's SSP, or the site itself) 
 can use FLEDGE to run an ad auction to select the most appropriate ads to display to the user. 

--- a/spec.bs
+++ b/spec.bs
@@ -19,8 +19,20 @@ Markup Shorthands: markdown yes
 Assume Explicit For: yes
 </pre>
 
+<h2 id="intro">Introduction</h2>
+
+<em>This section is non-normative</em>
+
+FLEDGE serves remarketing and custom audience use cases and is designed so that it cannot be used by third parties 
+to track user browsing behavior across sites.
+
+The FLEDGE API enables on-device auctions in the browser to choose relevant ads from websites the user has previously visited.
+
 
 <h2 id="join-ad-interest-group">joinAdInterestGroup</h2>
+
+An interest group owner (such as a DSP working for a site that displays ads) can ask the user's browser to add membership for the interest group
+by calling the JavaScript function navigator.joinAdInterestGroup().
 
 <xmp class="idl">
 [SecureContext]
@@ -62,6 +74,13 @@ dictionary AuctionAdInterestGroup {
 
 <h2 id="run-ad-auction">runAdAuction</h2>
 
+  An ad space seller for a site that displays ads (most likely the site's SSP, or the site itself) 
+  can use FLEDGE to run an ad auction to select the most appropriate ads to display to the user. 
+  The seller calls the navigator.runAdAuction()function, 
+  providing a configuration that lists interest group owners who are invited to bid. 
+  Bidding code is only run during the auction for interest groups that the browser is a member of, 
+  and whose owners have been invited to bid.
+  
 <xmp class="idl">
 [SecureContext]
 partial interface Navigator {

--- a/spec.bs
+++ b/spec.bs
@@ -77,7 +77,7 @@ dictionary AuctionAdInterestGroup {
 
 An ad space seller for a site that displays ads (most likely the site's SSP, or the site itself) 
 can use FLEDGE to run an ad auction to select the most appropriate ads to display to the user. 
-The seller calls the navigator.runAdAuction()function, 
+The seller calls the {{Window/navigator}}.{{Navigator/runAdAuction()}} function, 
 providing a configuration that lists interest group owners who are invited to bid. 
 Bidding code is only run during the auction for interest groups that the browser is a member of, 
 and whose owners have been invited to bid.

--- a/spec.bs
+++ b/spec.bs
@@ -30,8 +30,7 @@ When a user's interactions with an advertiser indicate an interest in something,
 
 <h2 id="joining-interest-groups">Joining Interest Groups</h2>
 
-An interest group owner (such as a DSP working for a site that displays ads) can ask the user's browser to add membership for the interest group
-by calling {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}.
+When a user's interactions with a website indicate that the user may have a particular interest, an advertiser or someone working on behalf of the advertiser (e.g. a demand side platform, DSP) can ask the user's browser to record this interest on-device by calling {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}.  This indicates an intent to display an advertisement relevant to this interest to this user in the future.
 
 
 <xmp class="idl">

--- a/spec.bs
+++ b/spec.bs
@@ -75,12 +75,12 @@ dictionary AuctionAdInterestGroup {
 
 <h2 id="run-ad-auction">runAdAuction</h2>
 
-  An ad space seller for a site that displays ads (most likely the site's SSP, or the site itself) 
-  can use FLEDGE to run an ad auction to select the most appropriate ads to display to the user. 
-  The seller calls the navigator.runAdAuction()function, 
-  providing a configuration that lists interest group owners who are invited to bid. 
-  Bidding code is only run during the auction for interest groups that the browser is a member of, 
-  and whose owners have been invited to bid.
+An ad space seller for a site that displays ads (most likely the site's SSP, or the site itself) 
+can use FLEDGE to run an ad auction to select the most appropriate ads to display to the user. 
+The seller calls the navigator.runAdAuction()function, 
+providing a configuration that lists interest group owners who are invited to bid. 
+Bidding code is only run during the auction for interest groups that the browser is a member of, 
+and whose owners have been invited to bid.
   
 <xmp class="idl">
 [SecureContext]

--- a/spec.bs
+++ b/spec.bs
@@ -73,12 +73,8 @@ dictionary AuctionAdInterestGroup {
 
 <h2 id="running-ad-auctions">Running Ad Auctions</h2>
 
-An ad space seller for a site that displays ads (most likely the site's SSP, or the site itself) 
-can use FLEDGE to run an ad auction to select the most appropriate ads to display to the user. 
-The seller calls the {{Window/navigator}}.{{Navigator/runAdAuction()}} function, 
-providing a configuration that lists interest group owners who are invited to bid. 
-Bidding code is only run during the auction for interest groups that the browser is a member of, 
-and whose owners have been invited to bid.
+When a website or someone working on behalf of the website (e.g. a supply side platform, SSP)  wants to conduct an auction to select an advertisement to display to the user, they can call the {{Window/navigator}}.{{Navigator/runAdAuction()}} function, 
+providing an auction configuration that tells the browser how to conduct the auction and which on-device recorded interests are allowed to bid in the auction for the chance to display their advertisement.
   
 <xmp class="idl">
 [SecureContext]

--- a/spec.bs
+++ b/spec.bs
@@ -27,61 +27,15 @@ Assume Explicit For: yes
 partial interface Navigator {
   Promise<undefined> joinAdInterestGroup(AuctionAdInterestGroup group, double durationSeconds);
 };
-</xmp>
 
-
-<h2 id="run-ad-auction">runAdAuction</h2>
-
-<xmp class="idl">
-[SecureContext]
-partial interface Navigator {
-  Promise<USVString?> runAdAuction(AuctionAdConfig config);
-};
-</xmp>
-
-
-<xmp class="idl">
-dictionary AuctionAdConfig {
-  required USVString seller;
-  required USVString decisionLogicUrl;
-  USVString trustedScoringSignalsUrl;
-  sequence<USVString> interestGroupBuyers;
-  any auctionSignals;
-  any sellerSignals;
-  USVString directFromSellerSignals;
-  unsigned long long sellerTimeout;
-  unsigned short sellerExperimentGroupId;
-  record<USVString, any> perBuyerSignals;
-  record<USVString, unsigned long long> perBuyerTimeouts;
-  record<USVString, unsigned short> perBuyerGroupLimits;
-  record<USVString, unsigned short> perBuyerExperimentGroupIds;
-  record<USVString, record<USVString, double>> perBuyerPrioritySignals;
-  sequence<AuctionAdConfig> componentAuctions;
-  AbortSignal? signal;
-};
-</xmp>
-
-
-
-<h2 id="advertisements">Advertisements</h2>
-
-
-<xmp class="idl">
-dictionary AuctionAd {
-  required USVString renderUrl;
-  any metadata;
-};
-</xmp>
-
-
-<h2 id="advertisement-interest-groups">Advertisement Interest Groups</h2>
-
-
-
-<xmp class="idl">
 enum WorkletExecutionMode {
   "compatibility",
   "groupByOrigin",
+};
+
+dictionary AuctionAd {
+  required USVString renderUrl;
+  any metadata;
 };
 
 dictionary AuctionAdInterestGroup {
@@ -102,5 +56,34 @@ dictionary AuctionAdInterestGroup {
   any userBiddingSignals;
   sequence<AuctionAd> ads;
   sequence<AuctionAd> adComponents;
+};
+</xmp>
+
+
+<h2 id="run-ad-auction">runAdAuction</h2>
+
+<xmp class="idl">
+[SecureContext]
+partial interface Navigator {
+  Promise<USVString?> runAdAuction(AuctionAdConfig config);
+};
+
+dictionary AuctionAdConfig {
+  required USVString seller;
+  required USVString decisionLogicUrl;
+  USVString trustedScoringSignalsUrl;
+  sequence<USVString> interestGroupBuyers;
+  any auctionSignals;
+  any sellerSignals;
+  USVString directFromSellerSignals;
+  unsigned long long sellerTimeout;
+  unsigned short sellerExperimentGroupId;
+  record<USVString, any> perBuyerSignals;
+  record<USVString, unsigned long long> perBuyerTimeouts;
+  record<USVString, unsigned short> perBuyerGroupLimits;
+  record<USVString, unsigned short> perBuyerExperimentGroupIds;
+  record<USVString, record<USVString, double>> perBuyerPrioritySignals;
+  sequence<AuctionAdConfig> componentAuctions;
+  AbortSignal? signal;
 };
 </xmp>

--- a/spec.bs
+++ b/spec.bs
@@ -23,9 +23,7 @@ Assume Explicit For: yes
 <h2 id="join-ad-interest-group">joinAdInterestGroup</h2>
 
 <xmp class="idl">
-[
-  SecureContext
-] partial interface Navigator {
+partial interface Navigator {
   Promise<undefined> joinAdInterestGroup(AuctionAdInterestGroup group, double durationSeconds);
 };
 </xmp>
@@ -34,9 +32,7 @@ Assume Explicit For: yes
 <h2 id="run-ad-auction">runAdAuction</h2>
 
 <xmp class="idl">
-[
-  SecureContext
-] partial interface Navigator {
+partial interface Navigator {
   Promise<USVString?> runAdAuction(AuctionAdConfig config);
 };
 </xmp>

--- a/spec.bs
+++ b/spec.bs
@@ -32,7 +32,8 @@ The FLEDGE API enables on-device auctions in the browser to choose relevant ads 
 <h2 id="join-ad-interest-group">joinAdInterestGroup</h2>
 
 An interest group owner (such as a DSP working for a site that displays ads) can ask the user's browser to add membership for the interest group
-by calling the JavaScript function navigator.joinAdInterestGroup().
+by calling {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}.
+
 
 <xmp class="idl">
 [SecureContext]

--- a/spec.bs
+++ b/spec.bs
@@ -19,7 +19,7 @@ Markup Shorthands: markdown yes
 Assume Explicit For: yes
 </pre>
 
-<h2 id="intro">Introduction</h2>
+# Introduction # {#intro}
 
 <em>This section is non-normative</em>
 
@@ -29,7 +29,7 @@ to track user browsing behavior across sites.
 The FLEDGE API enables on-device auctions in the browser to choose relevant ads from websites the user has previously visited.
 
 
-<h2 id="join-ad-interest-group">joinAdInterestGroup</h2>
+<h2 id="joining-interest-groups">Joining Interest Groups</h2>
 
 An interest group owner (such as a DSP working for a site that displays ads) can ask the user's browser to add membership for the interest group
 by calling {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}.

--- a/spec.bs
+++ b/spec.bs
@@ -18,3 +18,91 @@ Default Biblio Status: current
 Markup Shorthands: markdown yes
 Assume Explicit For: yes
 </pre>
+
+
+<h2 id="join-ad-interest-group">joinAdInterestGroup</h2>
+
+<xmp class="idl">
+[
+  SecureContext
+] partial interface Navigator {
+  Promise<undefined> joinAdInterestGroup(AuctionAdInterestGroup group, double durationSeconds);
+};
+</xmp>
+
+
+<h2 id="run-ad-auction">runAdAuction</h2>
+
+<xmp class="idl">
+[
+  SecureContext
+] partial interface Navigator {
+  Promise<USVString?> runAdAuction(AuctionAdConfig config);
+};
+</xmp>
+
+
+<xmp class="idl">
+dictionary AuctionAdConfig {
+  required USVString seller;
+  required USVString decisionLogicUrl;
+  USVString trustedScoringSignalsUrl;
+  sequence<USVString> interestGroupBuyers;
+  any auctionSignals;
+  any sellerSignals;
+  USVString directFromSellerSignals;
+  unsigned long long sellerTimeout;
+  unsigned short sellerExperimentGroupId;
+  record<USVString, any> perBuyerSignals;
+  record<USVString, unsigned long long> perBuyerTimeouts;
+  record<USVString, unsigned short> perBuyerGroupLimits;
+  record<USVString, unsigned short> perBuyerExperimentGroupIds;
+  record<USVString, record<USVString, double>> perBuyerPrioritySignals;
+  sequence<AuctionAdConfig> componentAuctions;
+  AbortSignal? signal;
+};
+</xmp>
+
+
+
+<h2 id="advertisements">Advertisements</h2>
+
+
+<xmp class="idl">
+dictionary AuctionAd {
+  required USVString renderUrl;
+  any metadata;
+};
+</xmp>
+
+
+<h2 id="advertisement-interest-groups">Advertisement Interest Groups</h2>
+
+
+
+<xmp class="idl">
+enum WorkletExecutionMode {
+  "compatibility",
+  "groupByOrigin",
+};
+
+dictionary AuctionAdInterestGroup {
+  required USVString owner;
+  required USVString name;
+
+  double priority;
+  boolean enableBiddingSignalsPrioritization;
+  record<USVString, double> priorityVector;
+  record<USVString, double> prioritySignalsOverrides;
+
+  WorkletExecutionMode executionMode;
+  USVString biddingLogicUrl;
+  USVString biddingWasmHelperUrl;
+  USVString dailyUpdateUrl;
+  USVString trustedBiddingSignalsUrl;
+  sequence<USVString> trustedBiddingSignalsKeys;
+  any userBiddingSignals;
+  sequence<AuctionAd> ads;
+  sequence<AuctionAd> adComponents;
+};
+</xmp>


### PR DESCRIPTION
This adds the minimal IDL for the functions joinAdInterestGroup and runAdAuction, and the parameter types AuctionAdInterestGroup and AuctionAdConfig.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dlaliberte/turtledove/pull/360.html" title="Last updated on Oct 3, 2022, 8:41 PM UTC (ad02dc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/360/8b04fa4...dlaliberte:ad02dc2.html" title="Last updated on Oct 3, 2022, 8:41 PM UTC (ad02dc2)">Diff</a>