### PR TITLE
Add sendReports parameter to deprecatedURNtoURL()

### DIFF
--- a/Proposed_First_FLEDGE_OT_Details.md
+++ b/Proposed_First_FLEDGE_OT_Details.md
@@ -114,7 +114,7 @@ In the FOT#1, rendering these opaque URLs only in Fenced Frames will temporarily
 
   
 
-The FOT#1 will include temporary support for `navigator.deprecatedURNToURL()`, a method that takes as an argument an opaque URL resolved from a Promise returned from `navigator.runAdAuction()` and returns the URL of the auction winning ad creative. This is included to [promote accurate measurement](#promoting-accurate-measurement-of-fledge-effectiveness.) and comparison of FLEDGE API utility by allowing auction winning URLs to be treated and used as they are in today’s ad auctions.
+The FOT#1 will include temporary support for `navigator.deprecatedURNToURL(urn, sendReports)`, a method that takes as an argument an opaque URL resolved from a Promise returned from `navigator.runAdAuction()` and returns the URL of the auction winning ad creative. If `sendReports` is true, reports will be sent just as if the URN were loaded in a frame. This is included to [promote accurate measurement](#promoting-accurate-measurement-of-fledge-effectiveness.) and comparison of FLEDGE API utility by allowing auction winning URLs to be treated and used as they are in today’s ad auctions.
 
 #### Permissions-Policy
 

--- a/Proposed_First_FLEDGE_OT_Details.md
+++ b/Proposed_First_FLEDGE_OT_Details.md
@@ -114,7 +114,7 @@ In the FOT#1, rendering these opaque URLs only in Fenced Frames will temporarily
 
   
 
-The FOT#1 will include temporary support for `navigator.deprecatedURNToURL(urn, sendReports)`, a method that takes as an argument an opaque URL resolved from a Promise returned from `navigator.runAdAuction()` and returns the URL of the auction winning ad creative. If `sendReports` is true, reports will be sent just as if the URN were loaded in a frame. This is included to [promote accurate measurement](#promoting-accurate-measurement-of-fledge-effectiveness.) and comparison of FLEDGE API utility by allowing auction winning URLs to be treated and used as they are in today’s ad auctions.
+The FOT#1 will include temporary support for `navigator.deprecatedURNToURL(urn, sendReports)`, a method that takes as an argument an opaque URL resolved from a Promise returned from `navigator.runAdAuction()` and returns the URL of the auction winning ad creative. If `sendReports` is true, reports will be sent just as if the URN were loaded in a frame. Note that the `sendReports` parameter is only respected in Chrome since versions 109.0.5414.16 and 110.0.5433.0. This is included to [promote accurate measurement](#promoting-accurate-measurement-of-fledge-effectiveness.) and comparison of FLEDGE API utility by allowing auction winning URLs to be treated and used as they are in today’s ad auctions.
 
 #### Permissions-Policy
 

--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,6 +1,13 @@
 # FLEDGE Release Notes
 
 
+## Chrome M109
+
+
+
+*   Since version 109.0.5414.16, the [`sendReports` parameter to `navigator.deprecatedURNToURL()`](https://github.com/WICG/turtledove/blob/main/Proposed_First_FLEDGE_OT_Details.md#advertisement-rendering) is respected.
+
+
 ## Chrome M108
 
 


### PR DESCRIPTION
This allows experimenters to trigger reports without having to load ad URNs in frames.  We recently switched to only sending reports (when there's a winner) if the ad URN is loaded in a frame, but this has caused unexpected issues for some folks experimenting with the API. Provide this new functionality as a workaround.