### PR TITLE
Add generate and score bid part to spec.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -451,13 +451,13 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Otherwise:
   1. [=Assert=] |isTopLevel| being true.
   1. Set |hasComponentAuctions| to true.
+  1. Run the following steps [=in parallel=]:
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
     1. Let |compWinner| be the result of [=generate and score bids=] with |component|, |global|, and
       false.
     1. If |compWinner| is not failure, [=list/append=] |compWinner| to |componentWinners|.
-1. If |hasComponentAuctions| is true, set |decisionLogicScript| to the result of
-  [=creating a seller script runner=].
-1. If |decisionLogicScript| is failure, return failure.
+  1. Let |decisionLogicScript| to the result of [=creating a seller script runner=].
+1. If |decisionLogicScript| is failure, return null.
 1. Let |leadingBidInfo| be a new [=leading bid info=].
 1. If |hasComponentAuctions| is true:
   1. [=list/For each=] |cw| of |componentWinners|:
@@ -509,7 +509,7 @@ To <dfn>score and rank a bid</dfn> given a [=generated bid=] |generatedBid|, a [
   scoreAd's arguements (including |generatedBid|).
 1. If |hasComponentAuction| is true, and |scoreAdOutput|'s
   [=score ad output/allow component auction=] is false, return.
-1. Let |score| be |scoreAdOutput=|'s [=score ad output/desirability=].
+1. Let |score| be |scoreAdOutput|'s [=score ad output/desirability=].
 1. If |score| is negative or 0, return.
 1. Let |maybeModifiedBid| be |generatedBid|.
 1. If |hasComponentAuction| is true and |scoreAdOutput|'s [=score ad output/bid=] is not null:

--- a/spec.bs
+++ b/spec.bs
@@ -434,12 +434,11 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 <div algorithm="generate and score bids">
 
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, an
-[=ordered map=] |bidGenerators|, and [=global object=] |global|:
+[=ordered map=] |bidGenerators|, a [=global object=] |global|, and a [=promise type=] |p|:
 1. Let |topScore|, and |numTopBids| be 0.
 1. Let |winningAdUrl| be null.
 1. Let |allBidsGeneratedAndScored| be null.
 1. Let |queue| be the result of [=starting a new parallel queue=].
-1. Let |p| be [=a new promise=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
   1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
     1. TODO: Create a seller script runner.
@@ -450,15 +449,23 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       runner.
   1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
     [=auction config/decision logic url=], and "text/javascript".
-  1. [=map/For each=] buyer → |perBuyerGenerator| of |bidGenerators|:
+  1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
+    [=auction config/all buyer experiment group id=].
+  1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
+    1. Let |buyerExperimentGroupId| be |allBuyersExperimentGroupId|.
+    1. Let |perBuyerExperimentGroupIds| be |auctionConfig|'s
+      [=auction config/per buyer experiment group ids=].
+    1. If |perBuyerExperimentGroupIds| is not null and |perBuyerExperimentGroupIds|[|buyer|] exists:
+      1. Set |buyerExperimentGroupId| to |perBuyerExperimentGroupIds|[|buyer|].
     1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
       1. Let |keys| be a new [=ordered set=].
       1. Let |igNames| be a new [=ordered set=].
-      1. [=set/For each=] |ig| of |groups|:
-        1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
-        1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
+      1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
+        1. [=list/For each=] |ig| of |groups|:
+          1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
+          1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
       1. Let |fullSignalsUrl| be the result of calling [=build trusted bidding signals url=] with
-        |signalsUrl|, |keys| and |igNames|.
+        |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
       1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
         and "application/json".
       1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
@@ -546,7 +553,8 @@ To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 <div algorithm="build trusted bidding signals url">
 
 To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
-[=strings=] |keys|, and an [=ordered set=] of [=strings=] |igNames|:
+[=strings=] |keys|, an [=ordered set=] of [=strings=] |igNames|, and a non-negative 16-bit integer
+|experimentGroupId|:
 1. Let |queryParamsList| be a new [=list/is empty|empty=] [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
 1. [=list/Append=] the result of [=UTF-8 percent encode=] [=this=]'s [=relevant settings object=]'s
@@ -559,12 +567,20 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
   1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
   1. Let |igNamesStr| be the result of [=string/concatenate=] |igNames| with separator set to ",".
   1. [=list/Append=] the result of [=UTF-8 percent encode=] |igNamesStr| to |queryParamsList|.
-1. TODO: Do we want to add [=auction config/seller experiment group id=]?
+1. If |experimentGroupId| is not null:
+  1. [=list/Append=] "&experimentGroupId=" to |queryParamsList|.
+  1. [=list/Append=] [=serialize an integer|serialized=] |experimentGroupId| to |queryParamsList|.
 1. Let |fullSignalsUrl| be |signalsUrl|.
 1. Set |fullSignalsUrl|'s [=url/query=] to the result of [=string/concatenating=] |queryParamsList|.
 1. return |fullSignalsUrl|.
 
 </div>
+
+To <dfn>serialize an integer</dfn>, represent it as a string of the shortest possible decimal
+number.
+
+Issue: This would ideally be replaced by a more descriptive algorithm in Infra. See
+<a href="https://github.com/whatwg/infra/issues/201">infra/201</a>
 
 <div algorithm="UTF-8 percent encode">
 

--- a/spec.bs
+++ b/spec.bs
@@ -443,11 +443,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
 1. Let |hasComponentAuctions| be false.
 1. Let |componentWinners| be an [=list/is empty|empty=] list.
-1. Let |decisionLogicScript| be null.
-1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
-  1. Set |decisionLogicScript| to the result of [=creating a seller script runner=] with
-    |auctionConfig|'s [=auction config/decision logic url=].
-1. Otherwise:
+1. If |auctionConfig|'s [=auction config/component auctions=] are not [=list/is empty|empty=]:
   1. [=Assert=] |isTopLevel| being true.
   1. Set |hasComponentAuctions| to true.
   1. Run the following steps [=in parallel=]:
@@ -455,7 +451,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     1. Let |compWinner| be the result of [=generate and score bids=] with |component|, |global|, and
       false.
     1. If |compWinner| is not failure, [=list/append=] |compWinner| to |componentWinners|.
-  1. Let |decisionLogicScript| to the result of [=creating a seller script runner=].
+1. Let |decisionLogicScript| to the result of [=creating a seller script runner=] with
+  |auctionConfig|'s [=auction config/decision logic url=].
 1. If |decisionLogicScript| is failure, return null.
 1. Let |leadingBidInfo| be a new [=leading bid info=].
 1. If |hasComponentAuctions| is true:

--- a/spec.bs
+++ b/spec.bs
@@ -273,10 +273,15 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
-1. Run the following steps [=in parallel=]:
-  1. Run [=generate and score bids=] with |auctionConfig|, |global|, and |p|.
-    TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
-    the auction.
+1. Let |queue| be the result of [=starting a new parallel queue=].
+1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
+  1. Let |winner| be the result of running [=generate and score bids=] with |auctionConfig|,
+    |global|, and true.
+  1. TODO: If |winner| is failure, fail the auction with manually_aborted set to true.
+  1. TODO: If |winner| is null, fail the auction with manually_aborted set to false.
+  1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
+    with |winner|'s [=generated bid/render=]. TODO: resolve |p| with urn-uuid, instead of a
+    URL.
   1. TODO: UpdateInterestGroupsPostAuction.
 1. Return |p|.
 
@@ -433,36 +438,31 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 <div algorithm>
 
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, a
-[=global object=] |global|, and a [=promise type=] |p|:
+[=global object=] |global|, and a [=boolean=] |isTopLevel|:
 1. [=Assert=] that these steps are running [=in parallel=].
-
-1. Let |topScore|, and |numTopBids| be 0.
-1. Let |winningAdUrl| be null.
-1. Let |allBidsGeneratedAndScored| be null.
-1. Let |queue| be the result of [=starting a new parallel queue=].
-1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-1. Let |winningAdUrl| be the result of running [=start generating and scoring bids=] with
-  |auctionConfig|, |glocal|, and true.
-1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p| with
-  |winningAdUrl|. TODO: resolve |p| with urn-uuid, instead of a URL.
-
-</div>
-
-<div algorithm>
-
-To <dfn>start generating and scoring bids</dfn> given an [=auction config=] |auctionConfig|, a
-[=global object=] |global|, and a [=boolean=] |isTopLevel|.
 1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
+1. Let |hasComponentAuctions| be false.
+1. Let |componentWinners| be an [=list/is empty|empty=] list.
+1. Let |decisionLogicScript| be null.
 1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
-  1. Let |decisionLogicScript| be the result of creating a seller script runner.
-  1. If |decisionLogicScript| is failure, [=Queue a global task=] on
-    [=DOM manipulation task source=], given |global|, to resolve |p| with `undefined`, and return.
+  1. Set |decisionLogicScript| to the result of [=creating a seller script runner=] with
+    |auctionConfig|'s [=auction config/decision logic url=].
+  1. If |decisionLogicScript| is failure, return null.
 1. Otherwise:
-  1. [=Assert=] |isTopLevel| being false.
+  1. [=Assert=] |isTopLevel| being true.
+  1. Set |hasComponentAuctions| to true.
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
-    1. [=generate and score bids=] with |component|, |global|, and false.
-  1. TODO: If the last |component|'s seller script runner is received, [=create a seller script
-    runner=].
+    1. Let |compWinner| be the result of [=generate and score bids=] with |component|, |global|, and
+      false.
+    1. If |compWinner| is not failure, [=list/append=] |compWinner| to |componentWinners|.
+1. If |hasComponentAuctions| is true, set |decisionLogicScript| to the result of
+  [=creating a seller script runner=].
+1. If |decisionLogicScript| is failure, return failure.
+1. Let |leadingBidInfo| be a new [=leading bid info=].
+1. If |hasComponentAuctions| is true:
+  1. [=list/For each=] |cw| of |componentWinners|:
+    1. [=Score and rank a bid=] given |cw|, |leadingBidInfo|, and true.
+  1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
 1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
   [=auction config/all buyer experiment group id=].
 1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
@@ -482,6 +482,8 @@ To <dfn>start generating and scoring bids</dfn> given an [=auction config=] |auc
       |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
     1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
       and "application/json".
+    1. TODO: If |trustedBiddingSignals| is failure, fail the auction with manually_aborted set to
+      true.
     1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. TODO: create bidder script runner. If failed, [=iteration/continue=].
@@ -491,29 +493,40 @@ To <dfn>start generating and scoring bids</dfn> given an [=auction config=] |auc
         1. TODO: Let |generatedBid| be the result of [=evaluating script=] with
           [=evaluate script/script=] set to |biddingScript|, [=evaluate script/functionName=] set
           to "generateBid", and [=evaluate script/arguments=] set to |trustedBiddingSignals|.
-        1. If |generatedBid|'s [=generate bid output/bid=] is negative or 0,
-          [=iteration/continue=].
+        1. If |generatedBid|'s [=generated bid/bid=] is negative or 0, [=iteration/continue=].
         1. TODO: Validate other fields of |generatedBid|.
-        1. TODO: Let |score| be the result of [=evaluating script=] with
-          [=evaluate script/script=] set to |decisionLogicScript|,
-          [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
-          to scoreAd's arguements.
-        1. If |score| is negative or 0, [=iteration/continue=].
-        1. If |score| is greater than |topScore|, then set |topScore| to |score|, set
-          |winningAdUrl| to |generatedBid|'s [=generate bid output/render=], and increment
-          |numTopBids| by 1.
-        1. Otherwise, if |score| equals to |topScore|, then set |winningAdUrl| to
-          |generatedBid|'s [=generate bid output/render=] with 1 in |numTopBids| chance.
-        1. If there is no more interest group waiting to be generated, waiting to be scored, or
-          still being scored, set |allBidsGeneratedAndScored| to true.
-1. Wait until |allBidsGeneratedAndScored| is set.
-1. Return |winningAdUrl|.
+        1. [=Score and rank a bid=] with |generatedBid|, |leadingBidInfo| and
+          |hasComponentAuctions|.
+1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
+
 </div>
 
-To <dfn>create a seller script runner</dfn> given a [=URL=] |url|:
+To <dfn>score and rank a bid</dfn> given a [=generated bid=] |generatedBid|, a [=leading bid info=]
+|leadingBidInfo|, and a [=boolean=] |hasComponentAuction|:
+1. TODO: Let |scoreAdOutput| be the result of [=evaluating script=] with
+  [=evaluate script/script=] set to |decisionLogicScript|,
+  [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set to
+  scoreAd's arguements (including |generatedBid|).
+1. If |hasComponentAuction| is true, and |scoreAdOutput|'s
+  [=score ad output/allow component auction=] is false, return.
+1. Let |score| be |scoreAdOutput=|'s [=score ad output/desirability=].
+1. If |score| is negative or 0, return.
+1. Let |maybeModifiedBid| be |generatedBid|.
+1. If |hasComponentAuction| is true and |scoreAdOutput|'s [=score ad output/bid=] is not null:
+  1. Set |maybeModifiedBid|'s [=generated bid/bid=] to |scoreAdOutput|'s [=score ad output/bid=].
+1. If |score| is greater than |leadingBidInfo|'s [=leading bid info/top score=]:
+  1. Set |leadingBidInfo|'s [=leading bid info/top score=] to |score|.
+  1. Set |leadingBidInfo|'s [=leading bid info/leading bid=] to |maybeModifiedBid|.
+  1. Set |leadingBidInfo|'s [=leading bid info/top bids count=] to 1.
+1. Otherwise if |score| equals to |leadingBidInfo|'s [=leading bid info/top score=]:
+  1. Increment |leadingBidInfo|'s [=leading bid info/top bids count=] by 1.
+  1. Set |leadingBidInfo|'s [=leading bid info/leading bid=] to |maybeModifiedBid| with 1 in
+    |leadingBidInfo|'s [=leading bid info/top bids count=] chance.
+
+To <dfn>create a seller script runner</dfn> given a [=URL=] |decisionLogicUrl|:
 1. TODO: create the script runner and set up environment.
-1. Let |decisionLogicScript| be the result of [=fetching resource=] with |auctionConfig|'s
-  [=auction config/decision logic url=], and "text/javascript".
+1. Let |decisionLogicScript| be the result of [=fetching resource=] with |decisionLogicUrl|, and
+  "text/javascript".
 1. Return |decisionLogicScript|.
 
 To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for="create a request">
@@ -759,16 +772,53 @@ representing [=interest group/joining origins=], and whose [=map/values=] are [=
 
 </dl>
 
-<h3 dfn-type=dfn>Generate bid output</h3>
+<h3 dfn-type=dfn>Generated bid</h3>
 
-The output of running a FLEDGE generateBid() script.
+The output of running a FLEDGE generateBid() script, which needs to be scored by the seller.
 
-<dl dfn-for="generate bid output">
+<dl dfn-for="generated bid">
 : <dfn>bid</dfn>
 :: A {{double}}. If the bid is zero or negative, then this interest group will not participate in
   the auction.
 : <dfn>render</dfn>
 :: A [=URL=], which will be rendered to display the creative if this bid wins the auction.
+
+</dl>
+
+<h3 dfn-type=dfn>Score ad output</h3>
+
+The output of running a FLEDGE scoreAd() script.
+
+<dl dfn-for="score ad output">
+: <dfn>desirability</dfn>
+:: A {{double}}.
+  Numeric score of the bid. Must be positive or the ad will be rejected. The winner of the auction
+  is the bid which was given the highest score.
+: <dfn>allow component auction</dfn>
+:: A [=boolean=].
+   If the bid being scored is from a component auction and this value is not true, the bid is
+   ignored. This field must be present and true both when the component seller scores a bid, and
+   when that bid is being scored by the top-level auction.
+: <dfn>bid</dfn>
+:: Null or a {{double}}. 
+  Is null if the auction has no component auction, or if the auction is a top-level auction.
+  Modified bid value to provide to the top-level seller script. If present, this will be passed to
+  the top-level seller's scoreAd() and reportResult() methods instead of the original bid, if the ad
+  wins the component auction and top-level auction, respectively.
+
+</dl>
+
+<h3 dfn-type=dfn>Leading bid info</h3>
+
+Information of the auction's leading bid so far when ranking scored bids.
+
+<dl dfn-for="leading bid info">
+: <dfn>top score</dfn>
+:: A {{double}}. Defaulting to 0.0. The highest score so far.
+: <dfn>top bids count</dfn>
+:: An integer. Defaulting to 0. The number of bids with the same `top score`.
+: <dfn>leading bid</dfn>
+:: Null or a [=generated bid=]. The leading bid of the auction so far.
 
 </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -273,9 +273,8 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
-1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
 1. Run the following steps [=in parallel=]:
-  1. Run [=generate and score bids=] with |auctionConfig|, |bidGenerators|, |global|, and |p|.
+  1. Run [=generate and score bids=] with |auctionConfig|, |global|, and |p|.
     TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
     the auction.
   1. TODO: UpdateInterestGroupsPostAuction.
@@ -397,7 +396,7 @@ To <dfn>parse an origin</dfn> given a [=string=] |input|:
 1. If |url| is an error, then return failure.
 1. Return |url|'s [=url/origin=].
 
-<div algorithm="build bid generators map">
+<div algorithm>
 
 To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfig|:
 1. Let |bidGenerators| be a new [=ordered map=] whose [=map/keys=] are [=url/origins=] and whose
@@ -431,72 +430,91 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 
 </div>
 
-<div algorithm="generate and score bids">
+<div algorithm>
 
-To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, an
-[=ordered map=] |bidGenerators|, a [=global object=] |global|, and a [=promise type=] |p|:
+To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, a
+[=global object=] |global|, and a [=promise type=] |p|:
+1. [=Assert=] that these steps are running [=in parallel=].
+
 1. Let |topScore|, and |numTopBids| be 0.
 1. Let |winningAdUrl| be null.
 1. Let |allBidsGeneratedAndScored| be null.
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-  1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
-    1. TODO: Create a seller script runner.
-  1. Otherwise:
-    1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
-      1. [=generate and score bids=] with |component|.
-    1. TODO: If the last |component|'s seller script runner is received, create a seller script
-      runner.
-  1. Let |decisionLogicScript| be the result of [=fetching resource=] with |auctionConfig|'s
-    [=auction config/decision logic url=], and "text/javascript".
-  1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
-    [=auction config/all buyer experiment group id=].
-  1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
-    1. Let |buyerExperimentGroupId| be |allBuyersExperimentGroupId|.
-    1. Let |perBuyerExperimentGroupIds| be |auctionConfig|'s
-      [=auction config/per buyer experiment group ids=].
-    1. If |perBuyerExperimentGroupIds| is not null and |perBuyerExperimentGroupIds|[|buyer|] exists:
-      1. Set |buyerExperimentGroupId| to |perBuyerExperimentGroupIds|[|buyer|].
-    1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
-      1. Let |keys| be a new [=ordered set=].
-      1. Let |igNames| be a new [=ordered set=].
-      1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
-        1. [=list/For each=] |ig| of |groups|:
-          1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
-          1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
-      1. Let |fullSignalsUrl| be the result of [=building trusted bidding signals url=] with
-        |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
-      1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
-        and "application/json".
-      1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
-        1. [=list/For each=] |ig| of |groups|:
-          1. TODO: create bidder script runner. If failed, [=iteration/continue=].
-          1. Let |biddingScript| be the result of [=fetching resource=] with |ig|'s
-            [=interest group/bidding url=], and "text/javascript". If |biddingScript| is an error,
-            [=iteration/continue=].
-          1. TODO: Let |generatedBid| be the result of [=evaluating script=] with
-            [=evaluate script/script=] set to |biddingScript|, [=evaluate script/functionName=] set
-            to "generateBid", and [=evaluate script/arguments=] set to |trustedBiddingSignals|.
-          1. If |generatedBid|'s [=generate bid output/bid=] is negative or 0,
-            [=iteration/continue=].
-          1. TODO: Validate other fields of |generatedBid|.
-          1. TODO: Let |score| be the result of [=evaluating script=] with
-            [=evaluate script/script=] set to |decisionLogicScript|,
-            [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
-            to scoreAd's arguements.
-          1. If |score| is negative or 0, [=iteration/continue=].
-          1. If |score| is greater than |topScore|, then set |topScore| to |score|, set
-            |winningAdUrl| to |generatedBid|'s [=generate bid output/render=], and increment
-            |numTopBids| by 1.
-          1. Otherwise, if |score| equals to |topScore|, then set |winningAdUrl| to
-            |generatedBid|'s [=generate bid output/render=] with 1 in |numTopBids| chance.
-          1. If there is no more interest group waiting to be generated, waiting to be scored, or
-            still being scored, set |allBidsGeneratedAndScored| to true.
-1. Wait until |allBidsGeneratedAndScored| is set.
+1. Let |winningAdUrl| be the result of running [=start generating and scoring bids=] with
+  |auctionConfig|, |glocal|, and true.
 1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p| with
   |winningAdUrl|. TODO: resolve |p| with urn-uuid, instead of a URL.
 
 </div>
+
+<div algorithm>
+
+To <dfn>start generating and scoring bids</dfn> given an [=auction config=] |auctionConfig|, a
+[=global object=] |global|, and a [=boolean=] |isTopLevel|.
+1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
+1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
+  1. Let |decisionLogicScript| be the result of creating a seller script runner.
+  1. If |decisionLogicScript| is failure, [=Queue a global task=] on
+    [=DOM manipulation task source=], given |global|, to resolve |p| with `undefined`, and return.
+1. Otherwise:
+  1. [=Assert=] |isTopLevel| being false.
+  1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
+    1. [=generate and score bids=] with |component|, |global|, and false.
+  1. TODO: If the last |component|'s seller script runner is received, [=create a seller script
+    runner=].
+1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
+  [=auction config/all buyer experiment group id=].
+1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
+  1. Let |buyerExperimentGroupId| be |allBuyersExperimentGroupId|.
+  1. Let |perBuyerExperimentGroupIds| be |auctionConfig|'s
+    [=auction config/per buyer experiment group ids=].
+  1. If |perBuyerExperimentGroupIds| is not null and |perBuyerExperimentGroupIds|[|buyer|] exists:
+    1. Set |buyerExperimentGroupId| to |perBuyerExperimentGroupIds|[|buyer|].
+  1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
+    1. Let |keys| be a new [=ordered set=].
+    1. Let |igNames| be a new [=ordered set=].
+    1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
+      1. [=list/For each=] |ig| of |groups|:
+        1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
+        1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
+    1. Let |fullSignalsUrl| be the result of [=building trusted bidding signals url=] with
+      |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
+    1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
+      and "application/json".
+    1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
+      1. [=list/For each=] |ig| of |groups|:
+        1. TODO: create bidder script runner. If failed, [=iteration/continue=].
+        1. Let |biddingScript| be the result of [=fetching resource=] with |ig|'s
+          [=interest group/bidding url=], and "text/javascript". If |biddingScript| is an error,
+          [=iteration/continue=].
+        1. TODO: Let |generatedBid| be the result of [=evaluating script=] with
+          [=evaluate script/script=] set to |biddingScript|, [=evaluate script/functionName=] set
+          to "generateBid", and [=evaluate script/arguments=] set to |trustedBiddingSignals|.
+        1. If |generatedBid|'s [=generate bid output/bid=] is negative or 0,
+          [=iteration/continue=].
+        1. TODO: Validate other fields of |generatedBid|.
+        1. TODO: Let |score| be the result of [=evaluating script=] with
+          [=evaluate script/script=] set to |decisionLogicScript|,
+          [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
+          to scoreAd's arguements.
+        1. If |score| is negative or 0, [=iteration/continue=].
+        1. If |score| is greater than |topScore|, then set |topScore| to |score|, set
+          |winningAdUrl| to |generatedBid|'s [=generate bid output/render=], and increment
+          |numTopBids| by 1.
+        1. Otherwise, if |score| equals to |topScore|, then set |winningAdUrl| to
+          |generatedBid|'s [=generate bid output/render=] with 1 in |numTopBids| chance.
+        1. If there is no more interest group waiting to be generated, waiting to be scored, or
+          still being scored, set |allBidsGeneratedAndScored| to true.
+1. Wait until |allBidsGeneratedAndScored| is set.
+1. Return |winningAdUrl|.
+</div>
+
+To <dfn>create a seller script runner</dfn> given a [=URL=] |url|:
+1. TODO: create the script runner and set up environment.
+1. Let |decisionLogicScript| be the result of [=fetching resource=] with |auctionConfig|'s
+  [=auction config/decision logic url=], and "text/javascript".
+1. Return |decisionLogicScript|.
 
 To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for="create a request">
 |accept|</dfn>:
@@ -531,17 +549,17 @@ To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 1. Let |resource| be null.
 1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given a
   [=response=] |response| and |responseBody|:
-  1. If |responseBody| is null or failure, set |resource| to failure.
+  1. If |responseBody| is null or failure, set |resource| to failure and return.
   1. Let |headers| be |response|'s [=response/header list=].
   1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
-    return true, set |resource| to failure.
+    return true, set |resource| to failure and return.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
-  1. Set |resource| to failure. if any of:
+  1. Set |resource| to failure and return, if any of:
     1. |headerMimeType| is failure.
     1. |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
     1. |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
   1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-  1. Set |resource| to failure. if any of:
+  1. Set |resource| to failure and return if any of:
     1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
       |responseBody| is not [=UTF-8=] encoded.
     1. If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].

--- a/spec.bs
+++ b/spec.bs
@@ -602,7 +602,12 @@ To <dfn>evaluate script</dfn> with given [=string=] <dfn for="evaluate script">|
 This specification defines two [=policy-controlled features=] identified by the string
 "<code><dfn noexport>join-ad-interest-group</dfn></code>", and
 "<code><dfn noexport>run-ad-auction</dfn></code>". Their
+<<<<<<< HEAD
 [=policy-controlled feature/default allowlists=] are `self`.
+=======
+[=policy-controlled feature/default allowlists=] are
+<a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">`self`</a>.
+>>>>>>> af6bdcc (Try fixing a build error about Permissions Policy.)
 
 Note: In the Chromium implementation the [=policy-controlled feature/default allowlists=] for both
 features are temporarily set to `*` to ease testing.

--- a/spec.bs
+++ b/spec.bs
@@ -271,13 +271,13 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. If |signal| is [=AbortSignal/aborted=], then [=reject=] |p| with |signal|'s
     [=AbortSignal/abort reason=] and return |p|.
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
-    1. Aborts the auction.
+    1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
 1. Let |winning_ad_url| be the result of running [=generate and score bids=] with |auctionConfig|.
 1. TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
   the auction.
 1. TODO: UpdateInterestGroupsPostAuction.
-1. If |winning_ad_url| is not null, resolve |p| with |winning_ad_url|.
+1. Resolve |p| with |winning_ad_url|.
 1. Return |p|.
 
 </div>
@@ -399,14 +399,15 @@ To <dfn>parse an origin</dfn> given a [=string=] |input|:
 <div algorithm="generate and score bids">
 
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|:
-1. If |auctionConfig|'s [=auction config/component auctions=] are empty:
-  1. TODO: Create a seller worklet.
+1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
+  1. TODO: Create a seller script runner.
 1. Otherwise:
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
     1. [=generate and score bids=] with |component|.
-  1. TODO: If the last |component|'s seller worklet is received, create a seller worklet.
-1. Let |decisionLogicScript| be the result of [=fetch a javascript=] with |auctionConfig|'s
-  [=auction config/decision logic url=].
+  1. TODO: If the last |component|'s seller script runner is received, create a seller script
+    runner.
+1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
+  [=auction config/decision logic url=], and "text/javascript".
 1. Let |bidGenerators| be a new [=ordered map=] whose [=map/keys=] are [=url/origins=] and whose
   [=map/values=] are [=per buyer bid generators=].
 1. [=list/For each=] |buyer| in [=auction config/interest group buyers=]:
@@ -439,19 +440,29 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
   1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
-    1. TODO: Fetch |signalsUrl| asynchronously.
+    1. Let |keys| be a new [=ordered set=].
+    1. Let |igNames| be a new [=ordered set=].
+    1. [=set/For each=] |ig| of |groups|:
+      1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
+      1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
+    1. Let |fullSignalsUrl| be the result of calling [=build trusted bidding signals url=] with
+      |signalsUrl|, |keys| and |igNames|.
+    1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl| and
+      "application/json".
     1. [=map/For each=] |joiningOrigin| -> |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-          1. TODO: create bidder worklet. If failed, [=iteration/continue=].
-          1. Let |biddingScript| be the result of [=fetch a javascript=] with |ig|'s
-            [=interest group/bidding url=]. If |biddingScript| is an error, [=iteration/continue=].
-          1. Let |generatedBid| be the result of running [=evaluate script=] with
+          1. TODO: create bidder script runner. If failed, [=iteration/continue=].
+          1. Let |biddingScript| be the result of [=fetching resource=] with |ig|'s
+            [=interest group/bidding url=], and "text/javascript". If |biddingScript| is an error,
+            [=iteration/continue=].
+          1. TODO: Let |generatedBid| be the result of running [=evaluate script=] with
             [=evaluate script/script=] set to |biddingScript|, [=evaluate script/functionName=] set
-            to "generateBid", and [=evaluate script/arguments=] set to generateBid's arguements.
+            to "generateBid", and [=evaluate script/arguments=] set to |trustedBiddingSignals|.
           1. If |generatedBid|'s [=generate bid output/bid=] is negative or 0,
             [=iteration/continue=].
-          1. Let |score| be the result of running [=evaluate script=] with
+          1. TODO: Validate other fields of |generatedBid|.
+          1. TODO: Let |score| be the result of running [=evaluate script=] with
             [=evaluate script/script=] set to |decisionLogicScript|,
             [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
             to scoreAd's arguements.
@@ -490,9 +501,11 @@ To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for=
     :: "`error`"
 1. Return |request|.
 
-To <dfn>fetch a javascript</dfn> with given [=URL=] |url|:
+<div algorithm="fetch resource">
+
+To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 1. Let |request| be the result of [=creating a request=] with |url|, and [=create a request/accept=]
-  set to "`application/javascript`".
+  set to |mimeType|.
 1. [=Fetch=] |request|.
 1. Wait for the [=fetch/processResponseConsumeBody=] algorithm to finish. TODO: use 
   [=fetch/processResponseConsumeBody=] as argument to [=fetch=].
@@ -502,11 +515,42 @@ To <dfn>fetch a javascript</dfn> with given [=URL=] |url|:
 1. Let |headers| be |response|'s [=response/header list=].
 1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
   return true, return failure.
-1. Let |mimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
-1. If |mimeType| is failure or not a [=JavaScript MIME type=], return failure.
-1. If |mimeType|'s [=MIME type/parameters=]["`charset`"] [=map/exists=], and is not "utf-8" or
-  "us-ascii", return failure.
+1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
+1. Return failure if any of:
+  1. |headerMimeType| is failure.
+  1. |mimeType| is "`application/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
+  1. |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
+1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
+1. Return failure if any of:
+  1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and |body| is not
+    [=UTF-8=] encoded.
+  1. If |mimeTypeCharset| is "us-ascii", and |body| is not [=ascii string=].
 1. Return |body|.
+
+</div>
+
+<div algorithm="build trusted bidding signals url">
+
+To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
+[=strings=] |keys|, and an [=ordered set=] of [=strings=] |igNames|:
+1. Let |queryParamsList| be a new [=list/is empty|empty=] [=list=].
+1. [=list/Append=] "hostname=" to |queryParamsList|.
+1. [=list/Append=] (escape) [=this=]'s [=relevant settings object=]'s
+  [=environment/top-level origin=] to |queryParamsList|.
+1. If |keys| is not [=set/is empty|empty=]:
+  1. [=list/Append=] "&keys=" to |queryParamsList|.
+  1. [=list/Append=] the result of (escape) [=string/concatenate=] |keys| with separator set to ","
+    to |queryParamsList|.
+1. If |igNames| is not [=set/is empty|empty]:
+  1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
+  1. [=list/Append=] the result of (escape) [=string/concatenate=] |igNames| with separator set to
+    "," to |queryParamsList|.
+1. TODO: Do we want to add [=auction config/seller experiment group id=]?
+1. Let |fullSignalsUrl| be |signalsUrl|.
+1. Set |fullSignalsUrl|'s [=url/query=] to the result of [=string/concatenating=] |queryParamsList|.
+1. return |fullSignalsUrl|.
+
+</div>
 
 To <dfn>evaluate script</dfn> with given [=string=] <dfn for="evaluate script">|script|</dfn>,
 [=string=] <dfn for="evaluate script">|functionName|</dfn>, and a [=list=]

--- a/spec.bs
+++ b/spec.bs
@@ -264,15 +264,21 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   "{{NotAllowedError}}" {{DOMException}}.
 1. Let |auctionConfig| be the result of running [=validate and convert auction ad config=] with
   |config| and [=validate and convert auction ad config/isTopLevel=] set to true.
-1. If |config|["{{AuctionAdConfig/signal}}"] [=map/exists=]:
-  1. If |config|["{{AuctionAdConfig/signal}}"] is [=AbortSignal/aborted=], then return
-    [=a promise rejected with=] |config|["{{AuctionAdConfig/signal}}"]'s
-    [=AbortSignal/abort reason=].
-1. [=AbortSignal/Add=] an algorithm (TODO: define it) to |config|["{{AuctionAdConfig/signal}}"].
+1. If |auctionConfig| is failure, then return [=a promise rejected with=] a {{TypeError}}.
 1. Let |p| be [=a new promise=].
-1. Return |p|, and run the remaining steps [=in parallel=].
-1. Run [=start bidding and scoring=] with |auctionConfig|.
-1. TODO: add missing steps.
+1. If |config|["{{AuctionAdConfig/signal}}"] [=map/exists=], then:
+  1. Let |signal| be |config|["{{AuctionAdConfig/signal}}"].
+  1. If |signal| is [=AbortSignal/aborted=], then [=reject=] |p| with |signal|'s
+    [=AbortSignal/abort reason=] and return |p|.
+  1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
+    1. Aborts the auction.
+    1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
+1. Let |winning_ad_url| be the result of running [=generate and score bids=] with |auctionConfig|.
+1. TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
+  the auction.
+1. TODO: UpdateInterestGroupsPostAuction.
+1. If |winning_ad_url| is not null, resolve |p| with |winning_ad_url|.
+1. Return |p|.
 
 </div>
 
@@ -390,15 +396,17 @@ To <dfn>parse an origin</dfn> given a [=string=] |input|:
 1. If |url| is an error, then return failure.
 1. Return |url|'s [=url/origin=].
 
-<div algorithm="start bidding and scoring">
+<div algorithm="generate and score bids">
 
-To <dfn>start bidding and scoring</dfn> given an [=auction config=] |auctionConfig|:
+To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|:
 1. If |auctionConfig|'s [=auction config/component auctions=] are empty:
   1. TODO: Create a seller worklet.
 1. Otherwise:
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
-    1. [=Start bidding and scoring=] with |component|.
+    1. [=generate and score bids=] with |component|.
   1. TODO: If the last |component|'s seller worklet is received, create a seller worklet.
+1. Let |decisionLogicScript| be the result of [=fetch a javascript=] with |auctionConfig|'s
+  [=auction config/decision logic url=].
 1. Let |bidGenerators| be a new [=ordered map=] whose [=map/keys=] are [=url/origins=] and whose
   [=map/values=] are [=per buyer bid generators=].
 1. [=list/For each=] |buyer| in [=auction config/interest group buyers=]:
@@ -426,17 +434,34 @@ To <dfn>start bidding and scoring</dfn> given an [=auction config=] |auctionConf
           1. [=map/Set=] |perSignalsUrlGenerator|[|joiningOrigin|] to « |ig| ».
         1. Otherwise:
           1. [=list/Append=] |ig| to |perSignalsUrlGenerator|[|joiningOrigin|].
+1. Let |top_score|, and |num_top_bids| be 0.
+1. Let |winning_ad_url| be null.
+1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
   1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
-    1. TODO: Fetch |signalsUrl| synchronously.
+    1. TODO: Fetch |signalsUrl| asynchronously.
     1. [=map/For each=] |joiningOrigin| -> |groups| of |perSignalsUrlGenerator|:
-      1. [=list/For each=] |ig| of |groups|: 
-        1. Let |biddingScript| be the result of [=fetch bidding or scoring javascript=] with |ig|'s
-          [=interest group/bidding url=].
-        1. If |biddingScript| is an error, [=iteration/continue=].
-        1. TODO: [=Evaluate script=] with [=evaluate script/script=] set to |biddingScript|,
-          [=evaluate script/functionName=] set to "generateBid", and [=evaluate script/arguments=]
-          set to generateBid's arguemnts.
+      1. [=list/For each=] |ig| of |groups|:
+        1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
+          1. TODO: create bidder worklet. If failed, [=iteration/continue=].
+          1. Let |biddingScript| be the result of [=fetch a javascript=] with |ig|'s
+            [=interest group/bidding url=]. If |biddingScript| is an error, [=iteration/continue=].
+          1. Let |generatedBid| be the result of running [=evaluate script=] with
+            [=evaluate script/script=] set to |biddingScript|, [=evaluate script/functionName=] set
+            to "generateBid", and [=evaluate script/arguments=] set to generateBid's arguements.
+          1. If |generatedBid|'s [=generate bid output/bid=] is negative or 0,
+            [=iteration/continue=].
+          1. Let |score| be the result of running [=evaluate script=] with
+            [=evaluate script/script=] set to |decisionLogicScript|,
+            [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
+            to scoreAd's arguements.
+          1. If |score| is negative or 0, [=iteration/continue=].
+          1. If |score| is greater than |top_score|, then set |top_score| to |score|, set
+            |winning_ad_url| to |generatedBid|'s [=generate bid output/render=], and add 1 to
+            |num_top_bids|.
+          1. Otherwise, if |score| equals to |top_score|, then set |winning_ad_url| to
+            |generatedBid|'s [=generate bid output/render=] with 1 in |num_top_bids| chance.
+1. Return |winning_ad_url|.
 
 </div>
 
@@ -465,7 +490,7 @@ To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for=
     :: "`error`"
 1. Return |request|.
 
-To <dfn>fetch bidding or scoring javascript</dfn> with given [=URL=] |url|:
+To <dfn>fetch a javascript</dfn> with given [=URL=] |url|:
 1. Let |request| be the result of [=creating a request=] with |url|, and [=create a request/accept=]
   set to "`application/javascript`".
 1. [=Fetch=] |request|.
@@ -635,6 +660,19 @@ A per buyer bid generator is an [=ordered map=] whose [=map/keys=] are [=URLs=] 
 A per signals url bid generator is an [=ordered map=] whose [=map/keys=] are [=url/origins=]
 representing [=interest group/joining origins=], and whose [=map/values=] are [=lists=] of
 [=interest groups=].
+
+</dl>
+
+<h3 dfn-type=dfn>Generate bid output</h3>
+
+The output of running a FLEDGE generateBid() script.
+
+<dl dfn-for="generate bid output">
+: <dfn>bid</dfn>
+:: A {{double}}. If the bid is zero or negative, then this interest group will not participate in
+  the auction.
+: <dfn>render</dfn>
+:: A [=URL=], which will be rendered to display the creative if this bid wins the auction.
 
 </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -19,12 +19,6 @@ Markup Shorthands: markdown yes
 Assume Explicit For: yes
 </pre>
 
-<pre class=anchors>
-urlPrefix: https://www.rfc-editor.org/rfc/rfc4122#; type: dfn; spec:rfc4122
-  text: Generate a version 4 UUID; url: section-4.4
-  text: Convert a UUID to a URN; url: section-3
-</pre>
-
 # Introduction # {#intro}
 
 <em>This section is non-normative</em>
@@ -279,17 +273,11 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
-1. Let |uuid| be the result of <a>generating a version 4 UUID</a>.
-1. Let |urnUuid| be the result of <a>converting a UUID to a URN</a> given a |uuid|.
-1. Let |uuidToUrlMap| be a new [=ordered map=] whose [=map/keys=] are [=strings=] and whose
-  [=map/values=] are [=URLs=].
 1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
 1. Run the following steps [=in parallel=]:
-  1. Let |winningAdUrl| be the result of running [=generate and score bids=] with |auctionConfig|,
-    |bidGenerators|, |global|, and |p|.
+  1. Run [=generate and score bids=] with |auctionConfig|, |bidGenerators|, |global|, and |p|.
     TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
     the auction.
-  1. Set |uuidToUrlMap|[|urnUuid|] to |winningAdUrl|.
   1. TODO: UpdateInterestGroupsPostAuction.
 1. Return |p|.
 
@@ -354,8 +342,8 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   |value| of |config|["{{AuctionAdConfig/perBuyerSignals}}"]:
   1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is an error,
     [=exception/throw=] a {{TypeError}}.
-  1. Let |signalsString| be the result of
-    [=serializing a JavaScript value to a JSON string=], given |value|.
+  1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given
+    |value|.
   1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to
     |signalsString|.
 1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=], [=map/for each=] |key| →
@@ -459,7 +447,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       1. [=generate and score bids=] with |component|.
     1. TODO: If the last |component|'s seller script runner is received, create a seller script
       runner.
-  1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
+  1. Let |decisionLogicScript| be the result of [=fetching resource=] with |auctionConfig|'s
     [=auction config/decision logic url=], and "text/javascript".
   1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
     [=auction config/all buyer experiment group id=].
@@ -476,7 +464,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
         1. [=list/For each=] |ig| of |groups|:
           1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
           1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
-      1. Let |fullSignalsUrl| be the result of calling [=build trusted bidding signals url=] with
+      1. Let |fullSignalsUrl| be the result of [=building trusted bidding signals url=] with
         |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
       1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
         and "application/json".
@@ -486,13 +474,13 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. Let |biddingScript| be the result of [=fetching resource=] with |ig|'s
             [=interest group/bidding url=], and "text/javascript". If |biddingScript| is an error,
             [=iteration/continue=].
-          1. TODO: Let |generatedBid| be the result of running [=evaluate script=] with
+          1. TODO: Let |generatedBid| be the result of [=evaluating script=] with
             [=evaluate script/script=] set to |biddingScript|, [=evaluate script/functionName=] set
             to "generateBid", and [=evaluate script/arguments=] set to |trustedBiddingSignals|.
           1. If |generatedBid|'s [=generate bid output/bid=] is negative or 0,
             [=iteration/continue=].
           1. TODO: Validate other fields of |generatedBid|.
-          1. TODO: Let |score| be the result of running [=evaluate script=] with
+          1. TODO: Let |score| be the result of [=evaluating script=] with
             [=evaluate script/script=] set to |decisionLogicScript|,
             [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
             to scoreAd's arguements.
@@ -506,8 +494,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             still being scored, set |allBidsGeneratedAndScored| to true.
 1. Wait until |allBidsGeneratedAndScored| is set.
 1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p| with
-  |winningAdUrl|.
-1. Return |winningAdUrl|.
+  |winningAdUrl|. TODO: resolve |p| with urn-uuid, instead of a URL.
 
 </div>
 
@@ -558,6 +545,7 @@ To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
     1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
       |responseBody| is not [=UTF-8=] encoded.
     1. If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
+  1. Set |resource| to |responseBody|.
 1. Wait for |resource| to be set.
 1. Return |resource|.
 
@@ -580,7 +568,7 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
     [=component percent-encode set=] to |queryParamsList|.
 1. If |igNames| is not [=set/is empty|empty]:
   1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
-  1. Let |igNamesStr| be the result of [=string/concatenate=] |igNames| with separator set to ",".
+  1. Let |igNamesStr| be the result of [=string/concatenating=] |igNames| with separator set to ",".
   1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |igNamesStr| using
     [=component percent-encode set=] to |queryParamsList|.
 1. If |experimentGroupId| is not null:
@@ -610,12 +598,7 @@ To <dfn>evaluate script</dfn> with given [=string=] <dfn for="evaluate script">|
 This specification defines two [=policy-controlled features=] identified by the string
 "<code><dfn noexport>join-ad-interest-group</dfn></code>", and
 "<code><dfn noexport>run-ad-auction</dfn></code>". Their
-<<<<<<< HEAD
 [=policy-controlled feature/default allowlists=] are `self`.
-=======
-[=policy-controlled feature/default allowlists=] are
-<a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">`self`</a>.
->>>>>>> af6bdcc (Try fixing a build error about Permissions Policy.)
 
 Note: In the Chromium implementation the [=policy-controlled feature/default allowlists=] for both
 features are temporarily set to `*` to ease testing.

--- a/spec.bs
+++ b/spec.bs
@@ -440,28 +440,30 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, a
 [=global object=] |global|, and a [=boolean=] |isTopLevel|:
 1. [=Assert=] that these steps are running [=in parallel=].
-1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
-1. Let |hasComponentAuctions| be false.
-1. Let |componentWinners| be an [=list/is empty|empty=] list.
-1. If |auctionConfig|'s [=auction config/component auctions=] are not [=list/is empty|empty=]:
-  1. [=Assert=] |isTopLevel| being true.
-  1. Set |hasComponentAuctions| to true.
-  1. Run the following steps [=in parallel=]:
-  1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
-    1. Let |compWinner| be the result of [=generate and score bids=] with |component|, |global|, and
-      false.
-    1. If |compWinner| is not failure, [=list/append=] |compWinner| to |componentWinners|.
-1. Let |decisionLogicScript| to the result of [=creating a seller script runner=] with
+1. Let |decisionLogicScript| be the result of [=creating a seller script runner=] with
   |auctionConfig|'s [=auction config/decision logic url=].
 1. If |decisionLogicScript| is failure, return null.
+1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
 1. Let |leadingBidInfo| be a new [=leading bid info=].
-1. If |hasComponentAuctions| is true:
-  1. [=list/For each=] |cw| of |componentWinners|:
-    1. [=Score and rank a bid=] given |cw|, |leadingBidInfo|, and true.
+1. Let |queue| be the result of [=starting a new parallel queue=].
+1. If |auctionConfig|'s [=auction config/component auctions=] are not [=list/is empty|empty=]:
+  1. [=Assert=] |isTopLevel| being true.
+  1. Let |pendingComponentAuctions| be the [=list/size=] of |auctionConfig|'s
+    [=auction config/component auctions=].
+  1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=],
+    [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
+    1. Let |compWinner| be the result of [=generate and score bids=] with |component|, |global|, and
+      false.
+    1. If |compWinner| is not failure or null, [=score and rank a bid=] with |compWinner|,
+      |leadingBidInfo|, |desisionLogicScript|, and true.
+    1. Decrement |pendingComponentAuctions| by 1.
+  1. Wait until |pendingComponentAuctions| is 0.
   1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
 1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
   [=auction config/all buyer experiment group id=].
-1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
+1. Let |pendingBuyers| be the [=map/size=] of |bidGenerators|.
+1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|,
+  [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
   1. Let |buyerExperimentGroupId| be |allBuyersExperimentGroupId|.
   1. Let |perBuyerExperimentGroupIds| be |auctionConfig|'s
     [=auction config/per buyer experiment group ids=].
@@ -491,14 +493,18 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           to "generateBid", and [=evaluate script/arguments=] set to |trustedBiddingSignals|.
         1. If |generatedBid|'s [=generated bid/bid=] is negative or 0, [=iteration/continue=].
         1. TODO: Validate other fields of |generatedBid|.
-        1. [=Score and rank a bid=] with |generatedBid|, |leadingBidInfo| and
-          |hasComponentAuctions|.
+        1. [=Score and rank a bid=] with |generatedBid|, |leadingBidInfo|, |desisionLogicScript| and
+          false.
+  1. Decrement |pendingBuyers| by 1.
+1. Wait until |pendingBuyers| is 0.
 1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
 
 </div>
 
+<div algorithm>
+
 To <dfn>score and rank a bid</dfn> given a [=generated bid=] |generatedBid|, a [=leading bid info=]
-|leadingBidInfo|, and a [=boolean=] |hasComponentAuction|:
+|leadingBidInfo|, a [=string=] |decisionLogicScript|, and a [=boolean=] |hasComponentAuction|:
 1. TODO: Let |scoreAdOutput| be the result of [=evaluating script=] with
   [=evaluate script/script=] set to |decisionLogicScript|,
   [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set to
@@ -518,6 +524,8 @@ To <dfn>score and rank a bid</dfn> given a [=generated bid=] |generatedBid|, a [
   1. Increment |leadingBidInfo|'s [=leading bid info/top bids count=] by 1.
   1. Set |leadingBidInfo|'s [=leading bid info/leading bid=] to |maybeModifiedBid| with 1 in
     |leadingBidInfo|'s [=leading bid info/top bids count=] chance.
+
+</div>
 
 To <dfn>create a seller script runner</dfn> given a [=URL=] |decisionLogicUrl|:
 1. TODO: create the script runner and set up environment.
@@ -550,7 +558,7 @@ To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for=
     :: "`error`"
 1. Return |request|.
 
-<div algorithm="fetch resource">
+<div algorithm>
 
 To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 1. Let |request| be the result of [=creating a request=] with |url|, and [=create a request/accept=]
@@ -578,7 +586,7 @@ To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 
 </div>
 
-<div algorithm="build trusted bidding signals url">
+<div algorithm>
 
 To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
 [=strings=] |keys|, an [=ordered set=] of [=strings=] |igNames|, and a non-negative 16-bit integer
@@ -593,7 +601,7 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
   1. Let |keysStr| be the result of [=string/concatenating=] |keys| with separator set to ",".
   1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |keysStr| using
     [=component percent-encode set=] to |queryParamsList|.
-1. If |igNames| is not [=set/is empty|empty]:
+1. If |igNames| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
   1. Let |igNamesStr| be the result of [=string/concatenating=] |igNames| with separator set to ",".
   1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |igNamesStr| using

--- a/spec.bs
+++ b/spec.bs
@@ -259,6 +259,7 @@ dictionary AuctionAdConfig {
 
 The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 
+1. Assert: These steps are running [=in parallel=].
 1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
   "[=run-ad-auction=]" [=policy-controlled feature=], then [=exception/throw=] a
   "{{NotAllowedError}}" {{DOMException}}.
@@ -273,11 +274,13 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
-1. Let |winning_ad_url| be the result of running [=generate and score bids=] with |auctionConfig|.
-1. TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
+1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
+1. Let |winningAdUrl| be the result of running [=generate and score bids=] with |auctionConfig|, and
+  |bidGenerators|.
+  TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
   the auction.
 1. TODO: UpdateInterestGroupsPostAuction.
-1. Resolve |p| with |winning_ad_url|.
+1. Resolve |p| with |winningAdUrl|.
 1. Return |p|.
 
 </div>
@@ -396,21 +399,12 @@ To <dfn>parse an origin</dfn> given a [=string=] |input|:
 1. If |url| is an error, then return failure.
 1. Return |url|'s [=url/origin=].
 
-<div algorithm="generate and score bids">
+<div algorithm="build bid generators map">
 
-To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|:
-1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
-  1. TODO: Create a seller script runner.
-1. Otherwise:
-  1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
-    1. [=generate and score bids=] with |component|.
-  1. TODO: If the last |component|'s seller script runner is received, create a seller script
-    runner.
-1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
-  [=auction config/decision logic url=], and "text/javascript".
+To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfig|:
 1. Let |bidGenerators| be a new [=ordered map=] whose [=map/keys=] are [=url/origins=] and whose
   [=map/values=] are [=per buyer bid generators=].
-1. [=list/For each=] |buyer| in [=auction config/interest group buyers=]:
+1. [=list/For each=] |buyer| in |auctionConfig|'s [=auction config/interest group buyers=]:
   1. [=list/For each=] |ig| of the user agent's [=interest group set=] whose
     [=interest group/owner=] is |buyer|:
     1. Let |signalsUrl| be |ig|'s [=interest group/trusted bidding signals url=].
@@ -435,10 +429,28 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. [=map/Set=] |perSignalsUrlGenerator|[|joiningOrigin|] to « |ig| ».
         1. Otherwise:
           1. [=list/Append=] |ig| to |perSignalsUrlGenerator|[|joiningOrigin|].
-1. Let |top_score|, and |num_top_bids| be 0.
-1. Let |winning_ad_url| be null.
+1. Return |bidGenerators|.
+
+</div>
+
+<div algorithm="generate and score bids">
+
+To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, and an
+[=ordered map=] |bidGenerators|:
+1. Let |topScore|, and |numTopBids| be 0.
+1. Let |winningAdUrl| be null.
+1. Let |allBidsGeneratedAndScored| be null.
 1. Let |queue| be the result of [=starting a new parallel queue=].
-1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|:
+1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
+  1. TODO: Create a seller script runner.
+1. Otherwise:
+  1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
+    1. [=generate and score bids=] with |component|.
+  1. TODO: If the last |component|'s seller script runner is received, create a seller script
+    runner.
+1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
+  [=auction config/decision logic url=], and "text/javascript".
+1. [=map/For each=] buyer → |perBuyerGenerator| of |bidGenerators|:
   1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
     1. Let |keys| be a new [=ordered set=].
     1. Let |igNames| be a new [=ordered set=].
@@ -449,7 +461,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       |signalsUrl|, |keys| and |igNames|.
     1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl| and
       "application/json".
-    1. [=map/For each=] |joiningOrigin| -> |groups| of |perSignalsUrlGenerator|:
+    1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
           1. TODO: create bidder script runner. If failed, [=iteration/continue=].
@@ -467,12 +479,15 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             [=evaluate script/functionName=] set to "scoreAd", and [=evaluate script/arguments=] set
             to scoreAd's arguements.
           1. If |score| is negative or 0, [=iteration/continue=].
-          1. If |score| is greater than |top_score|, then set |top_score| to |score|, set
-            |winning_ad_url| to |generatedBid|'s [=generate bid output/render=], and add 1 to
-            |num_top_bids|.
-          1. Otherwise, if |score| equals to |top_score|, then set |winning_ad_url| to
-            |generatedBid|'s [=generate bid output/render=] with 1 in |num_top_bids| chance.
-1. Return |winning_ad_url|.
+          1. If |score| is greater than |topScore|, then set |topScore| to |score|, set
+            |winningAdUrl| to |generatedBid|'s [=generate bid output/render=], and increment
+            |numTopBids| by 1.
+          1. Otherwise, if |score| equals to |topScore|, then set |winningAdUrl| to
+            |generatedBid|'s [=generate bid output/render=] with 1 in |numTopBids| chance.
+          1. If there is no more interest group waiting to be generated, waiting to be scored, or
+            still being scored, set |allBidsGeneratedAndScored| to true.
+1. Wait until |allBidsGeneratedAndScored| is set.
+1. return |winningAdUrl|.
 
 </div>
 
@@ -506,26 +521,25 @@ To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for=
 To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 1. Let |request| be the result of [=creating a request=] with |url|, and [=create a request/accept=]
   set to |mimeType|.
-1. [=Fetch=] |request|.
-1. Wait for the [=fetch/processResponseConsumeBody=] algorithm to finish. TODO: use 
-  [=fetch/processResponseConsumeBody=] as argument to [=fetch=].
-1. Let |response| be the result of [=fetch=] when it asynchronously completes.
-1. Let |body| be |response|’s [=response/body=].
-1. If |body| is null, return failure.
-1. Let |headers| be |response|'s [=response/header list=].
-1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
-  return true, return failure.
-1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
-1. Return failure if any of:
-  1. |headerMimeType| is failure.
-  1. |mimeType| is "`application/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
-  1. |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
-1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-1. Return failure if any of:
-  1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and |body| is not
-    [=UTF-8=] encoded.
-  1. If |mimeTypeCharset| is "us-ascii", and |body| is not [=ascii string=].
-1. Return |body|.
+1. Let |resource| be null.
+1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given a
+  [=response=] |response| and |responseBody|:
+  1. If |responseBody| is null or failure, set |resource| to failure.
+  1. Let |headers| be |response|'s [=response/header list=].
+  1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
+    return true, set |resource| to failure.
+  1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
+  1. Set |resource| to failure. if any of:
+    1. |headerMimeType| is failure.
+    1. |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
+    1. |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
+  1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
+  1. Set |resource| to failure. if any of:
+    1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
+      |responseBody| is not [=UTF-8=] encoded.
+    1. If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
+1. Wait for |resource| to be set.
+1. Return |resource|.
 
 </div>
 
@@ -535,20 +549,28 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
 [=strings=] |keys|, and an [=ordered set=] of [=strings=] |igNames|:
 1. Let |queryParamsList| be a new [=list/is empty|empty=] [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
-1. [=list/Append=] (escape) [=this=]'s [=relevant settings object=]'s
+1. [=list/Append=] the result of [=UTF-8 percent encode=] [=this=]'s [=relevant settings object=]'s
   [=environment/top-level origin=] to |queryParamsList|.
 1. If |keys| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&keys=" to |queryParamsList|.
-  1. [=list/Append=] the result of (escape) [=string/concatenate=] |keys| with separator set to ","
-    to |queryParamsList|.
+  1. Let |keysStr| be the result of [=string/concatenating=] |keys| with separator set to ",".
+  1. [=list/Append=] the result of [=UTF-8 percent encode=] |keysStr| to |queryParamsList|.
 1. If |igNames| is not [=set/is empty|empty]:
   1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
-  1. [=list/Append=] the result of (escape) [=string/concatenate=] |igNames| with separator set to
-    "," to |queryParamsList|.
+  1. Let |igNamesStr| be the result of [=string/concatenate=] |igNames| with separator set to ",".
+  1. [=list/Append=] the result of [=UTF-8 percent encode=] |igNamesStr| to |queryParamsList|.
 1. TODO: Do we want to add [=auction config/seller experiment group id=]?
 1. Let |fullSignalsUrl| be |signalsUrl|.
 1. Set |fullSignalsUrl|'s [=url/query=] to the result of [=string/concatenating=] |queryParamsList|.
 1. return |fullSignalsUrl|.
+
+</div>
+
+<div algorithm="UTF-8 percent encode">
+
+To <dfn>UTF-8 percent encode</dfn> a [=scalar value string=] |input|, return the result of
+[=string/UTF-8 percent-encoding=] |input| using <code>application/x-www-form-urlencoded</code>
+percent-encode set, and boolean spaceAsPlus set to true.
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -259,10 +259,9 @@ dictionary AuctionAdConfig {
 
 The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 
-1. Assert: These steps are running [=in parallel=].
-1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
-  "[=run-ad-auction=]" [=policy-controlled feature=], then [=exception/throw=] a
-  "{{NotAllowedError}}" {{DOMException}}.
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. If |global|'s [=associated Document=] is not [=allowed to use=] the "[=run-ad-auction=]"
+  [=policy-controlled feature=], then [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
 1. Let |auctionConfig| be the result of running [=validate and convert auction ad config=] with
   |config| and [=validate and convert auction ad config/isTopLevel=] set to true.
 1. If |auctionConfig| is failure, then return [=a promise rejected with=] a {{TypeError}}.
@@ -275,12 +274,11 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
     1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
 1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
-1. Let |winningAdUrl| be the result of running [=generate and score bids=] with |auctionConfig|, and
-  |bidGenerators|.
-  TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
-  the auction.
-1. TODO: UpdateInterestGroupsPostAuction.
-1. Resolve |p| with |winningAdUrl|.
+1. Run the following steps [=in parallel=]:
+  1. Run [=generate and score bids=] with |auctionConfig|, |bidGenerators|, and |global|.
+    TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
+    the auction.
+  1. TODO: UpdateInterestGroupsPostAuction.
 1. Return |p|.
 
 </div>
@@ -435,35 +433,36 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 
 <div algorithm="generate and score bids">
 
-To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, and an
-[=ordered map=] |bidGenerators|:
+To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, an
+[=ordered map=] |bidGenerators|, and [=global object=] |global|:
 1. Let |topScore|, and |numTopBids| be 0.
 1. Let |winningAdUrl| be null.
 1. Let |allBidsGeneratedAndScored| be null.
 1. Let |queue| be the result of [=starting a new parallel queue=].
-1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
-  1. TODO: Create a seller script runner.
-1. Otherwise:
-  1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
-    1. [=generate and score bids=] with |component|.
-  1. TODO: If the last |component|'s seller script runner is received, create a seller script
-    runner.
-1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
-  [=auction config/decision logic url=], and "text/javascript".
-1. [=map/For each=] buyer → |perBuyerGenerator| of |bidGenerators|:
-  1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
-    1. Let |keys| be a new [=ordered set=].
-    1. Let |igNames| be a new [=ordered set=].
-    1. [=set/For each=] |ig| of |groups|:
-      1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
-      1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
-    1. Let |fullSignalsUrl| be the result of calling [=build trusted bidding signals url=] with
-      |signalsUrl|, |keys| and |igNames|.
-    1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl| and
-      "application/json".
-    1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
-      1. [=list/For each=] |ig| of |groups|:
-        1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
+1. Let |p| be [=a new promise=].
+1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
+  1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
+    1. TODO: Create a seller script runner.
+  1. Otherwise:
+    1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=]:
+      1. [=generate and score bids=] with |component|.
+    1. TODO: If the last |component|'s seller script runner is received, create a seller script
+      runner.
+  1. Let |decisionLogicScript| be the result of [=fetch resource=] with |auctionConfig|'s
+    [=auction config/decision logic url=], and "text/javascript".
+  1. [=map/For each=] buyer → |perBuyerGenerator| of |bidGenerators|:
+    1. [=map/For each=] |signalsUrl| -> |perSignalsUrlGenerator| of |perBuyerGenerator|:
+      1. Let |keys| be a new [=ordered set=].
+      1. Let |igNames| be a new [=ordered set=].
+      1. [=set/For each=] |ig| of |groups|:
+        1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
+        1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
+      1. Let |fullSignalsUrl| be the result of calling [=build trusted bidding signals url=] with
+        |signalsUrl|, |keys| and |igNames|.
+      1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
+        and "application/json".
+      1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
+        1. [=list/For each=] |ig| of |groups|:
           1. TODO: create bidder script runner. If failed, [=iteration/continue=].
           1. Let |biddingScript| be the result of [=fetching resource=] with |ig|'s
             [=interest group/bidding url=], and "text/javascript". If |biddingScript| is an error,
@@ -487,7 +486,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. If there is no more interest group waiting to be generated, waiting to be scored, or
             still being scored, set |allBidsGeneratedAndScored| to true.
 1. Wait until |allBidsGeneratedAndScored| is set.
-1. return |winningAdUrl|.
+1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p| with
+  |winningAdUrl|.
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -19,6 +19,12 @@ Markup Shorthands: markdown yes
 Assume Explicit For: yes
 </pre>
 
+<pre class=anchors>
+urlPrefix: https://www.rfc-editor.org/rfc/rfc4122#; type: dfn; spec:rfc4122
+  text: Generate a version 4 UUID; url: section-4.4
+  text: Convert a UUID to a URN; url: section-3
+</pre>
+
 # Introduction # {#intro}
 
 <em>This section is non-normative</em>
@@ -273,11 +279,17 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. TODO: Abort the auction.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
+1. Let |uuid| be the result of <a>generating a version 4 UUID</a>.
+1. Let |urnUuid| be the result of <a>converting a UUID to a URN</a> given a |uuid|.
+1. Let |uuidToUrlMap| be a new [=ordered map=] whose [=map/keys=] are [=strings=] and whose
+  [=map/values=] are [=URLs=].
 1. Let |bidGenerators| be the result of running [=build bid generators map=] with |auctionConfig|.
 1. Run the following steps [=in parallel=]:
-  1. Run [=generate and score bids=] with |auctionConfig|, |bidGenerators|, and |global|.
+  1. Let |winningAdUrl| be the result of running [=generate and score bids=] with |auctionConfig|,
+    |bidGenerators|, |global|, and |p|.
     TODO: Let [=generate and score bids=] return a bool manually_aborted as well, to allow aborting
     the auction.
+  1. Set |uuidToUrlMap|[|urnUuid|] to |winningAdUrl|.
   1. TODO: UpdateInterestGroupsPostAuction.
 1. Return |p|.
 
@@ -495,6 +507,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Wait until |allBidsGeneratedAndScored| is set.
 1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p| with
   |winningAdUrl|.
+1. Return |winningAdUrl|.
 
 </div>
 
@@ -557,16 +570,19 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
 |experimentGroupId|:
 1. Let |queryParamsList| be a new [=list/is empty|empty=] [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
-1. [=list/Append=] the result of [=UTF-8 percent encode=] [=this=]'s [=relevant settings object=]'s
-  [=environment/top-level origin=] to |queryParamsList|.
+1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] [=this=]'s
+  [=relevant settings object=]'s [=environment/top-level origin=] using
+  [=component percent-encode set=] to |queryParamsList|.
 1. If |keys| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&keys=" to |queryParamsList|.
   1. Let |keysStr| be the result of [=string/concatenating=] |keys| with separator set to ",".
-  1. [=list/Append=] the result of [=UTF-8 percent encode=] |keysStr| to |queryParamsList|.
+  1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |keysStr| using
+    [=component percent-encode set=] to |queryParamsList|.
 1. If |igNames| is not [=set/is empty|empty]:
   1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
   1. Let |igNamesStr| be the result of [=string/concatenate=] |igNames| with separator set to ",".
-  1. [=list/Append=] the result of [=UTF-8 percent encode=] |igNamesStr| to |queryParamsList|.
+  1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |igNamesStr| using
+    [=component percent-encode set=] to |queryParamsList|.
 1. If |experimentGroupId| is not null:
   1. [=list/Append=] "&experimentGroupId=" to |queryParamsList|.
   1. [=list/Append=] [=serialize an integer|serialized=] |experimentGroupId| to |queryParamsList|.
@@ -581,14 +597,6 @@ number.
 
 Issue: This would ideally be replaced by a more descriptive algorithm in Infra. See
 <a href="https://github.com/whatwg/infra/issues/201">infra/201</a>
-
-<div algorithm="UTF-8 percent encode">
-
-To <dfn>UTF-8 percent encode</dfn> a [=scalar value string=] |input|, return the result of
-[=string/UTF-8 percent-encoding=] |input| using <code>application/x-www-form-urlencoded</code>
-percent-encode set, and boolean spaceAsPlus set to true.
-
-</div>
 
 To <dfn>evaluate script</dfn> with given [=string=] <dfn for="evaluate script">|script|</dfn>,
 [=string=] <dfn for="evaluate script">|functionName|</dfn>, and a [=list=]

--- a/spec.bs
+++ b/spec.bs
@@ -447,7 +447,6 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. If |auctionConfig|'s [=auction config/component auctions=] are [=list/is empty|empty=]:
   1. Set |decisionLogicScript| to the result of [=creating a seller script runner=] with
     |auctionConfig|'s [=auction config/decision logic url=].
-  1. If |decisionLogicScript| is failure, return null.
 1. Otherwise:
   1. [=Assert=] |isTopLevel| being true.
   1. Set |hasComponentAuctions| to true.


### PR DESCRIPTION
Document generate bid, score ad, picking winner, and resolve runAdAuction's promise in spec. Not touching the FLEDGE worklet and script execution part yet, but the steps around them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#running-ad-auctions, #structures
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/480.html" title="Last updated on Mar 30, 2023, 11:22 PM UTC (5b77db8)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/480.html#running-ad-auctions" title="#running-ad-auctions">#running-ad-auctions</a>) (<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/480.html#structures" title="#structures">#structures</a>) | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/480/04fa55a...qingxinwu:5b77db8.html" title="Last updated on Mar 30, 2023, 11:22 PM UTC (5b77db8)">Diff</a>