### PR TITLE
Emphasize that origins in perBuyerSignals=[origin] must be URL encoded for directFromSellerSignals.

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -332,7 +332,7 @@ The optional `directFromSellerSignals` field can be used to pass signals to the 
 
 The URL prefix should not have a query string (i.e. `?a=b&c=d`). Different calls to `navigator.runAdAuction()` on a page may use different prefixes -- for instance, to give different signals to different ad slots. The browser will append the following suffixes to the prefix:
 
-*   `?perBuyerSignals=[origin]`, where [origin] is one of the **URL encoded** origins in `interestGroupBuyers`: this corresponds to the `perBuyerSignals` for the buyer `origin`
+*   `?perBuyerSignals=[origin]`, where [origin] is one of the origins in `interestGroupBuyers` (encoded as a URL component): this corresponds to the `perBuyerSignals` for the buyer `origin`
 *   `?sellerSignals`: this corresponds to the `sellerSignals` only delivered to the seller
 *   `?auctionSignals`: this corresponds to `auctionSignals` delivered to the seller, and all buyers
 

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -332,7 +332,7 @@ The optional `directFromSellerSignals` field can be used to pass signals to the 
 
 The URL prefix should not have a query string (i.e. `?a=b&c=d`). Different calls to `navigator.runAdAuction()` on a page may use different prefixes -- for instance, to give different signals to different ad slots. The browser will append the following suffixes to the prefix:
 
-*   `?perBuyerSignals=[origin]`, where [origin] is one of the origins in `interestGroupBuyers`: this corresponds to the `perBuyerSignals` for the buyer `origin`
+*   `?perBuyerSignals=[origin]`, where [origin] is one of the **URL encoded** origins in `interestGroupBuyers`: this corresponds to the `perBuyerSignals` for the buyer `origin`
 *   `?sellerSignals`: this corresponds to the `sellerSignals` only delivered to the seller
 *   `?auctionSignals`: this corresponds to `auctionSignals` delivered to the seller, and all buyers
 


### PR DESCRIPTION
This stumped me for a while when I was working with the [`directFromSellerSignals`](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#25-additional-trusted-signals-directfromsellersignals) API. The only indicator of failure to load the subresource was a `perBuyerSignals` null value in the `directFromSellerSignals` argument to `generateBid`.

I eventually found this detail in [bidder_worklet.mojom](https://crrev.com/c/3615057). Once I encoded the signal subresources as `http://seller.example/signals?perBuyerSignals=https%3A%2F%2Fads.example` rather than my naive initial encoding of `http://seller.example/signals?perBuyerSignals=https://ads.example`, the signals were successfully loaded.