### PR TITLE
Fix two build errors and wrap a few long lines in spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -80,7 +80,8 @@ dictionary AuctionAdInterestGroup {
 
 <div algorithm="joinAdInterestGroup()">
 
-The <dfn for=Navigator method>joinAdInterestGroup(|group|, |durationSeconds|)</dfn> method steps are:
+The <dfn for=Navigator method>joinAdInterestGroup(|group|, |durationSeconds|)</dfn> method steps
+are:
 
 1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
   "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
@@ -213,7 +214,7 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 1. If |ig|'s [=interest group/ads=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
-  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null..
+  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
 1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
@@ -493,10 +494,11 @@ To <dfn>evaluate script</dfn> with given [=string=] <dfn for="evaluate script">|
 
 This specification defines two [=policy-controlled features=] identified by the string
 "<code><dfn noexport>join-ad-interest-group</dfn></code>", and
-"<code><dfn noexport>run-ad-auction</dfn></code>". Their [=policy-controlled feature/default allowlists=] are `'self'`.
+"<code><dfn noexport>run-ad-auction</dfn></code>". Their
+[=policy-controlled feature/default allowlists=] are `self`.
 
-Note: In the Chromium implementation the [=policy-controlled feature/default allowlists=] for both features are
-temporarily set to `*` to ease testing.
+Note: In the Chromium implementation the [=policy-controlled feature/default allowlists=] for both
+features are temporarily set to `*` to ease testing.
 
 
 # Structures # {#structures}
@@ -526,7 +528,7 @@ An interest group is a [=struct=] with the following items:
 :: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
   {{double}}. Overrides the {{AuctionAdConfig}}'s corresponding priority signals.
 : <dfn>execution mode</dfn>
-:: An {{WorkletExecutionMode}}, defaulting to "compatibility".
+:: A [=string=], defaulting to "compatibility".
 : <dfn>bidding url</dfn>
 :: Null or a [=URL=]. The URL to fetch the buyer's Javascript from.
 : <dfn>bidding wasm helper url</dfn>


### PR DESCRIPTION
fix two build errors:
1. {{WorkletExecutionMode}} -> [=string=]. The former type was removed in another PR, but didn't remove its usage.
2. default allowlist `'self'` -> `self`. Seems https://github.com/w3c/webappsec-permissions-policy/blob/main/index.bs#L370 requires the allowlist be `self` now, instead of allowing `'self'`.

Also wrapped a few long lines exceeding 100 characters.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/487.html" title="Last updated on Mar 23, 2023, 5:04 AM UTC (3ecfeee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/487/249d9e1...qingxinwu:3ecfeee.html" title="Last updated on Mar 23, 2023, 5:04 AM UTC (3ecfeee)">Diff</a>