### PR TITLE
Ad AdRender width/height parsing + support for "sh" units

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1116,6 +1116,21 @@ Issue: Finish specifying the following algorithms.
 </div>
 
 <div algorithm>
+  To <dfn>parse an adRender dimension value</dfn> given a [=string=] |input|:
+  
+  1. Let |position| be a [=string/position variable=], initially pointing at the start of |input|.
+  1. [=Strip leading and trailing ASCII whitespace=] from |input|.
+  1. [=Collect a sequence of code points=] that are [=ASCII integers=] or U+002E (.), given |position|. Let that be |dimensionString|.
+  1. If |dimensionString| is the empty string, then return null as the dimension and the empty string as the dimension unit.
+  1. Let |dimension| be the result of parsing |dimensionString| using the [=rules for parsing floating-point number values=].
+  1. If |dimension| is an error, then return null as the dimension and the empty string as the dimension unit.
+  1. [=Collect a sequence of code points=] that are [=ASCII lower alpha=], given |position|. Let that be |dimensionUnit|.
+  1. If |dimensionUnit| is the empty string, then set |dimensionUnit| to "px".
+  1. If |dimensionUnit| is not "px", "sh", or "sw", then return failure.
+  1. Return |dimension| as the dimension and |dimensionUnit| as the dimension unit.
+</div>
+
+<div algorithm>
   To <dfn>convert an ad render</dfn> given an {{AdRender}} |adRender|:
 
   1. If |adRender|["{{AdRender/url}}"] does not [=map/exist=], return false.
@@ -1126,14 +1141,12 @@ Issue: Finish specifying the following algorithms.
   1. Set |adDescriptor|'s [=ad descriptor/url=] to |adUrl|.
   1. If |adRender|["{{AdRender/width}}"] [=map/exists=]:
     1. If |adRender|["{{AdRender/height}}"] does not [=map/exist=], return failure.
-    1. Let |width| and |widthUnit| be the result of parsing (TODO) |adRender|["{{AdRender/width}}"].
-    1. Let |height| and |heightUnit| be the result of parsing (TODO)
-      |adRender|["{{AdRender/height}}"].
-    1. Return failure if any of the following conditions hold:
-      * |width| is non-positive, or non-finite;
-      * |height| is non-positive, or non-finite;
-      * |widthUnit| is not "px", "sh", or "sw";
-      * |heightUnit| is not "px", "sh", or "sw".
+    1. Let |width| and |widthUnit| be the dimension and dimension unit that results from running
+      [=parse an adRender dimension value=] with |adRender|["{{AdRender/width}}"], respectively.
+    1. If |width| is null, return failure.
+    1. Let |height| and |heightUnit| be the dimension and dimension unit that results from running
+      [=parse an adRender dimension value=] with |adRender|["{{AdRender/height}}"], respectively.
+    1. If |height| is null, return failure.
     1. Let |adSize| be a new [=ad size=].
     1. Set |adSize|'s [=ad size/width=] to |width|, [=ad size/width units=] to |widthUnit|,
       [=ad size/height=] to |height|, [=ad size/height units=] to |heightUnit|.

--- a/spec.bs
+++ b/spec.bs
@@ -1120,7 +1120,7 @@ Issue: Finish specifying the following algorithms.
   
   1. Let |position| be a [=string/position variable=], initially pointing at the start of |input|.
   1. [=Strip leading and trailing ASCII whitespace=] from |input|.
-  1. [=Collect a sequence of code points=] that are [=ASCII integers=] or U+002E (.), given |position|. Let that be |dimensionString|.
+  1. [=Collect a sequence of code points=] that are [=ASCII digits=] or U+002E (.), given |position|. Let that be |dimensionString|.
   1. If |dimensionString| is the empty string, then return null as the dimension and the empty string as the dimension unit.
   1. Let |dimension| be the result of parsing |dimensionString| using the [=rules for parsing floating-point number values=].
   1. If |dimension| is an error, then return null as the dimension and the empty string as the dimension unit.

--- a/spec.bs
+++ b/spec.bs
@@ -1116,12 +1116,12 @@ Issue: Finish specifying the following algorithms.
 </div>
 
 <div algorithm>
-  To <dfn>parse an adRender dimension value</dfn> given a [=string=] |input|:
+  To <dfn>parse an AdRender dimension value</dfn> given a [=string=] |input|:
   
   1. Let |position| be a [=string/position variable=], initially pointing at the start of |input|.
   1. [=Strip leading and trailing ASCII whitespace=] from |input|.
-  1. If |input| [=string/starts with=] "`0`" but [=string/is=] not "`0`", then return null as the dimension and the empty string
-     as the dimension unit.
+  1. If |input| [=string/starts with=] "`0`" but [=string/is=] not "`0`" and does not
+     [=string/start with=] "`0.`", then return null as the dimension and the empty string as the dimension unit.
   1. [=Collect a sequence of code points=] that are [=ASCII digits=] or U+002E (.), given |position|. Let that be |dimensionString|.
   1. If |dimensionString| is the empty string, then return null as the dimension and the empty string as the dimension unit.
   1. Let |dimension| be the result of parsing |dimensionString| using the [=rules for parsing floating-point number values=].
@@ -1145,10 +1145,10 @@ Issue: Finish specifying the following algorithms.
   1. If |adRender|["{{AdRender/width}}"] [=map/exists=]:
     1. If |adRender|["{{AdRender/height}}"] does not [=map/exist=], return failure.
     1. Let |width| and |widthUnit| be the dimension and dimension unit that results from running
-      [=parse an adRender dimension value=] with |adRender|["{{AdRender/width}}"], respectively.
+      [=parse an AdRender dimension value=] with |adRender|["{{AdRender/width}}"], respectively.
     1. If |width| is null, return failure.
     1. Let |height| and |heightUnit| be the dimension and dimension unit that results from running
-      [=parse an adRender dimension value=] with |adRender|["{{AdRender/height}}"], respectively.
+      [=parse an AdRender dimension value=] with |adRender|["{{AdRender/height}}"], respectively.
     1. If |height| is null, return failure.
     1. Let |adSize| be a new [=ad size=].
     1. Set |adSize|'s [=ad size/width=] to |width|, [=ad size/width units=] to |widthUnit|,

--- a/spec.bs
+++ b/spec.bs
@@ -1120,6 +1120,8 @@ Issue: Finish specifying the following algorithms.
   
   1. Let |position| be a [=string/position variable=], initially pointing at the start of |input|.
   1. [=Strip leading and trailing ASCII whitespace=] from |input|.
+  1. If |input| [=string/starts with=] "`0`" but [=string/is=] not "`0`", then return null as the dimension and the empty string
+     as the dimension unit.
   1. [=Collect a sequence of code points=] that are [=ASCII digits=] or U+002E (.), given |position|. Let that be |dimensionString|.
   1. If |dimensionString| is the empty string, then return null as the dimension and the empty string as the dimension unit.
   1. Let |dimension| be the result of parsing |dimensionString| using the [=rules for parsing floating-point number values=].

--- a/spec.bs
+++ b/spec.bs
@@ -1132,8 +1132,8 @@ Issue: Finish specifying the following algorithms.
     1. Return failure if any of the following conditions hold:
       * |width| is non-positive, or non-finite;
       * |height| is non-positive, or non-finite;
-      * |widthUnit| is not "px" or "sw";
-      * |heightUnit| is not "px" or "sw".
+      * |widthUnit| is not "px", "sh", or "sw";
+      * |heightUnit| is not "px", "sh", or "sw".
     1. Let |adSize| be a new [=ad size=].
     1. Set |adSize|'s [=ad size/width=] to |width|, [=ad size/width units=] to |widthUnit|,
       [=ad size/height=] to |height|, [=ad size/height units=] to |heightUnit|.
@@ -1598,11 +1598,11 @@ Width and height of an ad.
 : <dfn>width</dfn>
 :: A {{double}}.
 : <dfn>width units</dfn>
-:: A [=string=]. Can only be one of "px" (pixel) and "sw" (screen width).
+:: A [=string=]. Can only be one of "px" (pixel), "sh" (screen height), and "sw" (screen width).
 : <dfn>height</dfn>
 :: A {{double}}.
 : <dfn>height units</dfn>
-:: A [=string=]. Can only be one of "px" (pixel) and "sw" (screen width).
+:: A [=string=]. Can only be one of "px" (pixel), "sh" (screen height), and "sw" (screen width).
 
 </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1128,8 +1128,9 @@ Issue: Finish specifying the following algorithms.
   1. If |dimension| is an error, then return null as the dimension and the empty string as the dimension unit.
   1. [=Collect a sequence of code points=] that are [=ASCII lower alpha=], given |position|. Let that be |dimensionUnit|.
   1. If |position| is not past the end of |input|, then return null as the dimension and the empty string as the dimension unit.
-  1. If |dimensionUnit| is the empty string, then set |dimensionUnit| to "px".
-  1. If |dimensionUnit| is not "px", "sh", or "sw", then return null as the dimension and the empty string as the dimension unit.
+  1. If |dimensionUnit| [=string/is=] the empty string, then set |dimensionUnit| to "px".
+  1. If |dimensionUnit| [=string/is=] not "px", "sh", or "sw", then return null as the dimension and the empty string as the
+     dimension unit.
   1. Return |dimension| as the dimension and |dimensionUnit| as the dimension unit.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1125,8 +1125,9 @@ Issue: Finish specifying the following algorithms.
   1. Let |dimension| be the result of parsing |dimensionString| using the [=rules for parsing floating-point number values=].
   1. If |dimension| is an error, then return null as the dimension and the empty string as the dimension unit.
   1. [=Collect a sequence of code points=] that are [=ASCII lower alpha=], given |position|. Let that be |dimensionUnit|.
+  1. If |position| is not past the end of |input|, then return null as the dimension and the empty string as the dimension unit.
   1. If |dimensionUnit| is the empty string, then set |dimensionUnit| to "px".
-  1. If |dimensionUnit| is not "px", "sh", or "sw", then return failure.
+  1. If |dimensionUnit| is not "px", "sh", or "sw", then return null as the dimension and the empty string as the dimension unit.
   1. Return |dimension| as the dimension and |dimensionUnit| as the dimension unit.
 </div>
 


### PR DESCRIPTION
This PR builds on https://github.com/WICG/turtledove/pull/417 to add AdRender width/height parsing and also adds mention of the "sh" unit to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/recvfrom/turtledove/pull/544.html" title="Last updated on Apr 28, 2023, 6:28 PM UTC (bb490ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/544/a7cc975...recvfrom:bb490ec.html" title="Last updated on Apr 28, 2023, 6:28 PM UTC (bb490ec)">Diff</a>