### PR TITLE
Expand on when InterestGroup state is updated and reports are sent

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -588,7 +588,7 @@ _As a temporary mechanism, we will still allow network access,_ rendering the wi
 
 The TURTLEDOVE privacy goals mean that this cannot be the long-term solution.  Rendering ads from previously-downloaded Web Bundles, as originally proposed, is one way to mitigate this leakage.  Another possibility is ad rendering in which all network-loaded resources come from a trusted CDN that does not keep logs of the resources it serves.  As with servers involved in providing the trusted bidding signals, the privacy model and browser trust mechanism for such a CDN would require further work.
 
-Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priority and `priorityOverrides` are updated immediately upon generateBid() completion, since how the information from those are used it not expected to depend on whether the current auction was completed or not.
+Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priorities and `priorityOverrides` are updated immediately upon completion of the generateBid() call that invoked their respsective update functions, since how the information from those are used it not expected to depend on whether the current auction was completed or not.
 
 
 ### 5. Event-Level Reporting (for now)

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -588,7 +588,7 @@ _As a temporary mechanism, we will still allow network access,_ rendering the wi
 
 The TURTLEDOVE privacy goals mean that this cannot be the long-term solution.  Rendering ads from previously-downloaded Web Bundles, as originally proposed, is one way to mitigate this leakage.  Another possibility is ad rendering in which all network-loaded resources come from a trusted CDN that does not keep logs of the resources it serves.  As with servers involved in providing the trusted bidding signals, the privacy model and browser trust mechanism for such a CDN would require further work.
 
-Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priorities and `priorityOverrides` are updated immediately upon completion of the generateBid() call that invoked their respsective update functions, since how the information from those are used is not expected to depend on whether the current auction was completed or not.
+Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if and when the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priorities and `priorityOverrides` are updated immediately upon completion of the `generateBid()` call that invoked their respective update functions, since how the information from those are used is not expected to depend on whether the current auction was completed or not.
 
 
 ### 5. Event-Level Reporting (for now)

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -588,7 +588,7 @@ _As a temporary mechanism, we will still allow network access,_ rendering the wi
 
 The TURTLEDOVE privacy goals mean that this cannot be the long-term solution.  Rendering ads from previously-downloaded Web Bundles, as originally proposed, is one way to mitigate this leakage.  Another possibility is ad rendering in which all network-loaded resources come from a trusted CDN that does not keep logs of the resources it serves.  As with servers involved in providing the trusted bidding signals, the privacy model and browser trust mechanism for such a CDN would require further work.
 
-Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priorities and `priorityOverrides` are updated immediately upon completion of the generateBid() call that invoked their respsective update functions, since how the information from those are used it not expected to depend on whether the current auction was completed or not.
+Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priorities and `priorityOverrides` are updated immediately upon completion of the generateBid() call that invoked their respsective update functions, since how the information from those are used is not expected to depend on whether the current auction was completed or not.
 
 
 ### 5. Event-Level Reporting (for now)

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -588,6 +588,8 @@ _As a temporary mechanism, we will still allow network access,_ rendering the wi
 
 The TURTLEDOVE privacy goals mean that this cannot be the long-term solution.  Rendering ads from previously-downloaded Web Bundles, as originally proposed, is one way to mitigate this leakage.  Another possibility is ad rendering in which all network-loaded resources come from a trusted CDN that does not keep logs of the resources it serves.  As with servers involved in providing the trusted bidding signals, the privacy model and browser trust mechanism for such a CDN would require further work.
 
+Reports are only sent and most interest group state changes (e.g. updating `prevWins` and `bidCount`, updating k-anonymity information) are only applied if the winning `renderURL` is loaded in a fenced frame, in the case there is a winner, or when there is no winner. Priority and `priorityOverrides` are updated immediately upon generateBid() completion, since how the information from those are used it not expected to depend on whether the current auction was completed or not.
+
 
 ### 5. Event-Level Reporting (for now)
 


### PR DESCRIPTION
We're working on making running reporting worklets not block auction completion, but this has brought to focus just when we should apply various InterestGroup updates.  Here's my proposal, feedback welcome!