### PR TITLE
Fix reportEvent availability in same-origin subframes

### DIFF
--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -47,7 +47,7 @@ The following new APIs will be added for achieving this.
 
 Fenced frames can invoke the `reportEvent` API to tell the browser to send a beacon with event data to a URL registered by the worklet in `registerAdBeacon` (see below). Depending on the declared `destination`, the beacon is sent to either the buyer's or the seller's registered URL. Examples of such events are mouse hovers, clicks (which may or may not lead to navigation e.g. video player control element clicks), etc.
 
-This API is available from same-origin frames within the initial rendered ad document and across subsequent same-origin navigations, but it's no longer available after cross-origin navigations or in cross-origin subframes. (For this API, for chains of redirects, the requestor is considered same-origin with the target only if it is same-origin with all redirect URLs in the chain.) This way, the ad may redirect itself without losing access to reporting, but other sites can't send spurious reports.
+This API is available in all contexts within the fenced frame that are same-origin to the first committed origin. That is to say, you can access the API from the initial ad creative document that loads in the fenced frame (after redirects), any same-origin iframes on that page, and any same-origin pages+iframes resulting from navigations initiated inside the fenced frame. This way, the ad may redirect itself or create subframes without losing access to reporting, but documents from other sites can't send spurious reports.
 
 The browser processes the beacon by sending an HTTP POST request, like the existing [navigator.sendBeacon](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon).
 


### PR DESCRIPTION
Previously, by oversight reportEvent didn't work in subframes. Now it will, which requires changing the semantics a little. Essentially, it doesn't matter how you got to a context: all that matters is that the context is same-origin to the ad creative origin.