### PR TITLE
Check interest-group permissions for cross-origin joins

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -87,7 +87,7 @@ are:
   "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
   "{{NotAllowedError}}" {{DOMException}}.
 1. Let |frameOrigin| be the [=relevant settings object=]'s [=environment settings object/origin=].
-1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and that the [=origin/scheme=] of |frameOrigin| is "https".
+1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and its [=origin/scheme=] is "https".
 1. Let |interestGroup| be a new [=interest group=].
 1. Validate the given |group| and set |interestGroup|'s fields accordingly.
   1. Set |interestGroup|'s [=interest group/expiry=] to now plus |durationSeconds|.
@@ -255,10 +255,9 @@ To <dfn>check interest group permissions</dfn> given an [=origin=]
 1. Wait for |resource| to be set.
 1. If |resource| is failure, then return false.
 1. Let |permissions| be the result of [=parsing a JSON string to an Infra value=], returning false on failure.
-1. If |isJoin| is true and |permissions| is a JSON object containing key
-  "`joinAdInterestGroup`" with value `true`, return true.
-1. If |isJoin| is false and |permissions| is a JSON object containing key
-  "`leaveAdInterestGroup`" with value `true`, return true.
+1. If |permissions| is not an [=ordered map=], then return false.
+1. If |isJoin| is true and |permissions|["joinAdInterestGroup"] [=map/exists=], then return |permissions|["joinAdInterestGroup"].
+1. If |isJoin| is false and |permissions|["leaveAdInterestGroup"] [=map/exists=], then return |permissions|["leaveAdInterestGroup"].
 1. Return false.
 
 The browser may cache requests for |permissionsUrl| within a network partition.
@@ -272,7 +271,7 @@ prevents a leak of the user's ad interest group membership to the server.
 <div algorithm>
 
 To <dfn>build an interest group permissions url</dfn> given a [=origin=] |ownerOrigin| and a [=origin=] |frameOrigin|:
-1. Let |serializedFrameOrigin| be the result of [ =serialization of an origin|serializing=] |frameOrigin|.
+1. Let |serializedFrameOrigin| be the result of [=serialization of an origin|serializing=] |frameOrigin|.
 1. Return the string formed by [=string/concatenating=]
   * The [=serialization of an origin|serialization=] of |ownerOrigin|,
   * The string "`/.well-known/interest-group/permissions/?origin=`", and

--- a/spec.bs
+++ b/spec.bs
@@ -247,9 +247,11 @@ To <dfn>check interest group permissions</dfn> given an [=url/origin=]
 
 <div algorithm>
 
-To <dfn>build an interest group permissions url</dfn> given a [=string=] |ownerOrigin| and a [=string=] |frameOrigin|:
-1. Return the string formed by [=string/concatenating=] "`https://`", |ownerOrigin|,
-  "`/.well-known/interest-group/permissions/?origin=`", and |frameOrigin|.
+To <dfn>build an interest group permissions url</dfn> given a [=url/origin=] |ownerOrigin| and a [=url/origin=] |frameOrigin|:
+1. Return the string formed by [=string/concatenating=]
+  * The [=serialization of an origin|serialization=] of |ownerOrigin|,
+  * The string "`/.well-known/interest-group/permissions/?origin=`", and
+  * The [=serialization of an origin|serialization=] of |frameOrigin|.
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -87,8 +87,7 @@ are:
   "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
   "{{NotAllowedError}}" {{DOMException}}.
 1. Let |frameOrigin| be the [=relevant settings object=]'s [=environment settings object/origin=].
-1. If |frameOrigin| is an [=opaque origin=], then [=exception/throw=] a
-  "{{NotAllowedError}}" {{DOMException}}.
+1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and that the [=origin/scheme=] of |frameOrigin| is "https".
 1. Let |interestGroup| be a new [=interest group=].
 1. Validate the given |group| and set |interestGroup|'s fields accordingly.
   1. Set |interestGroup|'s [=interest group/expiry=] to now plus |durationSeconds|.
@@ -96,7 +95,7 @@ are:
     |group|["{{AuctionAdInterestGroup/owner}}"].
     1. If |ownerUrl| is an error, or its [=url/scheme=] is not "`https`", [=exception/throw=] a
       {{TypeError}}.
-    1. Set |interestGroup|'s [=interest group/owner=] to |ownerUrl|'s [=url/origin=].
+    1. Set |interestGroup|'s [=interest group/owner=] to |ownerUrl|'s [=origin=].
   1. Set |interestGroup|'s [=interest group/name=] to |group|["{{AuctionAdInterestGroup/name}}"].
   1. Set |interestGroup|'s [=interest group/priority=] to
     |group|["{{AuctionAdInterestGroup/priority}}"].
@@ -228,15 +227,13 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 
 <div algorithm>
 
-To <dfn>check interest group permissions</dfn> given an [=url/origin=]
-|ownerOrigin|, an [=url/origin=] |frameOrigin|, and a [=boolean=] |isJoin|:
+To <dfn>check interest group permissions</dfn> given an [=origin=]
+|ownerOrigin|, an [=origin=] |frameOrigin|, and a [=boolean=] |isJoin|:
 1. If |ownerOrigin| is [=same origin=] to |frameOrigin|, then return true.
 1. Let |permissionsUrl| be the result of [=building an interest group permissions url=]
   with |ownerOrigin| and |frameOrigin|.
-1. Let |resource| be the result of [=fetching resource=] with |permissionsUrl|
-  and "`application/json`".
 1. Let |request| be the result of [=creating a request=] with |permissionsUrl|, [=create a request/accept=]
-  set to "`application/json`"| and [=create a request/corsMode=] set to true.
+  set to "`application/json`"|. TODO: [maybe](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/interest_group/interest_group_permissions_checker.cc;drc=adac219925ef5d9c9a954d189c2e4b8852a4bbed;l=123) require cors mode here?
 1. Let |resource| be null.
 1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given a
   [=response=] |response| and |responseBody|:
@@ -263,15 +260,22 @@ To <dfn>check interest group permissions</dfn> given an [=url/origin=]
   "`leaveAdInterestGroup`" with value `true`, return true.
 1. Return false.
 
+The browser may cache requests for |permissionsUrl| within a network partition.
+
+In order to prevent leaking data, the browser must request |permissionsUrl|
+regardless of whether the user is a member of the ad interest group. This
+prevents a leak of the user's ad interest group membership to the server.
+
 </div>
 
 <div algorithm>
 
-To <dfn>build an interest group permissions url</dfn> given a [=url/origin=] |ownerOrigin| and a [=url/origin=] |frameOrigin|:
+To <dfn>build an interest group permissions url</dfn> given a [=origin=] |ownerOrigin| and a [=origin=] |frameOrigin|:
+1. Let |serializedFrameOrigin| be the result of [ =serialization of an origin|serializing=] |frameOrigin|.
 1. Return the string formed by [=string/concatenating=]
   * The [=serialization of an origin|serialization=] of |ownerOrigin|,
   * The string "`/.well-known/interest-group/permissions/?origin=`", and
-  * The [=serialization of an origin|serialization=] of |frameOrigin|.
+  * The result of [=string/UTF-8 percent-encoding=] |serializedFrameOrigin| using [=component percent-encode set=].
 
 </div>
 
@@ -625,8 +629,8 @@ To <dfn>create a seller script runner</dfn> given a [=URL=] |decisionLogicUrl|:
   "text/javascript".
 1. Return |decisionLogicScript|.
 
-To <dfn>create a request</dfn> given a [=URL=] |url|, a [=string=] <dfn for="create a request">
-|accept|</dfn> and a [=boolean=] <dfn for="create a request">|corsMode|</dfn>:
+To <dfn>create a request</dfn> given a [=URL=] |url| and a [=string=] <dfn for="create a request">
+|accept|</dfn>:
 1. Let |request| be a new [=request=] with the following properties:
     :   [=request/URL=]
     ::  |url|
@@ -648,15 +652,13 @@ To <dfn>create a request</dfn> given a [=URL=] |url|, a [=string=] <dfn for="cre
     ::  "`no-store`"
     :   [=request/redirect mode=]
     :: "`error`"
-    :   [=request/mode=]
-    :: If |corsMode| is true, then "`cors`", else "`same-origin`".
 1. Return |request|.
 
 <div algorithm>
 
 To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
 1. Let |request| be the result of [=creating a request=] with |url|, [=create a request/accept=]
-  set to |mimeType|, and [=create a request/corsMode=] set to false.
+  set to |mimeType|.
 1. Let |resource| be null.
 1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given a
   [=response=] |response| and |responseBody|:

--- a/spec.bs
+++ b/spec.bs
@@ -256,8 +256,8 @@ To <dfn>check interest group permissions</dfn> given an [=origin=]
 1. If |resource| is failure, then return false.
 1. Let |permissions| be the result of [=parsing a JSON string to an Infra value=], returning false on failure.
 1. If |permissions| is not an [=ordered map=], then return false.
-1. If |isJoin| is true and |permissions|["joinAdInterestGroup"] [=map/exists=], then return |permissions|["joinAdInterestGroup"].
-1. If |isJoin| is false and |permissions|["leaveAdInterestGroup"] [=map/exists=], then return |permissions|["leaveAdInterestGroup"].
+1. If |isJoin| is true and |permissions|["`joinAdInterestGroup`"] [=map/exists=], then return |permissions|["`joinAdInterestGroup`"].
+1. If |isJoin| is false and |permissions|["`leaveAdInterestGroup`"] [=map/exists=], then return |permissions|["`leaveAdInterestGroup`"].
 1. Return false.
 
 The browser may cache requests for |permissionsUrl| within a network partition.

--- a/spec.bs
+++ b/spec.bs
@@ -254,15 +254,8 @@ To <dfn>check interest group permissions</dfn> given an [=origin=]
   1. Let |headers| be |response|'s [=response/header list=].
   1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
     return true, set |resource| to failure and return.
-  1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
-  1. Set |resource| to failure and return, if any of the following conditions hold:
-    * |headerMimeType| is failure;
-    * |headerMimeType| is not a [=JSON MIME type=].
-  1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-  1. Set |resource| to failure and return if any of the following conditions hold:
-    * If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
-      |responseBody| is not [=UTF-8=] encoded;
-    * If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
+  1. Let |mimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
+  1. If |mimeType| is failure or is not a [=JSON MIME Type=], throw, set |resource| to failure and return.
   1. Set |resource| to |responseBody|.
 1. Wait for |resource| to be set.
 1. If |resource| is failure, then return false.

--- a/spec.bs
+++ b/spec.bs
@@ -180,13 +180,12 @@ are:
     |ownerUrl|'s [=url/origin=], |frameOrigin|, and true.
   1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
      "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
-  1. Otherwise, [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
-    1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
-    1. If the browser is currently storing an interest group with `owner` and `name` that matches
-      |interestGroup|, then remove the currently stored one.
-    1. Set |interestGroup|'s [=interest group/joining origin=] to [=this=]'s
-      [=relevant settings object=]'s [=environment/top-level origin=]
-    1. Store |interestGroup| in the browser’s [=interest group set=].
+  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
+  1. If the browser is currently storing an interest group with `owner` and `name` that matches
+    |interestGroup|, then remove the currently stored one.
+  1. Set |interestGroup|'s [=interest group/joining origin=] to [=this=]'s
+    [=relevant settings object=]'s [=environment/top-level origin=]
+  1. Store |interestGroup| in the browser’s [=interest group set=].
 1. Return |p|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -234,7 +234,7 @@ To <dfn>check interest group permissions</dfn> given an [=url/origin=]
 1. Let |resource| be the result of [=fetching resource=] with |permissionsUrl|
   and "`application/json`". (TODO: use cors mode)
 1. If |resource| is failure, then return false.
-1. Let |permissions| be the result of parsing |resource| as JSON, returning false on failure.
+1. Let |permissions| be the result of [=parsing a JSON string to an Infra value=], returning false on failure.
 1. If |isJoin| is true and |permissions| is a JSON object containing key
   "`joinAdInterestGroup`" with value `true`, return true.
 1. If |isJoin| is false and |permissions| is a JSON object containing key

--- a/spec.bs
+++ b/spec.bs
@@ -86,6 +86,9 @@ are:
 1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
   "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
   "{{NotAllowedError}}" {{DOMException}}.
+1. Let |frameOrigin| be the [=relevant settings object=]'s [=environment settings object/origin=].
+1. If |frameOrigin| is an [=opaque origin=], then [=exception/throw=] a
+  "{{NotAllowedError}}" {{DOMException}}.
 1. Let |interestGroup| be a new [=interest group=].
 1. Validate the given |group| and set |interestGroup|'s fields accordingly.
   1. Set |interestGroup|'s [=interest group/expiry=] to now plus |durationSeconds|.
@@ -171,9 +174,8 @@ are:
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
 1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
   [=exception/throw=] a {{TypeError}}.
-1. Let |frameOrigin| be the [=relevant settings object=]'s [=environment settings object/origin=].
 1. Let |permission| be the result of [=checking interest group permissions=] with 
-|ownerUrl|'s [=url/origin=], |frameOrigin|, and |true|.
+  |ownerUrl|'s [=url/origin=], |frameOrigin|, and true.
 1. If |permission| is false, then [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
 1. Let |p| be [=a new promise=].
 1. Let |queue| be the result of [=starting a new parallel queue=].

--- a/spec.bs
+++ b/spec.bs
@@ -173,18 +173,20 @@ are:
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
 1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
   [=exception/throw=] a {{TypeError}}.
-1. Let |permission| be the result of [=checking interest group permissions=] with 
-  |ownerUrl|'s [=url/origin=], |frameOrigin|, and true.
-1. If |permission| is false, then [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
 1. Let |p| be [=a new promise=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
-  1. If the browser is currently storing an interest group with `owner` and `name` that matches
-    |interestGroup|, then remove the currently stored one.
-  1. Set |interestGroup|'s [=interest group/joining origin=] to [=this=]'s
-    [=relevant settings object=]'s [=environment/top-level origin=]
-  1. Store |interestGroup| in the browser’s [=interest group set=].
+  1. Let |permission| be the result of [=checking interest group permissions=] with 
+    |ownerUrl|'s [=url/origin=], |frameOrigin|, and true.
+  1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
+     "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
+  1. Otherwise, [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
+    1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
+    1. If the browser is currently storing an interest group with `owner` and `name` that matches
+      |interestGroup|, then remove the currently stored one.
+    1. Set |interestGroup|'s [=interest group/joining origin=] to [=this=]'s
+      [=relevant settings object=]'s [=environment/top-level origin=]
+    1. Store |interestGroup| in the browser’s [=interest group set=].
 1. Return |p|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -234,7 +234,27 @@ To <dfn>check interest group permissions</dfn> given an [=url/origin=]
 1. Let |permissionsUrl| be the result of [=building an interest group permissions url=]
   with |ownerOrigin| and |frameOrigin|.
 1. Let |resource| be the result of [=fetching resource=] with |permissionsUrl|
-  and "`application/json`". (TODO: use cors mode)
+  and "`application/json`".
+1. Let |request| be the result of [=creating a request=] with |permissionsUrl|, [=create a request/accept=]
+  set to "`application/json`"| and [=create a request/corsMode=] set to true.
+1. Let |resource| be null.
+1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given a
+  [=response=] |response| and |responseBody|:
+  1. If |responseBody| is null or failure, set |resource| to failure and return.
+  1. Let |headers| be |response|'s [=response/header list=].
+  1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
+    return true, set |resource| to failure and return.
+  1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
+  1. Set |resource| to failure and return, if any of:
+    1. |headerMimeType| is failure.
+    1. |headerMimeType| is not a [=JSON MIME type=].
+  1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
+  1. Set |resource| to failure and return if any of:
+    1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
+      |responseBody| is not [=UTF-8=] encoded.
+    1. If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
+  1. Set |resource| to |responseBody|.
+1. Wait for |resource| to be set.
 1. If |resource| is failure, then return false.
 1. Let |permissions| be the result of [=parsing a JSON string to an Infra value=], returning false on failure.
 1. If |isJoin| is true and |permissions| is a JSON object containing key
@@ -605,8 +625,8 @@ To <dfn>create a seller script runner</dfn> given a [=URL=] |decisionLogicUrl|:
   "text/javascript".
 1. Return |decisionLogicScript|.
 
-To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for="create a request">
-|accept|</dfn>:
+To <dfn>create a request</dfn> given a [=URL=] |url|, a [=string=] <dfn for="create a request">
+|accept|</dfn> and a [=boolean=] <dfn for="create a request">|corsMode|</dfn>:
 1. Let |request| be a new [=request=] with the following properties:
     :   [=request/URL=]
     ::  |url|
@@ -628,13 +648,15 @@ To <dfn>create a request</dfn> given a [=URL=] |url|, and a [=string=] <dfn for=
     ::  "`no-store`"
     :   [=request/redirect mode=]
     :: "`error`"
+    :   [=request/mode=]
+    :: If |corsMode| is true, then "`cors`", else "`same-origin`".
 1. Return |request|.
 
 <div algorithm>
 
 To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
-1. Let |request| be the result of [=creating a request=] with |url|, and [=create a request/accept=]
-  set to |mimeType|.
+1. Let |request| be the result of [=creating a request=] with |url|, [=create a request/accept=]
+  set to |mimeType|, and [=create a request/corsMode=] set to false.
 1. Let |resource| be null.
 1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given a
   [=response=] |response| and |responseBody|:

--- a/spec.bs
+++ b/spec.bs
@@ -255,14 +255,14 @@ To <dfn>check interest group permissions</dfn> given an [=origin=]
   1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
     return true, set |resource| to failure and return.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
-  1. Set |resource| to failure and return, if any of:
-    1. |headerMimeType| is failure.
-    1. |headerMimeType| is not a [=JSON MIME type=].
+  1. Set |resource| to failure and return, if any of the following conditions hold:
+    * |headerMimeType| is failure;
+    * |headerMimeType| is not a [=JSON MIME type=].
   1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-  1. Set |resource| to failure and return if any of:
-    1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
-      |responseBody| is not [=UTF-8=] encoded.
-    1. If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
+  1. Set |resource| to failure and return if any of the following conditions hold:
+    * If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
+      |responseBody| is not [=UTF-8=] encoded;
+    * If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
   1. Set |resource| to |responseBody|.
 1. Wait for |resource| to be set.
 1. If |resource| is failure, then return false.

--- a/spec.bs
+++ b/spec.bs
@@ -171,10 +171,13 @@ are:
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
 1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
   [=exception/throw=] a {{TypeError}}.
+1. Let |frameOrigin| be [=this=]'s [=relevant global object=]'s `origin` property.
+1. Let |permission| be the result of [=checking interest group permissions=] with 
+|ownerUrl|'s [=url/origin=], |frameOrigin|, and |true|.
+1. If |permission| is false, then [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
 1. Let |p| be [=a new promise=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-  1. TODO: document .well-known fetches for cross-origin joins.
   1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
   1. If the browser is currently storing an interest group with `owner` and `name` that matches
     |interestGroup|, then remove the currently stored one.
@@ -220,6 +223,35 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
+
+<div algorithm="check interest group permissions">
+
+To <dfn>check interest group permissions</dfn> given a [=string=] <dfn
+for="fetch interest group permissions">|ownerOrigin|</dfn>, a [=string=] <dfn
+for="fetch interest group permissions">|frameOrigin|</dfn>, and a [=boolean=]
+<dfn for="fetch interest group permissions">|isJoin|</dfn>:
+1. If |ownerOrigin| is equal to |frameOrigin|, then return true.
+1. Let |permissionsUrl| be the result of [building an interest group permissions url=]
+  with |ownerOrigin| and |frameOrigin|.
+1. Let |resource| be the result of [=fetching resource=] with |permissionsUrl|
+  and "`application/json`". (TODO: use cors mode)
+1. If |resource| is failure, then return false.
+1. Let |permissions| be the result of parsing |resource| as JSON, returning false on failure.
+1. If |isJoin| is true and |permissions| is a JSON object containing key
+  "`joinAdInterestGroup`" with value `true`, return true.
+1. If |isJoin| is false and |permissions| is a JSON object containing key
+  "`leaveAdInterestGroup`" with value `true`, return true.
+1. Return false.
+
+</div>
+
+<div algorithm="build an interest group permissions url">
+
+To <dfn>build an interest group permissions url</dfn> given a [=string=] |ownerOrigin| and a [=string=] |frameOrigin|:
+1. Return the string formed by [=string/concatenating=] "`https://`", |ownerOrigin|,
+  "`/.well-known/interest-group/permissions/?origin=`", and |frameOrigin|.
+
+</div>
 
 <h2 id="leaving-interest-groups">Leaving Interest Groups</h2>
 

--- a/spec.bs
+++ b/spec.bs
@@ -231,7 +231,7 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 To <dfn>check interest group permissions</dfn> given an [=url/origin=]
 |ownerOrigin|, an [=url/origin=] |frameOrigin|, and a [=boolean=] |isJoin|:
 1. If |ownerOrigin| is [=same origin=] to |frameOrigin|, then return true.
-1. Let |permissionsUrl| be the result of [building an interest group permissions url=]
+1. Let |permissionsUrl| be the result of [=building an interest group permissions url=]
   with |ownerOrigin| and |frameOrigin|.
 1. Let |resource| be the result of [=fetching resource=] with |permissionsUrl|
   and "`application/json`". (TODO: use cors mode)

--- a/spec.bs
+++ b/spec.bs
@@ -171,7 +171,7 @@ are:
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
 1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
   [=exception/throw=] a {{TypeError}}.
-1. Let |frameOrigin| be [=this=]'s [=relevant global object=]'s `origin` property.
+1. Let |frameOrigin| be the [=relevant settings object=]'s [=environment settings object/origin=].
 1. Let |permission| be the result of [=checking interest group permissions=] with 
 |ownerUrl|'s [=url/origin=], |frameOrigin|, and |true|.
 1. If |permission| is false, then [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
@@ -224,13 +224,11 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
     [=interest group ad/render url=].
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
 
-<div algorithm="check interest group permissions">
+<div algorithm>
 
-To <dfn>check interest group permissions</dfn> given a [=string=] <dfn
-for="fetch interest group permissions">|ownerOrigin|</dfn>, a [=string=] <dfn
-for="fetch interest group permissions">|frameOrigin|</dfn>, and a [=boolean=]
-<dfn for="fetch interest group permissions">|isJoin|</dfn>:
-1. If |ownerOrigin| is equal to |frameOrigin|, then return true.
+To <dfn>check interest group permissions</dfn> given an [=url/origin=]
+|ownerOrigin|, an [=url/origin=] |frameOrigin|, and a [=boolean=] |isJoin|:
+1. If |ownerOrigin| is [=same origin=] to |frameOrigin|, then return true.
 1. Let |permissionsUrl| be the result of [building an interest group permissions url=]
   with |ownerOrigin| and |frameOrigin|.
 1. Let |resource| be the result of [=fetching resource=] with |permissionsUrl|
@@ -245,7 +243,7 @@ for="fetch interest group permissions">|frameOrigin|</dfn>, and a [=boolean=]
 
 </div>
 
-<div algorithm="build an interest group permissions url">
+<div algorithm>
 
 To <dfn>build an interest group permissions url</dfn> given a [=string=] |ownerOrigin| and a [=string=] |frameOrigin|:
 1. Return the string formed by [=string/concatenating=] "`https://`", |ownerOrigin|,


### PR DESCRIPTION
This adds some spec language to check `.well-known` URLs for cross-origin joins (and, when written, leaves).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/djmitche/turtledove/pull/508.html" title="Last updated on Apr 10, 2023, 8:38 PM UTC (334bd37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/508/ad6803a...djmitche:334bd37.html" title="Last updated on Apr 10, 2023, 8:38 PM UTC (334bd37)">Diff</a>