### PR TITLE
Spec: fix a permissions check error.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -269,8 +269,6 @@ To <dfn>check interest group permissions</dfn> given an [=origin=]
   [=response=] |response| and |responseBody|:
   1. If |responseBody| is null or failure, set |resource| to failure and return.
   1. Let |headers| be |response|'s [=response/header list=].
-  1. If [=header list/getting a structured field value=] "X-Allow-Protected-Audience" from |headers| does not
-    return true, set |resource| to failure and return.
   1. Let |mimeType| be the result of [=header list/extracting a MIME type=] from |headers|.
   1. If |mimeType| is failure or is not a [=JSON MIME Type=], throw, set |resource| to failure and return.
   1. Set |resource| to |responseBody|.


### PR DESCRIPTION
Remove checking of "X-Allow-Protected-Audience" in .well-known fetch response header. Our implementation does not check that, if I'm not missing something: https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:content/browser/interest_group/interest_group_permissions_checker.cc;drc=e0e0d24aaa54727dc0a8bc4b159ccdf80d3f5d8d;l=166