### PR TITLE
[Spec] Fix lint error

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1389,7 +1389,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
   1. [=list/For each=] |originalInterestGroup| of the user agent's [=interest group set=] whose
     [=interest group/owner=] is |owner| and [=interest group/next update after=] is before now:
 
-    Note: Implementations may consider loading only a portion of these interest groups
+    Note: Implementations can consider loading only a portion of these interest groups
     at a time to avoid issuing too many requests at once.
     1. Let |ig| be a deep copy of |originalInterestGroup|.
     1. Let |request| be the result of [=creating a request=] with |ig|'s


### PR DESCRIPTION
RFC2119 keywords aren't allowed in non-normative sections.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/557.html" title="Last updated on May 2, 2023, 3:45 PM UTC (e8fc0ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/557/232f83b...caraitto:e8fc0ce.html" title="Last updated on May 2, 2023, 3:45 PM UTC (e8fc0ce)">Diff</a>