### PR TITLE
Add InterestGroupScriptRunnerGlobalScope.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1014,28 +1014,35 @@ special value "*". The only interfaces that can be exposed inside of the globals
 specification are those that explicitly list the global names provided here.
 
 <pre class="idl">
-[Global=InterestGroupScriptRunnerGlobalScope, Exposed=InterestGroupScriptRunnerGlobalScope]
+[Global=InterestGroupScriptRunnerGlobalScope,
+ Exposed=InterestGroupScriptRunnerGlobalScope]
 interface InterestGroupScriptRunnerGlobalScope {
 };
 
 
-[Global=(InterestGroupScriptRunnerGlobalScope, InterestGroupBiddingScriptRunnerGlobalScope),
-Exposed=InterestGroupBiddingScriptRunnerGlobalScope]
-interface InterestGroupBiddingScriptRunnerGlobalScope : InterestGroupScriptRunnerGlobalScope {
+[Global=(InterestGroupScriptRunnerGlobalScope,
+         InterestGroupBiddingScriptRunnerGlobalScope),
+ Exposed=InterestGroupBiddingScriptRunnerGlobalScope]
+interface InterestGroupBiddingScriptRunnerGlobalScope
+        : InterestGroupScriptRunnerGlobalScope {
   boolean setBid();
   boolean setBid(GenerateBidOutput generateBidOutput);
   undefined setPriority(double priority);
   undefined setPrioritySignalsOverride(DOMString key, double priority);
 };
 
-[Global=(InterestGroupScriptRunnerGlobalScope, InterestGroupScoringScriptRunnerGlobalScope),
-Exposed=InterestGroupScoringScriptRunnerGlobalScope]
-interface InterestGroupScoringScriptRunnerGlobalScope : InterestGroupScriptRunnerGlobalScope {
+[Global=(InterestGroupScriptRunnerGlobalScope,
+         InterestGroupScoringScriptRunnerGlobalScope),
+ Exposed=InterestGroupScoringScriptRunnerGlobalScope]
+interface InterestGroupScoringScriptRunnerGlobalScope
+        : InterestGroupScriptRunnerGlobalScope {
 };
 
-[Global=(InterestGroupScriptRunnerGlobalScope, InterestGroupReportingScriptRunnerGlobalScope),
-Exposed=InterestGroupReportingScriptRunnerGlobalScope]
-interface InterestGroupReportingScriptRunnerGlobalScope : InterestGroupScriptRunnerGlobalScope {
+[Global=(InterestGroupScriptRunnerGlobalScope,
+         InterestGroupReportingScriptRunnerGlobalScope),
+ Exposed=InterestGroupReportingScriptRunnerGlobalScope]
+interface InterestGroupReportingScriptRunnerGlobalScope
+        : InterestGroupScriptRunnerGlobalScope {
   undefined sendReportTo(DOMString url);
 };
 

--- a/spec.bs
+++ b/spec.bs
@@ -1014,7 +1014,7 @@ special value "*". The only interfaces that can be exposed inside of the globals
 specification are those that explicitly list the global names provided here.
 
 <pre class="idl">
-[Exposed=InterestGroupScriptRunnerGlobalScope, Global=InterestGroupScriptRunnerGlobalScope]
+[Global=InterestGroupScriptRunnerGlobalScope, Exposed=InterestGroupScriptRunnerGlobalScope]
 interface InterestGroupScriptRunnerGlobalScope {
 };
 

--- a/spec.bs
+++ b/spec.bs
@@ -1014,23 +1014,28 @@ special value "*". The only interfaces that can be exposed inside of the globals
 specification are those that explicitly list the global names provided here.
 
 <pre class="idl">
-[Exposed=InterestGroupBiddingScriptRunnerGlobalScope,
-Global=InterestGroupBiddingScriptRunnerGlobalScope]
-interface InterestGroupBiddingScriptRunnerGlobalScope {
+[Exposed=InterestGroupScriptRunnerGlobalScope, Global=InterestGroupScriptRunnerGlobalScope]
+interface InterestGroupScriptRunnerGlobalScope {
+};
+
+
+[Global=(InterestGroupScriptRunnerGlobalScope, InterestGroupBiddingScriptRunnerGlobalScope),
+Exposed=InterestGroupBiddingScriptRunnerGlobalScope]
+interface InterestGroupBiddingScriptRunnerGlobalScope : InterestGroupScriptRunnerGlobalScope {
   boolean setBid();
   boolean setBid(GenerateBidOutput generateBidOutput);
   undefined setPriority(double priority);
   undefined setPrioritySignalsOverride(DOMString key, double priority);
 };
 
-[Exposed=InterestGroupScoringScriptRunnerGlobalScope,
-Global=InterestGroupScoringScriptRunnerGlobalScope]
-interface InterestGroupScoringScriptRunnerGlobalScope {
+[Global=(InterestGroupScriptRunnerGlobalScope, InterestGroupScoringScriptRunnerGlobalScope),
+Exposed=InterestGroupScoringScriptRunnerGlobalScope]
+interface InterestGroupScoringScriptRunnerGlobalScope : InterestGroupScriptRunnerGlobalScope {
 };
 
-[Exposed=InterestGroupReportingScriptRunnerGlobalScope,
-Global=InterestGroupReportingScriptRunnerGlobalScope]
-interface InterestGroupReportingScriptRunnerGlobalScope {
+[Global=(InterestGroupScriptRunnerGlobalScope, InterestGroupReportingScriptRunnerGlobalScope),
+Exposed=InterestGroupReportingScriptRunnerGlobalScope]
+interface InterestGroupReportingScriptRunnerGlobalScope : InterestGroupScriptRunnerGlobalScope {
   undefined sendReportTo(DOMString url);
 };
 

--- a/spec.bs
+++ b/spec.bs
@@ -1014,15 +1014,14 @@ special value "*". The only interfaces that can be exposed inside of the globals
 specification are those that explicitly list the global names provided here.
 
 <pre class="idl">
-[Global=InterestGroupScriptRunnerGlobalScope,
- Exposed=InterestGroupScriptRunnerGlobalScope]
+[Exposed=InterestGroupScriptRunnerGlobalScope,
+ Global=InterestGroupScriptRunnerGlobalScope]
 interface InterestGroupScriptRunnerGlobalScope {
 };
 
 
-[Global=(InterestGroupScriptRunnerGlobalScope,
-         InterestGroupBiddingScriptRunnerGlobalScope),
- Exposed=InterestGroupBiddingScriptRunnerGlobalScope]
+[Exposed=InterestGroupBiddingScriptRunnerGlobalScope,
+ Global=InterestGroupBiddingScriptRunnerGlobalScope]
 interface InterestGroupBiddingScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
   boolean setBid();
@@ -1031,16 +1030,14 @@ interface InterestGroupBiddingScriptRunnerGlobalScope
   undefined setPrioritySignalsOverride(DOMString key, double priority);
 };
 
-[Global=(InterestGroupScriptRunnerGlobalScope,
-         InterestGroupScoringScriptRunnerGlobalScope),
- Exposed=InterestGroupScoringScriptRunnerGlobalScope]
+[Exposed=InterestGroupScoringScriptRunnerGlobalScope,
+ Global=InterestGroupScoringScriptRunnerGlobalScope]
 interface InterestGroupScoringScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
 };
 
-[Global=(InterestGroupScriptRunnerGlobalScope,
-         InterestGroupReportingScriptRunnerGlobalScope),
- Exposed=InterestGroupReportingScriptRunnerGlobalScope]
+[Exposed=InterestGroupReportingScriptRunnerGlobalScope,
+ Global=InterestGroupReportingScriptRunnerGlobalScope]
 interface InterestGroupReportingScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
   undefined sendReportTo(DOMString url);

--- a/spec.bs
+++ b/spec.bs
@@ -1014,14 +1014,14 @@ special value "*". The only interfaces that can be exposed inside of the globals
 specification are those that explicitly list the global names provided here.
 
 <pre class="idl">
-[Exposed=InterestGroupScriptRunnerGlobalScope,
- Global=InterestGroupScriptRunnerGlobalScope]
+[Exposed=InterestGroupScriptRunnerGlobalScope]
 interface InterestGroupScriptRunnerGlobalScope {
 };
 
 
 [Exposed=InterestGroupBiddingScriptRunnerGlobalScope,
- Global=InterestGroupBiddingScriptRunnerGlobalScope]
+ Global=(InterestGroupScriptRunnerGlobalScope,
+         InterestGroupBiddingScriptRunnerGlobalScope)]
 interface InterestGroupBiddingScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
   boolean setBid();
@@ -1031,13 +1031,15 @@ interface InterestGroupBiddingScriptRunnerGlobalScope
 };
 
 [Exposed=InterestGroupScoringScriptRunnerGlobalScope,
- Global=InterestGroupScoringScriptRunnerGlobalScope]
+ Global=(InterestGroupScriptRunnerGlobalScope,
+         InterestGroupScoringScriptRunnerGlobalScope)]
 interface InterestGroupScoringScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
 };
 
 [Exposed=InterestGroupReportingScriptRunnerGlobalScope,
- Global=InterestGroupReportingScriptRunnerGlobalScope]
+ Global=(InterestGroupScriptRunnerGlobalScope,
+         InterestGroupReportingScriptRunnerGlobalScope)]
 interface InterestGroupReportingScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
   undefined sendReportTo(DOMString url);


### PR DESCRIPTION
Add InterestGroupScriptRunnerGlobalScope as a base interface that other global scope interfaces inherit from, to allow other specs expose their objects more easily using a single global scope.

This is requested to allow private aggregation API spec using script runner globals more easily:
"
1. Would it be possible to have the various global scopes inherit from one base global scope (e.g. InterestGroupScriptRunnerGlobalScope? (This would let PAA expose the PrivateAggregation object on this base class instead of each class.)
2. Could we also have a joint global name for the scopes, e.g. InterestGroupScriptRunner? (This would let PAA use this for Exposed= instead of listing all three FLEDGE global names.)
As a side note, global names (the part after Global=) don't usually include the "GlobalScope" suffix (e.g. just Window or AudioWorklet), so we may want to remove the suffixes.
     -- We tried to give the global scopes short names (removing GlobalScope suffix) using "Global=...ScriptRunner", but got build error complaining "...ScriptRunner" is not defined. @domfarolino opened a bug for it https://github.com/speced/bikeshed/issues/2517. 
"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/546.html" title="Last updated on Apr 25, 2023, 5:17 AM UTC (be5a43e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/546/dd47e66...qingxinwu:be5a43e.html" title="Last updated on Apr 25, 2023, 5:17 AM UTC (be5a43e)">Diff</a>