### PR TITLE
Specify return type of navigator.startServerAdAuction

### DIFF
--- a/FLEDGE_browser_bidding_and_auction_API.md
+++ b/FLEDGE_browser_bidding_and_auction_API.md
@@ -10,9 +10,9 @@ This document seeks to propose an API for web pages to perform FLEDGE auctions u
 
 #### Step 1: Get auction blob from browser
 
-To execute an on-server FLEDGE auction, sellers begin by calling `navigator.startServerAdAuction()`:
+To execute an on-server FLEDGE auction, sellers begin by calling `navigator.startServerAdAuction(): Promise<Uint8Array>`:
 ```  
-const auctionBlob = navigator.startServerAdAuction({
+const auctionBlob = await navigator.startServerAdAuction({
   // ‘seller’ works the same as for runAdAuction.
   'seller': 'https://www.example-ssp.com',
 });

--- a/FLEDGE_browser_bidding_and_auction_API.md
+++ b/FLEDGE_browser_bidding_and_auction_API.md
@@ -10,7 +10,7 @@ This document seeks to propose an API for web pages to perform FLEDGE auctions u
 
 #### Step 1: Get auction blob from browser
 
-To execute an on-server FLEDGE auction, sellers begin by calling `navigator.startServerAdAuction(): Promise<Uint8Array>`:
+To execute an on-server FLEDGE auction, sellers begin by calling `navigator.startServerAdAuction()` which returns a `Promise<Uint8Array>`:
 ```  
 const auctionBlob = await navigator.startServerAdAuction({
   // ‘seller’ works the same as for runAdAuction.


### PR DESCRIPTION
From the JavaScript perspective, we could receive a`Promise<Uint8Array>` although it's unclear to me what asynchronicity accomplishes given this appears to be a local data lookup?

`Uint8Array` is a standard way to handle binary data in JS and can easily be attached directly to the `fetch` request body or encoded into a string.