### PR TITLE
Generate index.html instead of spec.html

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,6 @@ jobs:
       with:
         TOOLCHAIN: bikeshed
         SOURCE: spec.bs
+        DESTINATION: index.html
         GH_PAGES_BRANCH: gh-pages
         BUILD_FAIL_ON: warning


### PR DESCRIPTION
Another option is to just delete index.html from the gh-pages branch and have people link to https://wicg.github.io/turtledove/spec.html. And a third option is to rename spec.bs to index.bs.

Fixes #379.