### PR TITLE
Fix join promise resolution

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -174,12 +174,12 @@ The <dfn for=Navigator method>joinAdInterestGroup(|group|, |durationSeconds|)</d
 1. Return |p| and run the following steps [=in parallel=]: (TODO: Enqueue the steps to a
   [=parallel queue=] instead.)
   1. TODO: document .well-known fetches for cross-origin joins.
+  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
   1. If the browser is currently storing an interest group with `owner` and `name` that matches
     |interestGroup|, then remove the currently stored one.
   1. TODO: Set |interestGroup|'s [=interest group/joining origin=] to top level page origin from
     where the interest group was joined.
   1. Store |interestGroup| in the browser’s [=interest group set=].
-  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
 
 </div>
 


### PR DESCRIPTION
The promise is resolved before database operations to avoid timing attacks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/488.html" title="Last updated on Mar 31, 2023, 12:59 PM UTC (ff42471)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/488/530c491...caraitto:ff42471.html" title="Last updated on Mar 31, 2023, 12:59 PM UTC (ff42471)">Diff</a>