### PR TITLE
Check allowComponentAuction and adComponents of generated bid

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1074,7 +1074,7 @@ a <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>priority signals</dfn>, w
       |groupHasAdComponents|.
     1. Let |numArguments| be |arguments|'s [=list/size=].
     1. Let |browserSignals| be |arguments|[|numArguments| - 1].
-    1. Let |isComponentAuction| be fasle.
+    1. Let |isComponentAuction| be false.
     1. If |browserSignals|["`topLevelSeller`"] is not null:
       1. Set |isComponentAuction| to true.
     1. Set [=this=]'s [=relevant global object=]'s

--- a/spec.bs
+++ b/spec.bs
@@ -628,12 +628,12 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=this=]'s [=relevant settings object=]'s
   [=environment/top-level origin=]'s [=origin/host=].
 1. [=map/Set=] |browserSignals|["seller"] to |auctionConfig|'s [=auction config/seller=].
-1. Let |isComponentAuction| be true.
+1. Let |isComponentAuction| be false.
 1. If |topLevelAuctionConfig| is not null:
   1. [=map/Set=] |browserSignals|["topLevelSeller"] to the
     [=serialization of an origin|serialization=] of |topLevelAuctionConfig|'s
     [=auction config/seller=].
-  1. Set |isComponentAuction| to false.
+  1. Set |isComponentAuction| to true.
 1. Let |pendingBuyers| be the [=map/size=] of |bidGenerators|.
 1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|,
   [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
@@ -686,8 +686,11 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
         1. Let |generatedBidIDL| be the result of [=converted to an IDL value|converting=]
           |generatedBidResult| to a {{GenerateBidOutput}}.
         1. If an exception was caught in the previous step, [=iteration/continue=].
+        1. Let |groupHasAdComponents| be true.
+        1. If |interestGroup|'s [=interest group/ad components=] is null:
+          1. Set |groupHasAdComponents| be false.
         1. Let |generatedBid| be the result of [=converting GenerateBidOutput to generated bid=]
-          with |generatedBidIDL| and |isComponentAuction|.
+          with |generatedBidIDL|, |isComponentAuction|, and |groupHasAdComponents|.
         1. If |generatedBid| is failure, [=iteration/continue=].
         1. Set |generatedBid|'s [=generated bid/interest group=] to |ig|.
         1. [=Score and rank a bid=] with |auctionConfig|, |generatedBid|, |leadingBidInfo|,
@@ -1048,14 +1051,23 @@ Each {{InterestGroupBiddingScriptRunnerGlobalScope}} has a
 <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>bid</dfn>, which is a [=generated bid=], a
 <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>priority</dfn>, which is a {{double}} or null,
 a <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>priority signals</dfn>, which is an
-[=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are {{double}}, and a
+[=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are {{double}}, a
 <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>is component auction</dfn>, which is a
+[=boolean=], and a
+<dfn for=InterestGroupBiddingScriptRunnerGlobalScope>group has ad components</dfn>, which is a
 [=boolean=].
 
 <div algorithm>
   To <dfn>evaluate a bidding script</dfn> given a [=string=] |script| and a [=list=] of arguments
   |arguments|:
 
+    1. Let |ig| be |arguments|[0].
+    1. Let |groupHasAdComponents| be true.
+    1. If |ig|'s [=interest group/ad components=] is null:
+      1. Set |groupHasAdComponents| be false.
+    1. Set [=this=]'s [=relevant global object=]'s
+      [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=] to
+      |groupHasAdComponents|.
     1. Let |numArguments| be |arguments|'s [=list/size=].
     1. Let |browserSignals| be |arguments|[|numArguments| - 1].
     1. Let |isComponentAuction| be fasle.
@@ -1254,7 +1266,7 @@ dictionary GenerateBidOutput {
 <div algorithm>
 
 To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOutput}}
-|generateBidOutput| and a [=boolean=] |isComponentAuction|:
+|generateBidOutput|, a [=boolean=] |isComponentAuction| and a [=boolean=] |groupHasAdComponents|:
   1. If |generateBidOutput|["{{GenerateBidOutput/bid}}"] is less than or equal to 0, return failure.
   1. If |isComponentAuction| is true, and
     |generateBidOutput|["{{GenerateBidOutput/allowComponentAuction}}"] is false:
@@ -1281,7 +1293,7 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. If |generateBidOutput|["{{GenerateBidOutput/adComponents}}"] [=map/exists=]:
     1. Let |adComponents| be |generateBidOutput|["{{GenerateBidOutput/adComponents}}"].
     1. Return failure if any of the following conditions hold:
-      * biddingScriptRunner's adComponents parameter does not exist; TODO: rewrite.
+      * |groupHasAdComponents| is false;
       * |adComponents| is not an array;
       * |adComponents|'s size is greater than 20.
     1. Let |adComponentDescriptors| be a new [=list=] of [=ad descriptors=].
@@ -1367,8 +1379,10 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. Set [=this=]'s [=relevant global object=]'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=]
     to null.
   1. Let |bidToSet| be the result of [=converting GenerateBidOutput to generated bid=] with
-    |generateBidOutput| and [=this=]'s [=relevant global object=]'s
-    [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=].
+    |generateBidOutput|, [=this=]'s [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=], and [=this=]'s
+    [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=].
   1. If |bidToSet| is failure, return false.
   1. Set [=this=]'s [=relevant global object=]'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=]
     to |bidToSet|.

--- a/spec.bs
+++ b/spec.bs
@@ -594,7 +594,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     [=auction config/component auctions=].
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=],
     [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
-    1. Let |compWinner| be the result of [=generate and score bids=] with |component|,
+    1. Let |compWinner| be the result of running [=generate and score bids=] with |component|,
       |auctionConfig|, and |global|.
     1. If |compWinner| is not null:
       1. Run [=score and rank a bid=] with |auctionConfig|, |compWinner|, |leadingBidInfo|,
@@ -607,8 +607,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. Set |leadingBidInfo|'s [=leading bid info/auction config=] to |auctionConfig|.
   1. Set |leadingBidInfo|'s [=leading bid info/component seller=] to |winningComponentConfig|'s
     [=auction config/seller=].
-  1. Let « |topLevelSellerSignals|, unusedTopLevelReportResultBrowserSignals » be the result of running
-    [=report result=] with |leadingBidInfo|.
+  1. Let « |topLevelSellerSignals|, unusedTopLevelReportResultBrowserSignals » be the result of
+    running [=report result=] with |leadingBidInfo|.
   1. Set |leadingBidInfo|'s [=leading bid info/auction config=] to |winningComponentConfig|.
   1. Set |leadingBidInfo|'s [=leading bid info/component seller=] to null.
   1. Set |leadingBidInfo|'s [=leading bid info/top level seller=] to |auctionConfig|'s
@@ -619,6 +619,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     [=report result=] with |leadingBidInfo|.
   1. Run [=report win=] with |leadingBidInfo|, |sellerSignals|, and |reportResultBrowserSignals|.
   1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
+
 1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
   [=auction config/all buyer experiment group id=].
 1. Let |auctionSignals| be |auctionConfig|'s [=auction config/auction signals=].
@@ -627,8 +628,12 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=this=]'s [=relevant settings object=]'s
   [=environment/top-level origin=]'s [=origin/host=].
 1. [=map/Set=] |browserSignals|["seller"] to |auctionConfig|'s [=auction config/seller=].
+1. Let |isComponentAuction| be true.
 1. If |topLevelAuctionConfig| is not null:
-  1. [=map/Set=] |browserSignals|["topLevelSeller"] to the [=serialization of an origin|serialization=] of |topLevelAuctionConfig|'s [=auction config/seller=].
+  1. [=map/Set=] |browserSignals|["topLevelSeller"] to the
+    [=serialization of an origin|serialization=] of |topLevelAuctionConfig|'s
+    [=auction config/seller=].
+  1. Set |isComponentAuction| to false.
 1. Let |pendingBuyers| be the [=map/size=] of |bidGenerators|.
 1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|,
   [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
@@ -678,15 +683,13 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
            |biddingScript| and « |interestGroup|, |auctionSignals|, |perBuyerSignals|,
            |trustedBiddingSignals|, |browserSignals| ».
         1. If |generatedBidResult| is an [=abrupt completion=], [=iteration/continue=].
-        1. Let |generatedBidIDL| be the result of [=converted to an IDL value|converting=] |generatedBidResult| to
-          a {{GenerateBidOutput}}.
+        1. Let |generatedBidIDL| be the result of [=converted to an IDL value|converting=]
+          |generatedBidResult| to a {{GenerateBidOutput}}.
         1. If an exception was caught in the previous step, [=iteration/continue=].
-
-        1. Let |generatedBid| be the result of [=converting GenerateBidOutput to generated bid=] with |generatedBidIDL|.
+        1. Let |generatedBid| be the result of [=converting GenerateBidOutput to generated bid=]
+          with |generatedBidIDL| and |isComponentAuction|.
         1. If |generatedBid| is failure, [=iteration/continue=].
         1. Set |generatedBid|'s [=generated bid/interest group=] to |ig|.
-        1. Let |isComponentAuction| be a [=boolean=] set to true when |topLevelAuctionConfig|
-          is not null, otherwise false.
         1. [=Score and rank a bid=] with |auctionConfig|, |generatedBid|, |leadingBidInfo|,
           |decisionLogicScript|, |dataVersion| and |isComponentAuction|.
 
@@ -1044,13 +1047,22 @@ of the following global objects:
 Each {{InterestGroupBiddingScriptRunnerGlobalScope}} has a
 <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>bid</dfn>, which is a [=generated bid=], a
 <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>priority</dfn>, which is a {{double}} or null,
-and a <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>priority signals</dfn>, which is an
-[=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are {{double}}.
+a <dfn for=InterestGroupBiddingScriptRunnerGlobalScope>priority signals</dfn>, which is an
+[=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are {{double}}, and a
+<dfn for=InterestGroupBiddingScriptRunnerGlobalScope>is component auction</dfn>, which is a
+[=boolean=].
 
 <div algorithm>
   To <dfn>evaluate a bidding script</dfn> given a [=string=] |script| and a [=list=] of arguments
   |arguments|:
 
+    1. Let |numArguments| be |arguments|'s [=list/size=].
+    1. Let |browserSignals| be |arguments|[|numArguments| - 1].
+    1. Let |isComponentAuction| be fasle.
+    1. If |browserSignals|["`topLevelSeller`"] is not null:
+      1. Set |isComponentAuction| to true.
+    1. Set [=this=]'s [=relevant global object=]'s
+      [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=] to |isComponentAuction|.
     1. Return the result of [=evaluating a script=] with
        {{InterestGroupBiddingScriptRunnerGlobalScope}}, |script|, "`generateBid`", and |arguments|.
 </div>
@@ -1241,10 +1253,12 @@ dictionary GenerateBidOutput {
 
 <div algorithm>
 
-To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOutput}} |generateBidOutput|:
+To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOutput}}
+|generateBidOutput| and a [=boolean=] |isComponentAuction|:
   1. If |generateBidOutput|["{{GenerateBidOutput/bid}}"] is less than or equal to 0, return failure.
-  1. If it's a component auction (TODO: how to integrate with runAdAuction), but
-    |generateBidOutput|["{{GenerateBidOutput/allowComponentAuction}}"] is false, return failure.
+  1. If |isComponentAuction| is true, and
+    |generateBidOutput|["{{GenerateBidOutput/allowComponentAuction}}"] is false:
+    1. Return failure.
   1. Let |bid| be a new [=generated bid=].
   1. Set |bid|'s [=generated bid/bid=] to |generateBidOutput|["{{GenerateBidOutput/bid}}"].
   1. If |generateBidOutput|["{{GenerateBidOutput/ad}}"] [=map/exists=]:
@@ -1353,7 +1367,8 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. Set [=this=]'s [=relevant global object=]'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=]
     to null.
   1. Let |bidToSet| be the result of [=converting GenerateBidOutput to generated bid=] with
-    |generateBidOutput|.
+    |generateBidOutput| and [=this=]'s [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=].
   1. If |bidToSet| is failure, return false.
   1. Set [=this=]'s [=relevant global object=]'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=]
     to |bidToSet|.


### PR DESCRIPTION
We need to validate and [convert](https://github.com/WICG/turtledove/blob/main/spec.bs#L1247) the generated bid from its webIDL form to an internal data type, for the bid object returned by generateBid(), or passed to setBid(|bid|).
In the convert method, two checkings were missing or todos:
1. **allowComponentAuction**:
If "topLevelSeller" field of generateBid()'s |browserSignals| argument is null (the bid is from a component auction), the {{GenerateBidOutput/allowComponentAuction}} must be present and true.
2. **adComponents**:
This field must not be present in generated bid, if generateBid()'s |InterestGroup| argument has no "adComponent" field.

I added the two booleans to BiddingScriptGlobalScope, and not sure if that's the correct way for setBid() to access the information. @domfarolino Mind taking a look? Thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/564.html" title="Last updated on May 8, 2023, 1:11 AM UTC (c3396eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/564/0f853ed...qingxinwu:c3396eb.html" title="Last updated on May 8, 2023, 1:11 AM UTC (c3396eb)">Diff</a>