### PR TITLE
Rename Trust Tokens to Private State Tokens

### DIFF
--- a/FLEDGE_k_anonymity_server.md
+++ b/FLEDGE_k_anonymity_server.md
@@ -203,30 +203,30 @@ group when, in fact, the other members of the group are not real.  It is
 important that we protect `Join` against malicious write traffic, and,
 to maintain privacy, that we do this in an anonymous way.
 
-To protect this endpoint we will use [Trust
+To protect this endpoint we will use [Private State
 Tokens](https://github.com/WICG/trust-token-api).  Every write to Join will
-require a one-time-use Trust Token be attached to the request, and tokens
-will be bound to a specific low-entropy identifier, `b`.  Each browser will
-be issued tokens with its assigned `b`, and it can spend those tokens as it
-wishes to make `Join` calls to the server.
+require a one-time-use Private State Token be attached to the request, and
+tokens will be bound to a specific low-entropy identifier, `b`.  Each browser
+will be issued tokens with its assigned `b`, and it can spend those tokens
+as it wishes to make `Join` calls to the server.
 
-We will operate a Trust Token issuer specific to this server and these
-tokens; we'll call this issuer **`Sign`**.  In our current proposal,
-`Sign` will require, at least initially for desktop Chrome, that the user
-be signed-in to Chrome with a Google Account.  Requiring sign-in lets us
-rate limit the number of tokens issued to a given user, assign each user a
-stable value for `b`, and prevent naive abuse of `Join` by anonymous users.
-Even though the user is signed-in, and Google Account credentials are
-used to issue Trust Tokens, the Trust Tokens received by `Join` [cannot be
+We will operate a Private State Token issuer specific to this server and
+these tokens; we'll call this issuer **`Sign`**.  In our current proposal,
+`Sign` will require, at least initially for desktop Chrome, that the user be
+signed-in to Chrome with a Google Account.  Requiring sign-in lets us rate
+limit the number of tokens issued to a given user, assign each user a stable
+value for `b`, and prevent naive abuse of `Join` by anonymous users.  Even
+though the user is signed-in, and Google Account credentials are used to issue
+Private State Tokens, the Private State Tokens received by `Join` [cannot be
 linked](https://github.com/WICG/trust-token-api#cryptographic-property-unlinkability)
-back to the Google Account they were issued to.  The Trust Token issuer can
-learn which users join a large number of interest groups.  To guard against
-this, we're exploring options that include having the client request tokens
-at a constant rate and discard unused tokens.
+back to the Google Account they were issued to.  The Private State Token
+issuer can learn which users join a large number of interest groups.  To guard
+against this, we're exploring options that include having the client request
+tokens at a constant rate and discard unused tokens.
 
 `Query` is a read-only API, so it doesn't have the same abuse concerns as
-`Join`.  We won't require Trust Tokens, or a Google Account, for a browser
-to call `Query`.
+`Join`.  We won't require Private State Tokens, or a Google Account, for a
+browser to call `Query`.
 
 #### Differential privacy of public data
 
@@ -313,7 +313,7 @@ other server functions like counting cardinalities and persisting state.
 
 #### Device attestations
 
-Our initial reliance on Google Accounts to issue Trust Tokens
+Our initial reliance on Google Accounts to issue Private State Tokens
 that authenticate writes is necessary partly because we
 don't have other methods of authenticating a Chrome browser
 to a server.  Some platforms, like Android with [SafetyNet
@@ -360,7 +360,7 @@ interest groups that might be more popular with signed-out users. Over time
 we expect to reduce, or otherwise eliminate, this potential bias by adding
 support for device attestation or other approaches to device-level trust.
 
-The Trust Token issuer, `Sign`, will enforce limits on token issuance to
+The Private State Token issuer, `Sign`, will enforce limits on token issuance to
 each Google Account.  Tokens are one-time-use, so these limits will restrict
 the number of `Join` calls a browser can make in a given period of time.
 This doesn't necessarily limit the number of interest groups the browser can


### PR DESCRIPTION
This is a pure renaming change to adopt the latest naming for the tokens project.