### PR TITLE
Document support for automatic beacons sent from <a> handlers

### DIFF
--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -169,16 +169,17 @@ Automatic beacons can be set in the click handler of an anchor tag, and will be 
 
 ```
 <script>
-function addBeaconData() {
+function addBeaconData(element) {
+  const data = element.id + " was clicked.";
   let beacon_event = {
     eventType: "reserved.top_navigation",
-    eventData: "an example string",
+    eventData: data,
     destination: ["buyer"],
   }
   window.fence.setReportEventDataForAutomaticBeacons(beacon_event);
 }
 </script>
-<a onclick="addBeaconData()" href="somesite.com" target="_blank">Click me!</a>
+<a onclick="addBeaconData(this)" id="link1" href="somesite.com" target="_blank">Click me!</a>
 ```
 
-The beacon data will be in place by the time that the navigation starts. When the navigation commits, the automatic beacon will be sent out.
+The beacon data will be in place by the time that the navigation starts. When the navigation commits, the automatic beacon will be sent out with event data set to "link1 was clicked.".

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -165,4 +165,20 @@ If invoked multiple times, the latest invocation before the top-level navigation
 
 If `setReportEventDataForAutomaticBeacons` is not invoked, the browser will not send an automatic beacon because the `destination` is unknown.
 
+Automatic beacons can be set in the click handler of an anchor tag, and will be sent on navigation:
 
+```
+<script>
+function addBeaconData() {
+  let beacon_event = {
+    eventType: "reserved.top_navigation",
+    eventData: "an example string",
+    destination: ["buyer"],
+  }
+  window.fence.setReportEventDataForAutomaticBeacons(beacon_event);
+}
+</script>
+<a onclick="addBeaconData()" href="somesite.com" target="_blank">Click me!</a>
+```
+
+The beacon data will be in place by the time that the navigation starts. When the navigation commits, the automatic beacon will be sent out.

--- a/Fenced_Frames_Ads_Reporting.md
+++ b/Fenced_Frames_Ads_Reporting.md
@@ -165,7 +165,7 @@ If invoked multiple times, the latest invocation before the top-level navigation
 
 If `setReportEventDataForAutomaticBeacons` is not invoked, the browser will not send an automatic beacon because the `destination` is unknown.
 
-Automatic beacons can be set in the click handler of an anchor tag, and will be sent on navigation:
+`setReportEventDataForAutomaticBeacons` can also be invoked in the click handler of an anchor tag, and will be sent on navigation:
 
 ```
 <script>


### PR DESCRIPTION
This is a feature that we already support. This PR updates the explainer to document that this is a use case that we support.