### PR TITLE
Detect window.FencedFrameConfig in code snippet

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -248,7 +248,7 @@ const result = await navigator.runAdAuction(myAuctionConfig);
 
 // If `result` is a `FencedFrameConfig` object, it must be used with a fenced frame
 // element via its `config` attribute. Otherwise, it's a `urn:uuid` for an iframe.
-if (FencedFrameConfig && result instanceof FencedFrameConfig)
+if (window.FencedFrameConfig && result instanceof FencedFrameConfig)
   fencedFrame.config = result;
 else
   iframe.src = result;


### PR DESCRIPTION
This snippet will throw an uncaught ReferenceError if FencedFrameConfig is not yet enabled, e.g. in older Chrome versions or in m112+ but without the FencedFrameAPIChanges flag enabled.

Implementers should take care to write a safe feature detection lookup.

An alternative approach would be writing: `typeof FencedFrameConfig !== 'undefined'`.