### PR TITLE
Fix initialisms casing

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -101,11 +101,11 @@ const myGroup = {
     ...
   }
   'enableBiddingSignalsPrioritization' : true,
-  'biddingLogicUrl': ...,
-  'biddingWasmHelperUrl': ...,
-  'dailyUpdateUrl': ...,
+  'biddingLogicURL': ...,
+  'biddingWasmHelperURL': ...,
+  'dailyUpdateURL': ...,
   'executionMode': ...,
-  'trustedBiddingSignalsUrl': ...,
+  'trustedBiddingSignalsURL': ...,
   'trustedBiddingSignalsKeys': ['key1', 'key2'],
   'userBiddingSignals': {...},
   'ads': [shoesAd1, shoesAd2, shoesAd3],
@@ -132,9 +132,9 @@ The `priority` is used to select which interest groups participate in an auction
 
 The `userBiddingSignals` is for storage of additional metadata that the owner can use during on-device bidding, and the `trustedBiddingSignals` attributes provide another mechanism for making real-time data available for use at bidding time.
 
-The `biddingWasmHelperUrl` field is optional, and lets the bidder provide computationally-expensive subroutines in WebAssembly, rather than JavaScript, to be driven from the JavaScript function provided by `biddingLogicUrl`. If provided, it must point to a WebAssembly binary, delivered with an `application/wasm` mimetype. The corresponding `WebAssembly.Module` will be made available by the browser to the `generateBid` function.
+The `biddingWasmHelperURL` field is optional, and lets the bidder provide computationally-expensive subroutines in WebAssembly, rather than JavaScript, to be driven from the JavaScript function provided by `biddingLogicURL`. If provided, it must point to a WebAssembly binary, delivered with an `application/wasm` mimetype. The corresponding `WebAssembly.Module` will be made available by the browser to the `generateBid` function.
 
-The `dailyUpdateUrl` provides a mechanism for the group's owner to periodically update the attributes of the interest group: any new values returned in this way overwrite the values previously stored (except that the `name` and `owner` cannot be changed, and `prioritySignalsOverrides` will be merged with the previous value, with `null` meaning a value should be removed from the interest group's old dictionary).  However, the browser will only allow daily updates when a sufficiently large number of people have the same `dailyUpdateUrl` , e.g. at least 100 browsers with the same update URL. This will not include any metadata, so data such as the interest group `name` should be included within the URL, so long as the URL exceeds the minimum count threshold.  (Without this sort of limit, a single-person interest group could be used to observe that person's coarse-grained IP-Geo location over time.)
+The `dailyUpdateURL` provides a mechanism for the group's owner to periodically update the attributes of the interest group: any new values returned in this way overwrite the values previously stored (except that the `name` and `owner` cannot be changed, and `prioritySignalsOverrides` will be merged with the previous value, with `null` meaning a value should be removed from the interest group's old dictionary).  However, the browser will only allow daily updates when a sufficiently large number of people have the same `dailyUpdateURL` , e.g. at least 100 browsers with the same update URL. This will not include any metadata, so data such as the interest group `name` should be included within the URL, so long as the URL exceeds the minimum count threshold.  (Without this sort of limit, a single-person interest group could be used to observe that person's coarse-grained IP-Geo location over time.)
 
 The `executionMode` attribute is optional, and may contain one of the following supported values:
 
@@ -158,7 +158,7 @@ The `ads` list contains the various ads that the interest group might show.  Eac
 The `adComponents` field contains the various ad components (or "products") that can be used to construct ["Ads Composed of Multiple Pieces"](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#34-ads-composed-of-multiple-pieces)). Similarly to the `ads` field, each entry is an object that includes both a rendering URL and arbitrary metadata that can be used at bidding time. Thanks to `ads` and `adsComponents` being separate fields, the buyer is able to update the `ads` field via daily update without losing `adComponents` stored in the interest group.
 
 All fields that accept arbitrary metadata objects (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable.
-All fields that specify URLs for loading scripts or JSON (`biddingLogicUrl`, `biddingWasmHelperUrl`, and `trustedBiddingSignalsUrl`) must point to URLs whose responses include the HTTP response header `X-Allow-FLEDGE: true` to ensure they are allowed to be used for loading FLEDGE resources.
+All fields that specify URLs for loading scripts or JSON (`biddingLogicURL`, `biddingWasmHelperURL`, and `trustedBiddingSignalsURL`) must point to URLs whose responses include the HTTP response header `X-Allow-FLEDGE: true` to ensure they are allowed to be used for loading FLEDGE resources.
 
 The browser will provide protection against microtargeting, by only rendering an ad if the same rendering URL is being shown to a sufficiently large number of people (e.g. at least 100 people would have seen the ad, if it were allowed to show).  While in the [Outcome-Based TURTLEDOVE](https://github.com/WICG/turtledove/blob/master/OUTCOME_BASED.md) proposal this threshold applied only to the rendered creative, FLEDGE has the additional requirement that the tuple of the interest group owner, bidding script URL, and rendered creative must be k-anonymous for an ad to be shown (this is necessary to ensure the current event-level reporting for interest group win reporting is sufficiently private). For interest groups that have component ads, all of the component ads must also separately meet this threshold for the ad to be shown. Since a single interest group can carry multiple possible ads that it might show, the group will have an opportunity to re-bid another one of its ads to act as a "fallback ad" any time its most-preferred choice is below threshold.  This means that a small, specialized interest group that is still below the daily-update threshold could still choose to participate in auctions, bidding with a more-generic ad until the group becomes large enough.
 
@@ -200,8 +200,8 @@ A seller initiates an auction by invoking a JavaScript API inside the publisher'
 ```
 const myAuctionConfig = {
   'seller': 'https://www.example-ssp.com',
-  'decisionLogicUrl': ...,
-  'trustedScoringSignalsUrl': ...,
+  'decisionLogicURL': ...,
+  'trustedScoringSignalsURL': ...,
   'interestGroupBuyers': ['https://www.example-dsp.com', 'https://buyer2.com', ...],
   'auctionSignals': {...},
   'directFromSellerSignals: 'https://www.example-ssp.com/...',
@@ -235,7 +235,7 @@ const myAuctionConfig = {
                                  ...},
   'componentAuctions': [
     {'seller': 'https://www.some-other-ssp.com',
-      'decisionLogicUrl': ...,
+      'decisionLogicURL': ...,
       ...},
     ...
   ],
@@ -281,7 +281,7 @@ Therefore, when requesting a `FencedFrameConfig` for use in a fenced frame eleme
 1. Unconditionally pass in `resolveToConfig: true` and check whether the auction result is a config or a URN.
 
 All fields that accept arbitrary metadata objects (`auctionSignals`, `sellerSignals`, and keys of `perBuyerSignals`) must be JSON-serializable.
-All fields that specify URLs for loading scripts or JSON (`decisionLogicUrl` and `trustedScoringSignalsUrl`) must point to URLs whose responses include the HTTP response header `X-Allow-FLEDGE: true` to ensure they are allowed to be used for loading FLEDGE resources.
+All fields that specify URLs for loading scripts or JSON (`decisionLogicURL` and `trustedScoringSignalsURL`) must point to URLs whose responses include the HTTP response header `X-Allow-FLEDGE: true` to ensure they are allowed to be used for loading FLEDGE resources.
 
 A `Permissions-Policy` directive named "run-ad-auction" controls access to the `navigator.runAdAuction()` API.
 
@@ -301,7 +301,7 @@ The seller may instead specify `'interestGroupBuyers': '*'` to permit all intere
 
 #### 2.3 Scoring Bids
 
-Once the bids are known, the seller runs code inside an _auction worklet_.  Within this worklet, the seller's auction script has an opportunity to consider each individual ad one at a time, with its associated bid and metadata, and then assign a numerical desirability score.  The seller's JavaScript is loaded from the auction configuration's `decisionLogicUrl`, which must expose a `scoreAd()` function:
+Once the bids are known, the seller runs code inside an _auction worklet_.  Within this worklet, the seller's auction script has an opportunity to consider each individual ad one at a time, with its associated bid and metadata, and then assign a numerical desirability score.  The seller's JavaScript is loaded from the auction configuration's `decisionLogicURL`, which must expose a `scoreAd()` function:
 
 
 ```
@@ -324,7 +324,7 @@ The function gets called once for each candidate ad in the auction.  The argumen
     ```
     { 'topWindowHostname': 'www.example-publisher.com',
       'interestGroupOwner': 'https://www.example-dsp.com',
-      'renderUrl': 'https://cdn.com/render_url_of_bid',
+      'renderURL': 'https://cdn.com/render_url_of_bid',
       'adComponents': ['https://cdn.com/ad_component_of_bid',
                        'https://cdn.com/next_ad_component_of_bid',
                        ...],
@@ -418,11 +418,11 @@ Buyers have three basic jobs in the on-device ad auction:
 #### 3.1 Fetching Real-Time Data from a Trusted Server
 
 
-Buyers may want to make on-device decisions that take into account real-time data (for example, the remaining budget of an ad campaign).  This need can be met using the interest group's `trustedBiddingSignalsUrl` and `trustedBiddingSignalsKeys` fields.  Once a seller initiates an on-device auction on a publisher page, the browser checks each participating interest group for these fields, and makes an uncredentialed (cookieless) HTTP fetch to a URL of the form:
+Buyers may want to make on-device decisions that take into account real-time data (for example, the remaining budget of an ad campaign).  This need can be met using the interest group's `trustedBiddingSignalsURL` and `trustedBiddingSignalsKeys` fields.  Once a seller initiates an on-device auction on a publisher page, the browser checks each participating interest group for these fields, and makes an uncredentialed (cookieless) HTTP fetch to a URL of the form:
 
     https://www.kv-server.example/getvalues?hostname=publisher.com&experimentGroupId=12345&keys=key1,key2&interestGroups=name1,name2
 
-The base URL `https://www.kv-server.example/getvalues` comes from the interest group's `trustedBiddingSignalsUrl`, the hostname of the top-level webpage where the ad will appear `publisher.com` is provided by the browser, `experimentGroupId` comes from `perBuyerExperimentGroupIds` if provided, `keys` is a list of `trustedBiddingSignalsKeys` strings, and `interestGroupNames` is a list of the names of the interest groups that data is being fetched for.  The requests may be coalesced (for efficiency) across any number of interest groups that share a `trustedBiddingSignalsUrl` (which means they also share an owner).
+The base URL `https://www.kv-server.example/getvalues` comes from the interest group's `trustedBiddingSignalsURL`, the hostname of the top-level webpage where the ad will appear `publisher.com` is provided by the browser, `experimentGroupId` comes from `perBuyerExperimentGroupIds` if provided, `keys` is a list of `trustedBiddingSignalsKeys` strings, and `interestGroupNames` is a list of the names of the interest groups that data is being fetched for.  The requests may be coalesced (for efficiency) across any number of interest groups that share a `trustedBiddingSignalsURL` (which means they also share an owner).
 
 The response from the server should be a JSON object of the form:
 
@@ -445,18 +445,18 @@ The response from the server should be a JSON object of the form:
 
 and the server must include the HTTP response header `X-fledge-bidding-signals-format-version: 2`.  If the server does not include the header, the response will assumed to be an in older format, where the response is only the contents of the `keys` dictionary.
 
-The value of each key that an interest group has in its `trustedBiddingSignalsKeys` list will be passed from the `keys` dictionary to the interest group's generateBid() function as the `trustedBiddingSignals` parameter. Values missing from the JSON object will be set to null. If the JSON download fails, or there are no `trustedBiddingSignalsKeys` or `trustedBiddingSignalsUrl` in the interest group, then the `trustedBiddingSignals` argument to generateBid() will be null.
+The value of each key that an interest group has in its `trustedBiddingSignalsKeys` list will be passed from the `keys` dictionary to the interest group's generateBid() function as the `trustedBiddingSignals` parameter. Values missing from the JSON object will be set to null. If the JSON download fails, or there are no `trustedBiddingSignalsKeys` or `trustedBiddingSignalsURL` in the interest group, then the `trustedBiddingSignals` argument to generateBid() will be null.
 
 The `perInterestGroupData` dictionary contains optional data for interest groups whose names were included in the request URL. The `priorityVector` will be used to calculate the final priority for an interest group, if that interest group has `enableBiddingSignalsPrioritization` set to true in its definition. Otherwise, it's only used to filter out interest groups, if the dot product with `prioritySignals` is negative. See [Filtering and Prioritizing Interest Groups](#35-filtering-and-prioritizing-interest-groups) for more information.
 
-Similarly, sellers may want to fetch information about a specific creative, e.g. the results of some out-of-band ad scanning system.  This works in much the same way, with the base URL coming from the `trustedScoringSignalsUrl` property of the seller's auction configuration object. The parameter `experimentGroupId` comes from `sellerExperimentGroupId` in the auction configuration if provided. However, the URL has two sets of keys: "renderUrls=url1,url2,..." and "adComponentRenderUrls=url1,url2,..." for the main and adComponent renderUrls bids offered in the auction. It is up to the client how and whether to aggregate the fetches with the URLs of multiple bidders.  The response to this request should be in the form:
+Similarly, sellers may want to fetch information about a specific creative, e.g. the results of some out-of-band ad scanning system.  This works in much the same way, with the base URL coming from the `trustedScoringSignalsURL` property of the seller's auction configuration object. The parameter `experimentGroupId` comes from `sellerExperimentGroupId` in the auction configuration if provided. However, the URL has two sets of keys: "renderURLs=url1,url2,..." and "adComponentRenderURLs=url1,url2,..." for the main and adComponent renderURLs bids offered in the auction. It is up to the client how and whether to aggregate the fetches with the URLs of multiple bidders.  The response to this request should be in the form:
 
 ```
-{ 'renderUrls': {
+{ 'renderURLs': {
       'https://cdn.com/render_url_of_some_bid': arbitrary_json,
       'https://cdn.com/render_url_of_some_other_bid': arbitrary_json,
       ...},
-  'adComponentRenderUrls': {
+  'adComponentRenderURLs': {
       'https://cdn.com/ad_component_of_a_bid': arbitrary_json,
       'https://cdn.com/another_ad_component_of_a_bid': arbitrary_json,
       ...}
@@ -466,8 +466,8 @@ Similarly, sellers may want to fetch information about a specific creative, e.g.
 The value of `trustedScoringSignals` passed to the seller's `scoreAd()` function is an object of the form:
 
 ```
-{ 'renderUrl': {'https://cdn.com/render_url_of_bidder': arbitrary_value_from_signals},
-  'adComponentRenderUrls': {
+{ 'renderURL': {'https://cdn.com/render_url_of_bidder': arbitrary_value_from_signals},
+  'adComponentRenderURLs': {
       'https://cdn.com/ad_component_of_a_bid': arbitrary_value_from_signals,
       'https://cdn.com/another_ad_component_of_a_bid': arbitrary_value_from_signals,
       ...}
@@ -485,7 +485,7 @@ For detailed specification and explainers of the trusted key-value server, see a
 
 #### 3.2 On-Device Bidding
 
-Once the trusted bidding signals are fetched, each interest group's bidding function will run, inside a bidding worklet associated with the interest group owner's domain.  The buyer's JavaScript is loaded from the interest group's `biddingLogicUrl`, which must expose a `generateBid()` function:
+Once the trusted bidding signals are fetched, each interest group's bidding function will run, inside a bidding worklet associated with the interest group owner's domain.  The buyer's JavaScript is loaded from the interest group's `biddingLogicURL`, which must expose a `generateBid()` function:
 
 
 ```
@@ -495,7 +495,7 @@ generateBid(interestGroup, auctionSignals, perBuyerSignals,
   return {'ad': adObject,
           'adCost': optionalAdCost,
           'bid': bidValue,
-          'render': renderUrl,
+          'render': renderURL,
           'adComponents': [adComponent1, adComponent2, ...],
           'allowComponentAuction': false,
           'modelingSignals': 123};
@@ -507,7 +507,7 @@ The arguments to `generateBid()` are:
 
 
 
-*   interestGroup: The interest group object, as saved during `joinAdInterestGroup()` and perhaps updated via the `dailyUpdateUrl`.
+*   interestGroup: The interest group object, as saved during `joinAdInterestGroup()` and perhaps updated via the `dailyUpdateURL`.
     * `priority` and `prioritySignalsOverrides` are not included. They can be modified by `generatedBid()` calls, so could theoretically be used to create a cross-site profile of a user accessible to `generateBid()` methods, otherwise.
 *   auctionSignals: As provided by the seller in the call to `runAdAuction()`.  This is the opportunity for the seller to provide information about the page context (ad size, publisher ID, etc), the type of auction (first-price vs second-price), and so on.
 *   perBuyerSignals: The value for _this specific buyer_ as taken from the auction config passed to `runAdAuction()`.  This can include contextual signals about the page that come from the buyer's server, if the seller is an SSP which performs a real-time bidding call to buyer servers and pipes the response back, or if the publisher page contacts the buyer's server directly.  If so, the buyer may wish to check a cryptographic signature of those signals inside `generateBid()` as protection against tampering.
@@ -520,7 +520,7 @@ The arguments to `generateBid()` are:
       'joinCount': 3,
       'bidCount': 17,
       'prevWins': [[time1,ad1],[time2,ad2],...],
-      'wasmHelper': ... /* a WebAssembly.Module object based on interest group's biddingWasmHelperUrl */
+      'wasmHelper': ... /* a WebAssembly.Module object based on interest group's biddingWasmHelperURL */
       'dataVersion': 1, /* Data-Version value from the trusted bidding signals server's response(s) */
     }
     ```
@@ -536,7 +536,7 @@ The output of `generateBid()` contains the following fields:
 *   adCost: (optional) A numerical value used to pass reporting advertiser click or conversion cost from generateBid to reportWin. The precision of this number is limited to an 8-bit mantissa and 8-bit exponent, with any rounding performed stochastically.
 *   bid: A numerical bid that will enter the auction.  The seller must be in a position to compare bids from different buyers, therefore bids must be in some seller-chosen unit (e.g. "USD per thousand").  If the bid is zero or negative, then this interest group will not participate in the seller's auction at all.  With this mechanism, the buyer can implement any advertiser rules for where their ads may or may not appear.
 *   render: A URL which will be rendered to display the creative if this bid wins the auction.
-*   adComponents: (optional) A list of up to 20 adComponent strings from the InterestGroup's adComponents field. Each value must match an adComponent renderUrl exactly. This field must not be present if the InterestGroup has no adComponent field. It is valid for this field not to be present even when adComponents is present. (See ["Ads Composed of Multiple Pieces"](#34-ads-composed-of-multiple-pieces) below.)
+*   adComponents: (optional) A list of up to 20 adComponent strings from the InterestGroup's adComponents field. Each value must match an adComponent renderURL exactly. This field must not be present if the InterestGroup has no adComponent field. It is valid for this field not to be present even when adComponents is present. (See ["Ads Composed of Multiple Pieces"](#34-ads-composed-of-multiple-pieces) below.)
 *   allowComponentAuction: If this buyer is taking part of a component auction, this value must be present and true, or the bid is ignored. This value is ignored (and may be absent) if the buyer is part of a top-level auction.
 * modelingSignals: A 0-4095 integer (12-bits) passed to `reportWin()`, with noising, as described in the [noising and bucketing scheme](#521-noised-and-bucketed-signals). Invalid values, such as negative, infinite, and NaN values, will be ignored and not passed. Only the lowest 12 bits will be passed.
 
@@ -613,7 +613,7 @@ interestGroup2 = {
 interestGroup3 = {
   'owner': 'https://buyer1.com/',
   'name': 'FilterOnDataFromServer',
-  'trustedBiddingSignalsUrl': 'https://buyer1.com/bidder_signals',
+  'trustedBiddingSignalsURL': 'https://buyer1.com/bidder_signals',
   ...
 }
 ```
@@ -648,7 +648,7 @@ In the long term, we need a mechanism to ensure that the after-the-fact reportin
 
 #### 5.1 Seller Reporting on Render
 
-A seller's JavaScript (i.e. the same script, loaded from `decisionLogicUrl`, that provided the `scoreAd()` function) can also expose a `reportResult()` function. This is called with the bid that won the auction, if applicable. For component auction seller scripts, `reportResult()` is only invoked if the bid that won the component auction also went on to win the top-level auction.
+A seller's JavaScript (i.e. the same script, loaded from `decisionLogicURL`, that provided the `scoreAd()` function) can also expose a `reportResult()` function. This is called with the bid that won the auction, if applicable. For component auction seller scripts, `reportResult()` is only invoked if the bid that won the component auction also went on to win the top-level auction.
 
 
 ```
@@ -673,7 +673,7 @@ The arguments to this function are:
       'topLevelSeller': 'https://www.example-ssp.com',
       'componentSeller': 'https://www.some-other-ssp.com',
       'interestGroupOwner': 'https://www.example-dsp.com/',
-      'renderUrl': 'https://cdn.com/url-of-winning-creative.wbn',
+      'renderURL': 'https://cdn.com/url-of-winning-creative.wbn',
       'bid:' bidValue,
       'desirability': desirabilityScoreForWinningAd,
       'topLevelSellerSignals': outputOfTopLevelSellersReportResult,
@@ -686,14 +686,14 @@ The arguments to this function are:
     *   sellerSignals: Like auctionConfig.sellerSignals, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?sellerSignals`.
     *   auctionSignals: Like auctionConfig.auctionSignals, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?auctionSignals`.
 
-The `browserSignals` argument must be handled carefully to avoid tracking.  It certainly cannot include anything like the full list of interest groups, which would be too identifiable as a tracking signal.  The `renderUrl` can be included since it has already passed a k-anonymity check.  The browser may limit the precision of the bid and desirability values by stochastically rounding them so that they fit into a floating point number with an 8 bit mantissa and 8 bit exponent to avoid these numbers exfiltrating information from the interest group's `userBiddingSignals`. On the upside, this set of signals can be expanded to include useful additional summary data about the wider range of bids that participated in the auction, e.g. the number of bids.  Additionally, the `dataVersion` will only be present if the `Data-Version` header was provided in the response headers from the Trusted Scoring server.
+The `browserSignals` argument must be handled carefully to avoid tracking.  It certainly cannot include anything like the full list of interest groups, which would be too identifiable as a tracking signal.  The `renderURL` can be included since it has already passed a k-anonymity check.  The browser may limit the precision of the bid and desirability values by stochastically rounding them so that they fit into a floating point number with an 8 bit mantissa and 8 bit exponent to avoid these numbers exfiltrating information from the interest group's `userBiddingSignals`. On the upside, this set of signals can be expanded to include useful additional summary data about the wider range of bids that participated in the auction, e.g. the number of bids.  Additionally, the `dataVersion` will only be present if the `Data-Version` header was provided in the response headers from the Trusted Scoring server.
 
 The `reportResult()` function's reporting happens by directly calling network APIs in the short-term, but will eventually go through the Private Aggregation API once it has been developed. The output of this function is not used for reporting, but rather as an input to the buyer's reporting function.
 
 
 #### 5.2 Buyer Reporting on Render and Ad Events
 
-The buyer's JavaScript (i.e. the same script, loaded from `biddingLogicUrl`, that provided the `generateBid()` function) can also expose a `reportWin()` function:
+The buyer's JavaScript (i.e. the same script, loaded from `biddingLogicURL`, that provided the `generateBid()` function) can also expose a `reportWin()` function:
 
 
 ```

--- a/spec.bs
+++ b/spec.bs
@@ -58,7 +58,7 @@ partial interface Navigator {
 };
 
 dictionary AuctionAd {
-  required USVString renderUrl;
+  required USVString renderURL;
   any metadata;
 };
 
@@ -72,10 +72,10 @@ dictionary AuctionAdInterestGroup {
   record<DOMString, double> prioritySignalsOverrides;
 
   DOMString executionMode = "compatibility";
-  USVString biddingLogicUrl;
-  USVString biddingWasmHelperUrl;
-  USVString dailyUpdateUrl;
-  USVString trustedBiddingSignalsUrl;
+  USVString biddingLogicURL;
+  USVString biddingWasmHelperURL;
+  USVString dailyUpdateURL;
+  USVString trustedBiddingSignalsURL;
   sequence<USVString> trustedBiddingSignalsKeys;
   any userBiddingSignals;
   sequence<AuctionAd> ads;
@@ -115,19 +115,19 @@ are:
   1. For each |groupMember| and |interestGroupField| in the following table <table class="data">
       <thead><tr><th>Group member</th><th>Interest group field</th></tr></thead>
       <tr>
-        <td>"{{AuctionAdInterestGroup/biddingLogicUrl}}"</td>
+        <td>"{{AuctionAdInterestGroup/biddingLogicURL}}"</td>
         <td>[=interest group/bidding url=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/biddingWasmHelperUrl}}"</td>
+        <td>"{{AuctionAdInterestGroup/biddingWasmHelperURL}}"</td>
         <td>[=interest group/bidding wasm helper url=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/dailyUpdateUrl}}"</td>
+        <td>"{{AuctionAdInterestGroup/dailyUpdateURL}}"</td>
         <td>[=interest group/daily update url=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsUrl}}"</td>
+        <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsURL}}"</td>
         <td>[=interest group/trusted bidding signals url=]</td>
       </tr>
     </table>
@@ -162,13 +162,13 @@ are:
     </table>
     1. [=list/For each=] |ad| of |group|[|groupMember|]:
       1. Let |igAd| be a new [=interest group ad=].
-      1. Let |renderUrl| be the result of running the [=URL parser=] on
-        |ad|["{{AuctionAd/renderUrl}}"].
+      1. Let |renderURL| be the result of running the [=URL parser=] on
+        |ad|["{{AuctionAd/renderURL}}"].
       1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
-        * |renderUrl| is an error;
-        * |renderUrl| [=url/scheme=] is not "`https`";
-        * |renderUrl| [=includes credentials=].
-      1. Set |igAd|'s [=interest group ad/render url=] to |renderUrl|.
+        * |renderURL| is an error;
+        * |renderURL| [=url/scheme=] is not "`https`";
+        * |renderURL| [=includes credentials=].
+      1. Set |igAd|'s [=interest group ad/render url=] to |renderURL|.
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
         |igAd|'s [=interest group ad/metadata=] be the result of
         [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].
@@ -468,8 +468,8 @@ partial interface Navigator {
 
 dictionary AuctionAdConfig {
   required USVString seller;
-  required USVString decisionLogicUrl;
-  USVString trustedScoringSignalsUrl;
+  required USVString decisionLogicURL;
+  USVString trustedScoringSignalsURL;
   sequence<USVString> interestGroupBuyers;
   any auctionSignals;
   any sellerSignals;
@@ -533,20 +533,20 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. [=exception/Throw=] a {{TypeError}} if |seller| is an error, or its [=url/scheme=] is not
     "`https`".
   1. Set |auctionConfig|'s [=auction config/seller=] to |seller|.
-1. Let |decisionLogicUrl| be the result of running the [=URL parser=] on
-  |config|["{{AuctionAdConfig/decisionLogicUrl}}"].
-  1. [=exception/Throw=] a {{TypeError}} if |decisionLogicUrl| is an error, or it is not
+1. Let |decisionLogicURL| be the result of running the [=URL parser=] on
+  |config|["{{AuctionAdConfig/decisionLogicURL}}"].
+  1. [=exception/Throw=] a {{TypeError}} if |decisionLogicURL| is an error, or it is not
     [=same origin=] with |auctionConfig|'s [=auction config/seller=].
-  1. [=Assert=]: |decisionLogicUrl|'s [=url/scheme=] is "`https`".
-  1. Set |auctionConfig|'s [=auction config/decision logic url=] to |decisionLogicUrl|.
-1. If |config|["{{AuctionAdConfig/trustedScoringSignalsUrl}}"] [=map/exists=]:
-  1. Let |trustedScoringSignalsUrl| be the result of running the [=URL parser=] on
-    |config|["{{AuctionAdConfig/trustedScoringSignalsUrl}}"].
-  1. [=exception/Throw=] a {{TypeError}} if |trustedScoringSignalsUrl| is an error,
+  1. [=Assert=]: |decisionLogicURL|'s [=url/scheme=] is "`https`".
+  1. Set |auctionConfig|'s [=auction config/decision logic url=] to |decisionLogicURL|.
+1. If |config|["{{AuctionAdConfig/trustedScoringSignalsURL}}"] [=map/exists=]:
+  1. Let |trustedScoringSignalsURL| be the result of running the [=URL parser=] on
+    |config|["{{AuctionAdConfig/trustedScoringSignalsURL}}"].
+  1. [=exception/Throw=] a {{TypeError}} if |trustedScoringSignalsURL| is an error,
     or it is not [=same origin=] with |auctionConfig|'s [=auction config/seller=].
-  1. [=Assert=]: |trustedScoringSignalsUrl|'s [=url/scheme=] is "`https`".
+  1. [=Assert=]: |trustedScoringSignalsURL|'s [=url/scheme=] is "`https`".
   1. Set |auctionConfig|'s [=auction config/trusted scoring signals url=] to
-    |trustedScoringSignalsUrl|.
+    |trustedScoringSignalsURL|.
 1. If |config|["{{AuctionAdConfig/interestGroupBuyers}}"] [=map/exists=], let |buyers| be a new
   [=list/is empty|empty=] [=list=].
   1. [=list/For each=] |buyerString| in |config|["{{AuctionAdConfig/interestGroupBuyers}}"]:
@@ -777,7 +777,7 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
 1. TODO: Set |browserSignals|'s "topWindowHostname" to hostname of top window
 1. [=map/Set=] |browserSignals|["interestGroupOwner"] to |generatedBid|'s
   [=generated bid/interest group]'s [=interest group/owner=].
-1. [=map/Set=] |browserSignals|["renderUrl"] to |generatedBid|'s [=generated bid/ad descriptor=]'s
+1. [=map/Set=] |browserSignals|["renderURL"] to |generatedBid|'s [=generated bid/ad descriptor=]'s
   [=ad descriptor/url=].
 1. TODO: Set |browserSignals|'s "adComponents" to ...need to pass in as part of |generatedBid|
 1. TODO: Set |browserSignals|'s "biddingDurationMsec" to ...need to calculate and pass in
@@ -806,9 +806,9 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
 
 </div>
 
-To <dfn>create a seller script runner</dfn> given a [=URL=] |decisionLogicUrl|:
+To <dfn>create a seller script runner</dfn> given a [=URL=] |decisionLogicURL|:
 1. TODO: create the script runner and set up environment.
-1. Let |decisionLogicScript| be the result of [=fetching resource=] with |decisionLogicUrl|, and
+1. Let |decisionLogicScript| be the result of [=fetching resource=] with |decisionLogicURL|, and
   "text/javascript".
 1. Return |decisionLogicScript|.
 
@@ -968,7 +968,7 @@ To <dfn>generate reporting URLs</dfn> given an {{AuctionAdConfig}} |config| and 
 1. TODO: [=map/Set=] |browserSignals|["componentSeller"] to the component seller.
 1. [=map/Set=] |browserSignals|["interestGroupOwner"] to |bid|'s [=generated bid/interest group=]'s
   [=interest group/owner=].
-1. [=map/Set=] |browserSignals|["renderUrl"] to |bid|'s [=generated bid/ad descriptor=]'s
+1. [=map/Set=] |browserSignals|["renderURL"] to |bid|'s [=generated bid/ad descriptor=]'s
   [=ad descriptor/url=].
 1. [=map/Set=] |browserSignals|["bid"] to |bid|'s [=generated bid/bid=].
 1. TODO: [=map/Set=] |browserSignals|["desirability"] to the desirability score.
@@ -1014,8 +1014,8 @@ To <dfn>generate reporting URLs</dfn> given an {{AuctionAdConfig}} |config| and 
 
 TODO: specify, including move 2 trigger sections out.
 
-Interest groups define a field, dailyUpdateUrl, that allows updating the interest group definition
-stored on disk with information periodically retrieved from the dailyUpdateUrl.
+Interest groups define a field, dailyUpdateURL, that allows updating the interest group definition
+stored on disk with information periodically retrieved from the dailyUpdateURL.
 
 <xmp class="idl">
 [SecureContext]
@@ -1042,15 +1042,15 @@ update called "owners":
     Implementations may consider loading only a portion of these interest groups at a time to avoid
     issuing too many requests at once. While the loaded set isn't empty:
     1. For each loaded interest group:
-      1. Fetch the dailyUpdateUrl of the interest group from the network.
+      1. Fetch the dailyUpdateURL of the interest group from the network.
       1. If the network fetch failed, continue to the next interest group.
       1. Parse the response body as JSON. If parsing fails, continue to the next interest group.
       1. If the response JSON object is not a JSON dict, continue to the next interest group.
       1. If "name" and or "owner" keys are present in the response dict, they must match the "name" and "owner" of
         the original interest group, respectively. If they don't, continue to the next interest group.
       1. For each remaining field, if the field is one of {priority, enableBiddingSignalsPrioritization,
-        priorityVector, prioritySignalsOverrides, sellerCapabilities, executionMode, biddingLogicUrl,
-        biddingWasmHelperUrl, trustedBiddingSignalsUrl, trustedBiddingSignalsKeys, ads,
+        priorityVector, prioritySignalsOverrides, sellerCapabilities, executionMode, biddingLogicURL,
+        biddingWasmHelperURL, trustedBiddingSignalsURL, trustedBiddingSignalsKeys, ads,
         adComponents, adSizes, sizeGroups}:
         1. If the field is prioritySignalsOverrides, merge with the stored value: for each key, value pair in the JSON prioritySignalsOverrides:
           1. If the value is null, delete the stored prioritySignalsOverrides key, value pair.


### PR DESCRIPTION
Fix the initialisms casing of "Url" -> "URL".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shuranhuang/turtledove/pull/527.html" title="Last updated on Apr 12, 2023, 7:16 PM UTC (f31d01d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/527/edc3b88...shuranhuang:f31d01d.html" title="Last updated on Apr 12, 2023, 7:16 PM UTC (f31d01d)">Diff</a>