### PR TITLE
Small change of "if any of" in the spec.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -129,9 +129,9 @@ are:
     1. If |group| [=map/contains=] |groupMember|:
       1. Let |parsedUrl| be the result of running the [=URL parser=] on |group|[|groupMember|].
       1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
-        * |parsedUrl| is an error.
-        * |parsedUrl| is not [=same origin=] with |interestGroup|'s [=interest group/owner=].
-        * |parsedUrl| [=includes credentials=].
+        * |parsedUrl| is an error;
+        * |parsedUrl| is not [=same origin=] with |interestGroup|'s [=interest group/owner=];
+        * |parsedUrl| [=includes credentials=];
         * |parsedUrl| [=url/fragment=] is not null.
       1. Set |interestGroup|'s |interestGroupField| to |parsedUrl|.
   1. If |interestGroup|'s [=interest group/trusted bidding signals url=]'s [=url/query=] is not
@@ -160,8 +160,8 @@ are:
       1. Let |renderUrl| be the result of running the [=URL parser=] on
         |ad|["{{AuctionAd/renderUrl}}"].
       1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
-        * |renderUrl| is an error.
-        * |renderUrl| [=url/scheme=] is not "`https`".
+        * |renderUrl| is an error;
+        * |renderUrl| [=url/scheme=] is not "`https`";
         * |renderUrl| [=includes credentials=].
       1. Set |igAd|'s [=interest group ad/render url=] to |renderUrl|.
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
@@ -334,9 +334,9 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   |directFromSellerSignalsPrefix| be the result of running the [=URL parser=] on
   |config|["{{AuctionAdConfig/directFromSellerSignals}}"].
   1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
-    * |directFromSellerSignalsPrefix| is an error.
+    * |directFromSellerSignalsPrefix| is an error;
     * |directFromSellerSignalsPrefix| is not [=same origin=] with |auctionConfig|'s
-      [=auction config/seller=].
+      [=auction config/seller=];
     * |directFromSellerSignalsPrefix|'s [=url/query=] is not null.
   1. Assert: |directFromSellerSignalsPrefix|'s [=url/scheme=] is "`https`".
   1. TODO: Figure out how to deal with DirectFromSellerSignals.
@@ -602,13 +602,13 @@ To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
     return true, set |resource| to failure and return.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
   1. Set |resource| to failure and return, if any of the following conditions hold:
-    * |headerMimeType| is failure.
-    * |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
+    * |headerMimeType| is failure;
+    * |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=];
     * |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
   1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
   1. Set |resource| to failure and return if any of the following conditions hold:
     * If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
-      |responseBody| is not [=UTF-8=] encoded.
+      |responseBody| is not [=UTF-8=] encoded;
     * If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
   1. Set |resource| to |responseBody|.
 1. Wait for |resource| to be set.

--- a/spec.bs
+++ b/spec.bs
@@ -128,7 +128,7 @@ are:
     </table>
     1. If |group| [=map/contains=] |groupMember|:
       1. Let |parsedUrl| be the result of running the [=URL parser=] on |group|[|groupMember|].
-      1. [=exception/Throw=] a {{TypeError}} if any of:
+      1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
         * |parsedUrl| is an error.
         * |parsedUrl| is not [=same origin=] with |interestGroup|'s [=interest group/owner=].
         * |parsedUrl| [=includes credentials=].
@@ -159,7 +159,7 @@ are:
       1. Let |igAd| be a new [=interest group ad=].
       1. Let |renderUrl| be the result of running the [=URL parser=] on
         |ad|["{{AuctionAd/renderUrl}}"].
-      1. [=exception/Throw=] a {{TypeError}} if any of:
+      1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
         * |renderUrl| is an error.
         * |renderUrl| [=url/scheme=] is not "`https`".
         * |renderUrl| [=includes credentials=].
@@ -333,7 +333,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 1. If |config|["{{AuctionAdConfig/directFromSellerSignals}}"] [=map/exists=], let
   |directFromSellerSignalsPrefix| be the result of running the [=URL parser=] on
   |config|["{{AuctionAdConfig/directFromSellerSignals}}"].
-  1. [=exception/Throw=] a {{TypeError}} if any of:
+  1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
     * |directFromSellerSignalsPrefix| is an error.
     * |directFromSellerSignalsPrefix| is not [=same origin=] with |auctionConfig|'s
       [=auction config/seller=].
@@ -601,15 +601,15 @@ To <dfn>fetch resource</dfn> given a [=URL=] |url|, and a [=string=] |mimeType|:
   1. If [=header list/getting a structured field value=] "X-Allow-FLEDGE" from |headers| does not
     return true, set |resource| to failure and return.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
-  1. Set |resource| to failure and return, if any of:
-    1. |headerMimeType| is failure.
-    1. |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
-    1. |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
+  1. Set |resource| to failure and return, if any of the following conditions hold:
+    * |headerMimeType| is failure.
+    * |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=].
+    * |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
   1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-  1. Set |resource| to failure and return if any of:
-    1. If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
+  1. Set |resource| to failure and return if any of the following conditions hold:
+    * If |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and
       |responseBody| is not [=UTF-8=] encoded.
-    1. If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
+    * If |mimeTypeCharset| is "us-ascii", and |responseBody| is not [=ascii string=].
   1. Set |resource| to |responseBody|.
 1. Wait for |resource| to be set.
 1. Return |resource|.


### PR DESCRIPTION
This came up in another review. Chaning all of existing ones to be consistent with the suggested format.
1. "if any of" => "if any of the following conditions hold".
2. numbered bullets "1." => "*" for conditions of "if any of".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/514.html" title="Last updated on Apr 5, 2023, 9:19 PM UTC (699eb8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/514/53c6703...qingxinwu:699eb8b.html" title="Last updated on Apr 5, 2023, 9:19 PM UTC (699eb8b)">Diff</a>