### PR TITLE
Spec: Fail auction.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -612,8 +612,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
         1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
     1. Let |fullSignalsUrl| be the result of [=building trusted bidding signals url=] with
       |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
-    1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
-      and "application/json", and null.
+    1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|,
+      "application/json", and null.
     1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. TODO: Let |interestGroup| be ... from |ig| ... minus priority and prioritySignalsOverrides and any browser-defined pieces

--- a/spec.bs
+++ b/spec.bs
@@ -400,7 +400,8 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
     1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
       with null.
   1. Otherwise:
-    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
+    1. [=Queue a global task=] on the [=DOM manipulation task source=], given |global|, to resolve |p|
+
       with |winner|'s [=generated bid/ad descriptor=]. TODO: resolve |p| with urn-uuid, instead of a
       URL.
     1. Run [=generate reporting URLs=] with |auctionConfig| and |winner|.

--- a/spec.bs
+++ b/spec.bs
@@ -387,9 +387,9 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
     [=AbortSignal/abort reason=] and return |p|.
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
+    1. TODO: Update bidCount for interest groups that participated in the auction.
     1. Run [=interest group update=] with |auctionConfig|'s
       [=auction config/interest group buyers=].
-    1. TODO: Update bidCount for interest groups that participated in the auction.
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
   1. Let |winner| be the result of running [=generate and score bids=] with |auctionConfig|, null

--- a/spec.bs
+++ b/spec.bs
@@ -387,22 +387,23 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. If |signal| is [=AbortSignal/aborted=], then [=reject=] |p| with |signal|'s
     [=AbortSignal/abort reason=] and return |p|.
   1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
-    1. TODO: Specify. Abort the auction. If the auction has already completed, this has no
-      effect. Otherwise, stop running new worklet functions, and do not cause side-effects, like
-      reporting and updating bid statistics.
     1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
+    1. Run [=interest group update=] with |auctionConfig|'s
+      [=auction config/interest group buyers=].
+    1. TODO: Update bidCount for interest groups that participated in the auction.
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-  1. Let |winner| be the result of running [=generate and score bids=] with |auctionConfig|,
-    null, and |global|.
-  1. TODO: If |winner| is failure, fail the auction with manually_aborted set to true.
-  1. TODO: If |winner| is null, fail the auction with manually_aborted set to false.
-  1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
-    with |winner|'s [=generated bid/ad descriptor=]. TODO: resolve |p| with urn-uuid, instead of a
-    URL.
-  1. Run [=generate reporting URLs=] with |auctionConfig| and |winner|.
-  1. Update interest groups post-auction. Execute the algorithm [=interest group update=] using
-    |config|["{{AuctionAdConfig/interestGroupBuyers}}"] as `owners`.
+  1. Let |winner| be the result of running [=generate and score bids=] with |auctionConfig|, null
+    and |global|.
+  1. If |winner| is null:
+    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
+      with null.
+  1. Otherwise:
+    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
+      with |winner|'s [=generated bid/ad descriptor=]. TODO: resolve |p| with urn-uuid, instead of a
+      URL.
+    1. Run [=generate reporting URLs=] with |auctionConfig| and |winner|.
+  1. Run [=interest group update=] with |auctionConfig|'s [=auction config/interest group buyers=].
   1. TODO: Update bidCount and prevWins for interest groups that participated in the auction.
 1. Return |p|.
 
@@ -613,8 +614,6 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
     1. Let |trustedBiddingSignals| be the result of [=fetching resource=] with |fullSignalsUrl|
       and "application/json".
-    1. TODO: If |trustedBiddingSignals| is failure, fail the auction with manually_aborted set to
-      true.
     1. [=map/For each=] joiningOrigin -> |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. TODO: create bidder script runner. If failed, [=iteration/continue=].
@@ -1302,7 +1301,6 @@ An interest group is a [=struct=] with the following items:
   which includes some slots that can be filled in with specific "products".
 : <dfn>joining origin</dfn>
 :: An [=origin=]. The top level page origin from where the interest group was joined.
-
 : <dfn>join counts</dfn>
 :: A [=list=] containing [=tuple=]s of the day and per day join count. The day
   is calculated based on local time. The join count is a count of the number of


### PR DESCRIPTION
fail auction steps.
abort auction only happens when some signals like auctionSignals are provided as promises and the promise rejects. We're not specing using promises for these signals, so there's no abortAuction currently, but only failAuction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/540.html" title="Last updated on Apr 25, 2023, 12:21 PM UTC (5249268)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/540/dd47e66...qingxinwu:5249268.html" title="Last updated on Apr 25, 2023, 12:21 PM UTC (5249268)">Diff</a>