### PR TITLE
Convert between infra values and JS values.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -571,12 +571,12 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
         [=serializing a JavaScript value to a JSON string=], given |result|.
       1. If no exception was [=exception/thrown=] in the previous step:
         1. Set |auctionConfig|'s [=auction config/auction signals=] to |auctionSignalsJSON|.
-        1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}} to
+        1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"] to
           |result|.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon rejection=] of |auctionConfig|'s [=auction config/auction signals=]:
       1. Set |auctionConfig|'s [=auction config/auction signals=] to failure.
-      1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}} to
+      1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"] to
         undefined.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
   1. Otherwise, set |auctionConfig|'s [=auction config/auction signals=] to the result of
@@ -998,7 +998,7 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dt>{{GenerateBidInterestGroup/executionMode}}
       <dd>|ig|'s [=interest group/execution mode=]
       <dt>{{GenerateBidInterestGroup/biddingLogicURL}}
-      <dd>The [=serialize a URL|serialization=] of |ig|'s [=interest group/bidding url=]
+      <dd>The [=serialize a URL|serialization-or-undefined=] of |ig|'s [=interest group/bidding url=]
       <dt>{{GenerateBidInterestGroup/biddingWasmHelperURL}}
       <dd>The [=serialize a URL|serialization=] of |ig|'s [=interest group/bidding wasm helper url=]
       <dt>{{GenerateBidInterestGroup/updateURL}}
@@ -1008,7 +1008,8 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsKeys}}
       <dd>|ig|'s [=interest group/trusted bidding signals keys=]
       <dt>{{GenerateBidInterestGroup/userBiddingSignals}}
-      <dd>[=Parsed a JSON string to a JavaScript value=] given |ig|'s [=interest group/user bidding signals=]
+      <dd>[=Parse a JSON string to a JavaScript value=] given |ig|'s [=interest group/user bidding signals=]
+
       <dt>{{GenerateBidInterestGroup/ads}}
       <dd>|ig|'s [=interest group/ads=] [=converted to an AuctionAd sequence=]
       <dt>{{GenerateBidInterestGroup/adComponents}}
@@ -1639,7 +1640,8 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
     1. Set |global|'s
       [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=] to true if |ig|'s
       [=interest group/ad components=] is not null, or false otherwise.
-    1. Let |isComponentAuction| be true if |browserSignals|["`topLevelSeller`"] is not null, or
+    1. Let |isComponentAuction| be true if |browserSignals|["{{BiddingBrowserSignals/topLevelSeller}}"] is not null, or
+
       false otherwise.
     1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=] to
       |isComponentAuction|.

--- a/spec.bs
+++ b/spec.bs
@@ -28,11 +28,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/C
   type: dfn
     text: create an agent; url: create-an-agent
     text: immediately; url: immediately
-spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
-  type: dfn
-    text: ParseScript; url: sec-parse-script
-    text: ScriptEvaluation; url: sec-runtime-semantics-scriptevaluation
-    text: Number; url: sec-ecmascript-language-types-number-type
 spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
   type: dfn
     text: structured header; url: top
@@ -1778,7 +1773,7 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
       |script| might otherwise be able to more easily exfiltrate data by using more accurate time
       measurements.
 
-    1. Let |result| be [=ParseScript=](|script|, |realm|, `empty`).
+    1. Let |result| be [$ParseScript$](|script|, |realm|, `empty`).
 
        Note: The resulting [=ECMAScript/Script Record=] will have no \[[HostDefined]] component,
        unlike traditional [=scripts=] on the web platform.
@@ -1792,7 +1787,7 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
        stack|JavaScript execution context stack=]; it is now the [=ECMAScript/running execution
        context|running JavaScript execution context=].
 
-    1. Let |evaluationStatus| be the result of [=ScriptEvaluation=](result).
+    1. Let |evaluationStatus| be the result of [$ScriptEvaluation$](result).
 
     1. If |evaluationStatus| is an [=ECMAScript/abrupt completion=], jump to the step labeled <i><a
        href=#evaluate-script-return>return</a></i>.

--- a/spec.bs
+++ b/spec.bs
@@ -94,15 +94,13 @@ dictionary AuctionAd {
   any metadata;
 };
 
-dictionary AuctionAdInterestGroup {
+dictionary GenerateBidInterestGroup {
   required USVString owner;
   required USVString name;
   required double lifetimeMs;
 
-  double priority = 0.0;
   boolean enableBiddingSignalsPrioritization = false;
   record<DOMString, double> priorityVector;
-  record<DOMString, double> prioritySignalsOverrides;
 
   DOMString executionMode = "compatibility";
   USVString biddingLogicURL;
@@ -114,7 +112,18 @@ dictionary AuctionAdInterestGroup {
   sequence<AuctionAd> ads;
   sequence<AuctionAd> adComponents;
 };
+
+dictionary AuctionAdInterestGroup : GenerateBidInterestGroup {
+  double priority = 0.0;
+  record<DOMString, double> prioritySignalsOverrides;
+};
 </xmp>
+
+{{AuctionAdInterestGroup}} is used by {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}, and
+when an interest group is stored to [=interest group set=].
+`priority` and `prioritySignalsOverrides` are not passed to `generateBid()` because they can be
+modified by `generatedBid()` calls, so could theoretically be used to create a cross-site profile of
+a user accessible to `generateBid()` methods, otherwise.
 
 <div algorithm="joinAdInterestGroup()">
 
@@ -2004,34 +2013,6 @@ Issue(WICG/turtledove#522): Move from "`*`" to "`self`".
 
 
 # Structures # {#structures}
-
-
-<xmp class="idl">
-
-dictionary GenerateBidInterestGroup {
-  required USVString owner;
-  required USVString name;
-
-  boolean enableBiddingSignalsPrioritization = false;
-  record<DOMString, double> priorityVector;
-
-  DOMString executionMode = "compatibility";
-  USVString biddingLogicURL;
-  USVString biddingWasmHelperURL;
-  USVString updateURL;
-  USVString trustedBiddingSignalsURL;
-  sequence<USVString> trustedBiddingSignalsKeys;
-  any userBiddingSignals;
-  sequence<AuctionAd> ads;
-  sequence<AuctionAd> adComponents;
-};
-</xmp>
-
-{{GenerateBidInterestGroup}} is {{AuctionAdInterestGroup}} with its `priority` and
-`prioritySignalsOverrides` fields removed.
-`priority` and `prioritySignalsOverrides` are not included when interest group is passed to
-`generateBid()` because they can be modified by `generatedBid()` calls, so could theoretically be
-used to create a cross-site profile of a user accessible to `generateBid()` methods, otherwise.
 
 <h3 dfn-type=dfn>Interest group</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -121,7 +121,7 @@ dictionary AuctionAdInterestGroup {
 The <dfn for=Navigator method>joinAdInterestGroup(|group|)</dfn> method steps are:
 <div class="note">
 
-Temporarily, Chromium does not include the <span class="allow-2119">[=dictionary member/required=]</span> keyword
+Temporarily, Chromium does not include the <span class="allow-2119">required</span> keyword
 for {{AuctionAdInterestGroup/lifetimeMs}}, and instead starts this algorithm with the step
 
 1. If |group|["{{AuctionAdInterestGroup/lifetimeMs}}"] does not [=map/exist=], throw a {{TypeError}}.
@@ -749,7 +749,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Let |topLevelHost| be [=this=]'s [=relevant settings object=]'s
   [=environment/top-level origin=]'s [=origin/host=].
 1. If |topLevelHost| is an integer:
-  1. Let |topLevelHost| be the result of converting |topLevelHost| to a [=string=].
+  1. Let |topLevelHost| be the result of [=serializing an integer=] given |topLevelHost|.
 1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=string=] |topLevelHost|.
 1. [=map/Set=] |browserSignals|["seller"] to the [=serialization of an origin|serialization=] of
   |auctionConfig|'s [=auction config/seller=].
@@ -881,23 +881,30 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dt>{{GenerateBidInterestGroup/executionMode}}
       <dd>|ig|'s [=interest group/execution mode=]
       <dt>{{GenerateBidInterestGroup/biddingLogicURL}}
-      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/bidding url=]
+      <dd>The [=serialize a URL|serialization=] of |ig|'s [=interest group/bidding url=]
       <dt>{{GenerateBidInterestGroup/biddingWasmHelperURL}}
-      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/bidding wasm helper url=]
+      <dd>The [=serialize a URL|serialization=] of |ig|'s [=interest group/bidding wasm helper url=]
       <dt>{{GenerateBidInterestGroup/updateURL}}
-      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/update url=]
+      <dd>The [=serialize a URL|serialization=] of |ig|'s [=interest group/update url=]
       <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}
-      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/trusted bidding signals url=]
-      <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}
-      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/trusted bidding signals keys=]
+      <dd>The [=serialize a URL|serialization=] of |ig|'s [=interest group/trusted bidding signals url=]
+      <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsKeys}}
+      <dd>|ig|'s [=interest group/trusted bidding signals keys=]
       <dt>{{GenerateBidInterestGroup/userBiddingSignals}}
-      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/user bidding signals=]
+      <dd>[=Parsed a JSON string to a JavaScript value=] given |ig|'s [=interest group/user bidding signals=]
       <dt>{{GenerateBidInterestGroup/ads}}
       <dd>|ig|'s [=interest group/ads=] [=converted to an AuctionAd sequence=]
       <dt>{{GenerateBidInterestGroup/adComponents}}
       <dd>|ig|'s [=interest group/ad components=] [=converted to an AuctionAd sequence=]
     </dl>
   1. Return |igGenerateBid|.
+</div>
+
+<div algorithm>
+To <dfn>serialize a URL</dfn> given a [=URL=]-or-undefined |url|:
+
+  1. If |url| is undefined, then return undefined.
+  1. Return the [=URL serializer|serialization=] of |url|.
 </div>
 
 <div algorithm>
@@ -910,9 +917,10 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-undefined |ad
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
     1. If |ad|'s [=interest group ad/metadata=] is not undefined, then [=map/set=]
-      |adIDL|["{{AuctionAd/metadata}}"] to it.
+      |adIDL|["{{AuctionAd/metadata}}"] to the result of
+      [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
     1. [=list/Append=] |adIDL| to |adsIDL|.
-  1. Return |adsIDL|
+  1. Return |adsIDL|.
 </div>
 
 <div algorithm>
@@ -1391,8 +1399,8 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
 <div algorithm>
   To <dfn>evaluate a bidding script</dfn> given a [=string=] |script|, an [=interest group=] |ig|, a
   {{GenerateBidInterestGroup}} |igGenerateBid|, a [=string=]-or-null |auctionSignals|, an
-  [=ordered map=]-or-null |perBuyerSignals|, an [=ordered map=] |trustedBiddingSignals|, an
-  [=ordered map=] |browserSignals|, and an integer millisecond [=duration=] |timeout|:
+  [=ordered map=]-or-null |perBuyerSignals|, an [=ordinary object=] |trustedBiddingSignals|, a
+  [=record=]<{{DOMString}}, {{any}}> |browserSignals|, and an integer millisecond [=duration=] |timeout|:
 
     1. Let |global| be a new {{InterestGroupBiddingScriptRunnerGlobalScope}}.
     1. Set |global|'s

--- a/spec.bs
+++ b/spec.bs
@@ -1430,11 +1430,11 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|:
   1. Let |reportResultOutputJS| be the result of [=evaluating a reporting script=] with
      |sellerReportingScript|, "`reportResult`", and « |config|, |browserSignals|».
   1. If |reportResultOutputJS| is an [=abrupt completion=], [=iteration/continue=].
-  1. Let |reportResultOutputIDL| be the result of [=converted to an IDL value|converting=]
-     |reportResultOutputJS| to a {{ReportResultOutput}}.
   1. [=map/Remove=] |browserSignals|["`dataVersion`"].
   1. [=map/Remove=] |browserSignals|["`modifiedBid`"].
   1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].
+  1. Let |reportResultOutputIDL| be the result of [=converted to an IDL value|converting=]
+     |reportResultOutputJS| to a {{ReportResultOutput}}.
   1. If an exception was [=exception/thrown=] in the previous step, return « null, |browserSignals| ».
   1. TODO: Store |reportResultOutputIDL|["{{ReportResultOutput/reportUrl}}"] and
      |reportResultOutputIDL|["{{ReportResultOutput/reportingBeaconMap}}"] in the

--- a/spec.bs
+++ b/spec.bs
@@ -1604,9 +1604,10 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
     1. Set |global|'s
       [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=] to true if |ig|'s
       [=interest group/ad components=] is not null, or false otherwise.
-    1. Set |global|'s
-      [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=] to true if
-      |browserSignals|["`topLevelSeller`"] is not null, or false otherwise.
+    1. Let |isComponentAuction| be true if |browserSignals|["`topLevelSeller`"] is not null, or
+      false otherwise.
+    1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=] to
+      |isComponentAuction|.
     1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/interest group=] to |ig|.
     1. Let |igJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
       given |igGenerateBid|.

--- a/spec.bs
+++ b/spec.bs
@@ -716,7 +716,54 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       1. [=list/For each=] |ig| of |groups|:
         1. TODO: If rerunning `generateBid()` with only k-anonymous ads, remember to swap out |ig|'s ads
           to just k-anonymous ones so that [=validating an ad url=] excludes the non-k-anonymous ones.
-        1. TODO: Let |interestGroup| be ... from |ig| ... minus priority and prioritySignalsOverrides and any browser-defined pieces
+        1. Let |igIDL| be a new {{AuctionAdInterestGroup}}.
+        1. [=map/Set=] |igIDL|["{{AuctionAdInterestGroup/owner}}"] to |ig|'s [=interest group/owner=].
+        1. [=map/Set=] |igIDL|["{{AuctionAdInterestGroup/name}}"] to |ig|'s [=interest group/name=].
+        1. For each |interestGroupField| and |groupMember| in the following table <table class="data">
+            <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead>
+            <tr>
+              <td>[=interest group/enable bidding signals prioritization=]</td>
+              <td>"{{AuctionAdInterestGroup/enableBiddingSignalsPrioritization}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/execution mode=]</td>
+              <td>"{{AuctionAdInterestGroup/executionMode}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/bidding url=]</td>
+              <td>"{{AuctionAdInterestGroup/biddingLogicURL}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/bidding wasm helper url=]</td>
+              <td>"{{AuctionAdInterestGroup/biddingWasmHelperURL}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/update url=]</td>
+              <td>"{{AuctionAdInterestGroup/updateURL}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/trusted bidding signals url=]</td>
+              <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsURL}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/trusted bidding signals keys=]</td>
+              <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsKeys}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/trusted bidding signals url=]</td>
+              <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsURL}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/ads=]</td>
+              <td>"{{AuctionAdInterestGroup/ads}}"</td>
+            </tr>
+            <tr>
+              <td>[=interest group/ad components=]</td>
+              <td>"{{AuctionAdInterestGroup/adComponents}}"</td>
+            </tr>           
+          </table>
+          1. If |ig|'s |interestGroupField| is not null, then [=map/set=] |igIDL|[|groupMember|] to it.
+
         1. [=map/Set=] |browserSignals|["`joinCount`"] to the sum of |ig|'s
            [=interest group/join counts=] for all days within the last 30 days.
         1. [=map/Set=] |browserSignals|["`bidCount`"] to the sum of |ig|'s
@@ -741,20 +788,20 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. If |allTrustedBiddingSignals| is an [=ordered map=] and |allTrustedBiddingSignals|[|key|]
             [=map/exists=], then [=map/set=] |trustedBiddingSignals|[|key|] to
             |allTrustedBiddingSignals|[|key|].
-        1. Let |startTime| be the current time.
-        1. Let |generatedBidResult| be the result of [=evaluating a bidding script=] with
-           |biddingScript|, |ig|, « |interestGroup|, |auctionSignals|, |perBuyerSignals|,
+        1. Let |startTime| be the [=current wall time=].
+        1. Let |generateBidOutputJS| be the result of [=evaluating a bidding script=] with
+           |biddingScript|, |ig|, « |igIDL|, |auctionSignals|, |perBuyerSignals|,
            |trustedBiddingSignals|, |browserSignals| », and |perBuyerTimeout|.
-        1. Let |duration| be the current time minus |startTime| in milliseconds.
-        1. If |generatedBidResult| is an [=abrupt completion=], [=iteration/continue=].
-        1. Let |generatedBidIDL| be the result of [=converted to an IDL value|converting=]
-          |generatedBidResult| to a {{GenerateBidOutput}}.
+        1. Let |duration| be the [=current wall time=] minus |startTime| in milliseconds.
+        1. If |generateBidOutputJS| is an [=abrupt completion=], [=iteration/continue=].
+        1. Let |generateBidOutputIDL| be the result of [=converted to an IDL value|converting=]
+          |generateBidOutputJS| to a {{GenerateBidOutput}}.
         1. If an exception was caught in the previous step, [=iteration/continue=].
         1. Let |groupHasAdComponents| be true.
-        1. If |interestGroup|'s [=interest group/ad components=] is null:
+        1. If |ig|'s [=interest group/ad components=] is null:
           1. Set |groupHasAdComponents| be false.
         1. Let |generatedBid| be the result of [=converting GenerateBidOutput to generated bid=]
-          with |generatedBidIDL|, |ig|, |isComponentAuction|, and |groupHasAdComponents|.
+          with |generateBidOutputIDL|, |ig|, |isComponentAuction|, and |groupHasAdComponents|.
         1. Set |generatedBid|'s [=generated bid/bid duration=] to |duration|.
         1. If |generatedBid| is failure, [=iteration/continue=].
         1. Set |generatedBid|'s [=generated bid/interest group=] to |ig|.
@@ -835,6 +882,7 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
 1. Let |scoreAdOutput| be the result of [=evaluating a scoring script=] with
    |decisionLogicScript|, « |adMetadata|, |bidValue|, |auctionConfig|, |trustedScoringSignals|,
    |browserSignals| », and |auctionConfig|'s [=auction config/seller timeout=].
+1. If |scoreAdOutput| is an [=abrupt completion=], [=iteration/continue=].
 1. If |isComponentAuction| is true, and |scoreAdOutput|'s
   [=score ad output/allow component auction=] is false, return.
 1. Let |score| be |scoreAdOutput|'s [=score ad output/desirability=].
@@ -1134,14 +1182,18 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|:
   1. Set |config| to |leadingBidInfo|'s [=leading bid info/auction config=].
   1. Let |sellerReportingScript| be the result of [=fetching script=] with |config|'s
     [=auction config/decision logic url=].
-  1. Let « |sellerSignals|, |reportUrl|, |reportingBeaconMap| » be the result of [=evaluating a
-     reporting script=] with |sellerReportingScript|, "`reportResult`", and « |config|,
-     |browserSignals|».
-  1. TODO: Store |reportUrl| and |reportingBeaconMap| in the {{FencedFrameConfig}} as appropriate.
+  1. Let |reportResultOutputJS| be the result of [=evaluating a reporting script=] with
+     |sellerReportingScript|, "`reportResult`", and « |config|, |browserSignals|».
+  1. If |reportResultOutputJS| is an [=abrupt completion=], [=iteration/continue=].
+  1. Let |reportResultOutputIDL| be the result of [=converted to an IDL value|converting=]
+     |reportResultOutputJS| to a {{ReportResultOutput}}.
+  1. TODO: Store |reportResultOutputIDL|["{{ReportResultOutput/reportUrl}}"] and
+     |reportResultOutputIDL|["{{ReportResultOutput/reportingBeaconMap}}"] in the
+     {{FencedFrameConfig}} as appropriate.
   1. [=map/Remove=] |browserSignals|["`dataVersion`"].
   1. [=map/Remove=] |browserSignals|["`modifiedBid`"].
-  1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].  
-  1. Return « |sellerSignals|, |browserSignals| ».
+  1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].
+  1. Return « |reportResultOutputIDL|["{{ReportResultOutput/signalsForWinner}}"], |browserSignals| ».
 </div>
 
 <div algorithm>
@@ -1375,8 +1427,11 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
        |finalCompletion| to |F| and jump to the step labeled <i><a
        href=#evaluate-script-return>return</a></i>.
 
+    1. Let |argumentsJS| be the result of
+      [=converted to ECMAScript values|converting to ECMAScript values=] given |arguments|.
+
     1. Set |finalCompletion| be [=ECMAScript/Completion Record|Completion=]([$Call$](F, `undefined`,
-       |arguments|)). 
+       |argumentsJS|)). 
        
        In |timeout| milliseconds, if the invocation of [$Call$] has not completed,
        [=immediately=] interrupt the execution and set |finalCompletion| to a new
@@ -1446,6 +1501,12 @@ dictionary GenerateBidOutput {
   double adCost;
   double modelingSignals;
   boolean allowComponentAuction = false;
+};
+
+dictionary ReportResultOutput {
+  DOMString signalsForWinner;
+  USVString reportUrl;
+  any reportingBeaconMap;
 };
 </pre>
 
@@ -1815,7 +1876,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
               
         </dl>
               
-    1. Set |ig|'s [=interest group/next update after=] to the current time plus 24 hours.
+    1. Set |ig|'s [=interest group/next update after=] to the [=current wall time=] plus 24 hours.
     1. [=list/Replace=] |originalInterestGroup| with |ig| in the browser's
       [=interest group set=].
     1. <i id=abort-update>Abort update</i>: We jump here if some part of the
@@ -2071,7 +2132,7 @@ the seller.
   [=interest group/ad components=] field.
 : <dfn>ad cost</dfn>
 :: Null or a {{double}}. Advertiser click or conversion cost passed from `generateBid()` to
-  reportWin(). Invalid values, such as negative, infinite, and NaN values, will be ignored and not
+  `reportWin()`. Invalid values, such as negative, infinite, and NaN values, will be ignored and not
   passed. Only the lowest 12 bits will be passed.
 : <dfn>modeling signals</dfn>
 :: Null or an {{unsigned short}}. A 0-4095 integer (12-bits) passed to `reportWin()`, with noising.

--- a/spec.bs
+++ b/spec.bs
@@ -781,12 +781,9 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 <div algorithm="generate a bid">
 
 To <dfn>generate a bid</dfn> given an [=ordered map=] |allTrustedBiddingSignals|, a 
-[=string=] |auctionSignals|, an {{BiddingBrowserSignals}} |browserSignals|, a [=string=]
+[=string=] |auctionSignals|, a {{BiddingBrowserSignals}} |browserSignals|, a [=string=]
 |perBuyerSignals|, a [=duration=] |perBuyerTimeout| in milliseconds, an [=interest group=] |ig|, and
 a [=moment=] |auctionStartTime|:
-  1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
-    [=interest group/bidding url=].
-  1. If |biddingScript| is failure, return failure.
   1. Let |igGenerateBid| be the result of [=building an interest group passed to generateBid=]
     with |ig|.
   1. Set |browserSignals|["{{BiddingBrowserSignals/joinCount}}"] to the sum of |ig|'s
@@ -806,6 +803,9 @@ a [=moment=] |auctionStartTime|:
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
   1. If |dataVersion| is not null:
     1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
+  1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
+    [=interest group/bidding url=].
+  1. If |biddingScript| is failure, return failure.
   1. If |ig|'s [=interest group/bidding wasm helper url=] is not null:
     1. Let |wasmModuleObject| be the result of [=fetching WebAssembly=] with |ig|'s
       [=interest group/bidding wasm helper url=].
@@ -817,9 +817,9 @@ a [=moment=] |auctionStartTime|:
     1. If |allTrustedBiddingSignals| is an [=ordered map=] and |allTrustedBiddingSignals|[|key|]
       [=map/exists=], then [=map/set=] |trustedBiddingSignals|[|key|] to
       |allTrustedBiddingSignals|[|key|].
-  1. Return be the result of [=evaluating a bidding script=] with
-     |biddingScript|, |ig|, |igGenerateBid|, |auctionSignals|, |perBuyerSignals|,
-     |trustedBiddingSignals|, |browserSignals|, and |perBuyerTimeout|.
+  1. Return tbe the result of [=evaluating a bidding script=] with |biddingScript|, |ig|,
+    |igGenerateBid|, |auctionSignals|, |perBuyerSignals|, |trustedBiddingSignals|, |browserSignals|,
+    and |perBuyerTimeout|.
 </div>
   
 <div algorithm="generate and score bids">

--- a/spec.bs
+++ b/spec.bs
@@ -28,10 +28,17 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/C
     text: immediately; url: immediately
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
-    text: ParseScript; url: sec-parse-script
     text: abrupt completion; url: sec-completion-record-specification-type
-    text: throw completion; url: sec-completion-record-specification-type
+    text: CreateDataProperty; url: sec-createdataproperty
+    text: Get; url: sec-get-o-p
+    text: HasProperty; url: sec-hasproperty
+    text: is not an Object; url: sec-object-type
+    text: IsArray; url: sec-runtime-semantics-scriptevaluation
+    text: ordinary object; url: ordinary-object
+    text: ParseScript; url: sec-parse-script
     text: ScriptEvaluation; url: sec-runtime-semantics-scriptevaluation
+    text: throw completion; url: sec-completion-record-specification-type
+    
 spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
   type: dfn
     text: structured header; url: top
@@ -44,6 +51,9 @@ spec: WebAssembly; urlPrefix: https://webassembly.github.io/spec/core/
 spec: WebAssembly-js-api; urlPrefix: https://webassembly.github.io/spec/js-api/
   type: dfn
     text: compiling a WebAssembly module; url: #compile-a-webassembly-module
+spec: WebIDL; urlPrefix: https://webidl.spec.whatwg.org/
+  type: dfn
+    text: Web IDL arguments list; url: #web-idl-arguments-list
 </pre>
 
 # Introduction # {#intro}
@@ -246,34 +256,34 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 1. 8 bytes, which is the size of |ig|'s [=interest group/priority=].
 1. The [=string/length=] of |ig|'s [=interest group/execution mode=].
 1. 2 bytes, which is the size of |ig|'s [=interest group/enable bidding signals prioritization=].
-1. If |ig|'s [=interest group/priority vector=] is not null, [=map/for each=] |key| → |value| of
-  [=interest group/priority vector=]:
+1. If |ig|'s [=interest group/priority vector=] is not undefined, [=map/for each=] |key| → |value|
+  of [=interest group/priority vector=]:
   1. The [=string/length=] of |key|.
   1. 8 bytes, which is the size of |value|.
-1. If |ig|'s [=interest group/priority signals overrides=] is not null, [=map/for each=] |key| →
-  |value| of [=interest group/priority signals overrides=]:
+1. If |ig|'s [=interest group/priority signals overrides=] is not undefined, [=map/for each=]
+  |key| → |value| of [=interest group/priority signals overrides=]:
   1. The [=string/length=] of |key|.
   1. 8 bytes, which is the size of |value|.
 1. The size of [=interest group/execution mode=].
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/bidding url=], if the field is not null.
+  [=interest group/bidding url=], if the field is not undefined.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/bidding wasm helper url=], if the field is not null.
+  [=interest group/bidding wasm helper url=], if the field is not undefined.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/update url=], if the field is not null.
+  [=interest group/update url=], if the field is not undefined.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/trusted bidding signals url=], if the field is not null.
+  [=interest group/trusted bidding signals url=], if the field is not undefined.
 1. [=list/For each=] |key| of |ig|'s [=interest group/trusted bidding signals keys=]:
   1. The [=string/length=] of |key|.
 1. The [=string/length=] of |ig|'s [=interest group/user bidding signals=].
-1. If |ig|'s [=interest group/ads=] is not null, [=list/for each=] |ad| of it:
+1. If |ig|'s [=interest group/ads=] is not undefined, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
-  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
-1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
+  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not undefined.
+1. If |ig|'s [=interest group/ad components=] is not undefined, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
-  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
+  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not undefined.
 
 </div>
 
@@ -606,15 +616,14 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     to |value|, and [=iteration/continue=].
   1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
     [=exception/throw=] a {{TypeError}}.
-  1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer group limits=][|buyer|] to |value|.
+  1. Set |auctionConfig|'s [=auction config/per buyer group limits=][|buyer|] to |value|.
 1. If |config|["{{AuctionAdConfig/perBuyerExperimentGroupIds}}"] [=map/exists=], [=map/for each=]
   |key| → |value| of |config|["{{AuctionAdConfig/perBuyerExperimentGroupIds}}"]:
   1. If |key| equals to "*", then set |auctionConfig|'s
     [=auction config/all buyer experiment group id=] to |value|, and [=iteration/continue=].
   1. Let |buyer| the result of [=parsing an origin=] with |key|. If |buyer| is failure,
     [=exception/throw=] a {{TypeError}}.
-  1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer experiment group ids=][|buyer|] to
-    |value|.
+  1. Set |auctionConfig|'s [=auction config/per buyer experiment group ids=][|buyer|] to |value|.
 1. If |config|["{{AuctionAdConfig/perBuyerPrioritySignals}}"] [=map/exists=], [=map/for each=]
   |key| → |value| of |config|["{{AuctionAdConfig/perBuyerPrioritySignals}}"]:
   1. Let |signals| be an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=]
@@ -626,13 +635,13 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     [=auction config/all buyers priority signals=] to |value|, and [=iteration/continue=].
   1. Let |buyer| be the result of [=parsing an origin=] with |key|. If it fails, [=exception/throw=]
     a {{TypeError}}.
-  1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer priority signals=][|buyer|] to
-    |signals|.
+  1. Set |auctionConfig|'s [=auction config/per buyer priority signals=][|buyer|] to |signals|.
 1. [=list/For each=] |component| in |config|["{{AuctionAdConfig/componentAuctions}}"]:
   1. If |isTopLevel| is false, [=exception/throw=] a {{TypeError}}.
   1. Let |componentAuction| be the result of running [=validate and convert auction ad config=] with
     |component| and false.
   1. [=list/Append=] |componentAuction| to |auctionConfig|'s [=auction config/component auctions=].
+1. Set |auctionConfig|'s [=auction config/config idl=] to |config|.
 1. Return |auctionConfig|.
 
 </div>
@@ -736,11 +745,14 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. If |auctionSignals|, |auctionConfig|'s [=auction config/seller signals=],
   [=auction config/per buyer signals=], or [=auction config/per buyer timeouts=] is failure, return
   failure.
-1. Let |browserSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=] and whose
-  [=map/values=] are {{any}}.
-1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=this=]'s [=relevant settings object=]'s
+1. Let |browserSignals| be a [=record=]<{{DOMString}}, {{any}}>.
+1. Let |topLevelHost| be [=this=]'s [=relevant settings object=]'s
   [=environment/top-level origin=]'s [=origin/host=].
-1. [=map/Set=] |browserSignals|["seller"] to |auctionConfig|'s [=auction config/seller=].
+1. If |topLevelHost| is an integer:
+  1. Let |topLevelHost| be the result of converting |topLevelHost| to a [=string=].
+1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=string=] |topLevelHost|.
+1. [=map/Set=] |browserSignals|["seller"] to the [=serialization of an origin|serialization=] of
+  |auctionConfig|'s [=auction config/seller=].
 1. Let |isComponentAuction| be false.
 1. If |topLevelAuctionConfig| is not null:
   1. [=map/Set=] |browserSignals|["topLevelSeller"] to the
@@ -793,6 +805,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       with |biddingSignalsUrl| and true.
     1. [=map/For each=] joiningOrigin → |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
+        1. If |ig|'s [=interest group/bidding url=] is undefined, [=iteration/continue=].
         1. TODO: If rerunning `generateBid()` with only k-anonymous ads, remember to swap out |ig|'s ads
           to just k-anonymous ones so that [=validating an ad url=] excludes the non-k-anonymous ones.
         1. Let |igGenerateBid| be the result of [=building an interest group passed to generateBid=]
@@ -805,22 +818,21 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
            time and the corresponding winning [=interest group ad=] from |ig|'s
            [=interest group/previous wins=] field with a data within the last 30 days. The time
            field is specified in seconds relative to the start of the auction.
+           TODO: make this an IDL type.
         1. If |dataVersion| is not null:
           1. [=map/Set=] |browserSignals|["`dataVersion`"] to |dataVersion|.
         1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
           [=interest group/bidding url=].
         1. If |biddingScript| is failure, [=iteration/continue=].
-        1. If |ig|'s [=interest group/bidding wasm helper url=] is not null:
+        1. If |ig|'s [=interest group/bidding wasm helper url=] is not undefined:
           1. Let |wasmModuleObject| be the result of [=fetching WebAssembly=] with |ig|'s
             [=interest group/bidding wasm helper url=].
           1. If |wasmModuleObject| is not failure:
             1. [=map/Set=] |browserSignals|["`wasmHelper`"] to |wasmModuleObject|.
-        1. Let |trustedBiddingSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=] and
-          whose [=map/values=] are {{any}}.
+        1. Let |trustedBiddingSignals| be a new [=ordinary object=].
         1. [=list/For each=] |key| of |ig|'s [=interest group/trusted bidding signals keys=]:
-          1. If |allTrustedBiddingSignals| is an [=ordered map=] and |allTrustedBiddingSignals|[|key|]
-            [=map/exists=], then [=map/set=] |trustedBiddingSignals|[|key|] to
-            |allTrustedBiddingSignals|[|key|].
+          1. If [=HasProperty=](|allTrustedBiddingSignals|, |key|), then 
+            [=CreateDataProperty=](|trustedBiddingSignals|, [|key|], [=Get=](|allTrustedBiddingSignals|, [|key|]).
         1. Let |startTime| be the [=current wall time=].
         1. Let |generateBidOutputJS| be the result of [=evaluating a bidding script=] with
            |biddingScript|, |ig|, |igGenerateBid|, |auctionSignals|, |perBuyerSignals|,
@@ -856,77 +868,51 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 <div algorithm>
 To <dfn>build an interest group passed to generateBid</dfn> given an [=interest group=] |ig|:
   
-  1. Let |igGenerateBid| be a new {{GenerateBidInterestGroup}}.
-  1. For each |interestGroupField| and |groupMember| in the following table
-    <table class="data">
-      <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead>
-      <tr>
-        <td>[=interest group/name=]</td>
-        <td>"{{GenerateBidInterestGroup/name}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/owner=]</td>
-        <td>"{{GenerateBidInterestGroup/owner}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/enable bidding signals prioritization=]</td>
-        <td>"{{GenerateBidInterestGroup/enableBiddingSignalsPrioritization}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/execution mode=]</td>
-        <td>"{{GenerateBidInterestGroup/executionMode}}"</td>
-      </tr>
-    </table>
-    1. [=map/Set=] |igGenerateBid|[|groupMember|] to |ig|'s |interestGroupField|.
+  1. Let |igGenerateBid| be a new {{GenerateBidInterestGroup}} with the following fields:
+    <dl>
+      <dt>{{GenerateBidInterestGroup/owner}}
+      <dd>The [=serialization of an origin|serialization=] of |ig|'s [=interest group/owner=]
+      <dt>{{GenerateBidInterestGroup/name}}
+      <dd>|ig|'s [=interest group/name=]
+      <dt>{{GenerateBidInterestGroup/enableBiddingSignalsPrioritization}}
+      <dd>|ig|'s [=interest group/enable bidding signals prioritization=]
+      <dt>{{GenerateBidInterestGroup/priorityVector}}
+      <dd>|ig|'s [=interest group/priority vector=]
+      <dt>{{GenerateBidInterestGroup/executionMode}}
+      <dd>|ig|'s [=interest group/execution mode=]
+      <dt>{{GenerateBidInterestGroup/biddingLogicURL}}
+      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/bidding url=]
+      <dt>{{GenerateBidInterestGroup/biddingWasmHelperURL}}
+      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/bidding wasm helper url=]
+      <dt>{{GenerateBidInterestGroup/updateURL}}
+      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/update url=]
+      <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}
+      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/trusted bidding signals url=]
+      <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}
+      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/trusted bidding signals keys=]
+      <dt>{{GenerateBidInterestGroup/userBiddingSignals}}
+      <dd>The [=URL serializer|serialization=] of |ig|'s [=interest group/user bidding signals=]
+      <dt>{{GenerateBidInterestGroup/ads}}
+      <dd>|ig|'s [=interest group/ads=] [=converted to an AuctionAd sequence=]
+      <dt>{{GenerateBidInterestGroup/adComponents}}
+      <dd>|ig|'s [=interest group/ad components=] [=converted to an AuctionAd sequence=]
+    </dl>
+  1. Return |igGenerateBid|.
+</div>
 
-  1. For each |interestGroupField| and |groupMember| in the following table
-    <table class="data">
-      <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead>
-      <tr>
-        <td>[=interest group/bidding url=]</td>
-        <td>"{{GenerateBidInterestGroup/biddingLogicURL}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/bidding wasm helper url=]</td>
-        <td>"{{GenerateBidInterestGroup/biddingWasmHelperURL}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/update url=]</td>
-        <td>"{{GenerateBidInterestGroup/updateURL}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/trusted bidding signals url=]</td>
-        <td>"{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}"</td>
-      </tr>
-    </table>
-    1. If |ig|'s |interestGroupField| is not null, then [=map/set=] |igGenerateBid|[|groupMember|]
-      to the [=URL serializer|serialization=] of it.
+<div algorithm>
+To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-undefined |ads|:
 
-  1. For each |interestGroupField| and |groupMember| in the following table
-    <table class="data">
-      <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead> 
-      <tr>
-        <td>[=interest group/ads=]</td>
-        <td>"{{GenerateBidInterestGroup/ads}}"</td>
-      </tr>
-      <tr>
-        <td>[=interest group/ad components=]</td>
-        <td>"{{GenerateBidInterestGroup/adComponents}}"</td>
-      </tr>
-    </table>
-    1. If |ig|'s |interestGroupField| is not null:
-      1. Let |ads| be a new [=list=].
-      1. [=list/for each] |igAd| of it:
-        1. Let |ad| be a new {{AuctionAd}}.
-        1. [=map/Set=] |ad|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
-          |igAd|'s [=interest group ad/render url=].
-        1. If |igAd|'s [=interest group ad/metadata=] is not null, then [=map/set=]
-          |ad|["{{AuctionAd/metadata}}"] to it.
-        1. [=list/Append=] |ad| to |ads|.
-      1. [=map/Set=] |igGenerateBid|[|groupMember|] to |ads|.
-
-  1. If |ig|'s [=interest group/trusted bidding signals keys=] is not null, then [=map/set]
-    |igGenerateBid|{{GenerateBidInterestGroup/trustedBiddingSignalsKeys}} to it.
+  1. If |ads| is undefined, then return undefined.
+  1. Let |adsIDL| be a new [=list=].
+  1. [=list/for each] |ad| of |ads|:
+    1. Let |adIDL| be a new {{AuctionAd}}.
+    1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
+      |ad|'s [=interest group ad/render url=].
+    1. If |ad|'s [=interest group ad/metadata=] is not undefined, then [=map/set=]
+      |adIDL|["{{AuctionAd/metadata}}"] to it.
+    1. [=list/Append=] |adIDL| to |adsIDL|.
+  1. Return |adsIDL|
 </div>
 
 <div algorithm>
@@ -976,7 +962,7 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
   1. Set |bidValue| to |generatedBid|'s [=generated bid/modified bid=].
 1. Let |owner| be |generatedBid|'s [=generated bid/interest group=]'s [=interest group/owner=].
 1. Let |browserSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=] and whose
-  [=map/values=] are {{any}}.
+  [=map/values=] are {{any}}. TODO: Change to an IDL record<>.
 1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to |topWindowOrigin|'s [=origin/host=].
 1. [=map/Set=] |browserSignals|["`interestGroupOwner`"] to |owner|.
 1. [=map/Set=] |browserSignals|["`renderURL`"] to |generatedBid|'s [=generated bid/ad descriptor=]'s
@@ -987,10 +973,10 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
   [=generated bid/bid duration=].
 1. If |scoringDataVersion| is not null:
   1. [=map/Set=] |browserSignals|["`dataVersion`"] to |scoringDataVersion|.
-1. TODO: Remove fields of |auctionConfig| that don't pass through.
 1. Let |scoreAdOutput| be the result of [=evaluating a scoring script=] with
-   |decisionLogicScript|, « |adMetadata|, |bidValue|, |auctionConfig|, |trustedScoringSignals|,
-   |browserSignals| », and |auctionConfig|'s [=auction config/seller timeout=].
+   |decisionLogicScript|, « |adMetadata|, |bidValue|, |auctionConfig|'s
+   [=auction config/config idl=], |trustedScoringSignals|, |browserSignals| », and
+   |auctionConfig|'s [=auction config/seller timeout=].
 1. If |scoreAdOutput| is an [=abrupt completion=], [=iteration/continue=].
 1. If |isComponentAuction| is true, and |scoreAdOutput|'s
   [=score ad output/allow component auction=] is false, return.
@@ -1163,15 +1149,17 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
     1. If |isBiddingSignal| is true:
       1. Set |formatVersion| to the result of [=header list/getting a structured field value=]
         given [:X-protected-audience-bidding-signals-format-version:] and "`item`" from |headers|.
-    1. Set |signals| to the result of [=parsing JSON bytes to an Infra value=] |responseBody|.
+    1. Set |signals| to the result of [=parsing JSON bytes to a JavaScript value=] |responseBody|.
   1. Wait for |signals| to be set.
-  1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,
-    null ».
+  1. Return « null, null » if any of the following conditions hold:
+    * |signals| is a parsing exception;
+    * |signals| [=is not an Object=];
+    * [=IsArray=](|signals|);
   1. If |formatVersion| is 2:
-    1. If |signals|["`keys`"] [=map/exists=], then set |signals| to |signals|["`keys`"].
+    1. If ![=HasProperty=](|signals|, "`keys`"), return « null, null ».
+    1. Set |signals| to [=Get=](|signals|, "`keys`").
     1. TODO: handle priority vector.
-    1. Otherwise, return « null, null ».
-    1. If |signals| is not an [=ordered map=], return « null, null ».
+    1. If |signals| [=is not an Object=], or [=IsArray=](|signals|), return « null, null ».
   1. Return « |signals|, |dataVersion| ».
 </div>
 
@@ -1425,7 +1413,7 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
     1. Let |browserSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
       given |browserSignals|.      
     1. Return the result of [=evaluating a script=] with |global|, |script|, "`generateBid`",
-      [ |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS| ],
+      « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS| »,
       and |timeout|.
 </div>
 
@@ -1482,8 +1470,8 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
 
 <div algorithm>
   To <dfn>evaluate a script</dfn> with a [=realm/global object=] |global|, [=string=] |script|,
-  [=string=] |functionName|, an ECMAScript Array object |arguments|, and an integer millisecond
-  duration |timeout|, run these steps.
+  [=string=] |functionName|, a [=list=] |arguments|, and an integer millisecond duration |timeout|,
+  run these steps.
   They return a [=ECMAScript/Completion Record=], which is either an [=abrupt completion=] (in the case of
   a parse failure or execution error), or a normal completion populated with the
   [=ECMAScript/ECMAScript language value=] result of invoking |functionName|.
@@ -1889,9 +1877,9 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
 
         <dt>"`priorityVector`"
         <dd>
-        1. If |value| is null or an [=ordered map=] whose [=map/keys=] are
-          [=strings=] and whose [=map/values=] are {{double}}, set |ig|'s
-          [=interest group/priority vector=] to |value|.
+        1. If |value| is undefined or an [=ordered map=] whose [=map/keys=] are [=strings=] and
+          whose [=map/values=] are {{double}}, set |ig|'s [=interest group/priority vector=] to
+          |value|.
         1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
 
         <dt>"`prioritySignalsOverrides`"
@@ -2016,8 +2004,8 @@ dictionary GenerateBidInterestGroup {
   required USVString owner;
   required USVString name;
 
-  double priority = 0.0;
   boolean enableBiddingSignalsPrioritization = false;
+  record<DOMString, double> priorityVector;
 
   DOMString executionMode = "compatibility";
   USVString biddingLogicURL;
@@ -2031,7 +2019,7 @@ dictionary GenerateBidInterestGroup {
 };
 </xmp>
 
-{{GenerateBidInterestGroup}} is {{AuctionAdInterestGroup}} with its `priorityVector` and
+{{GenerateBidInterestGroup}} is {{AuctionAdInterestGroup}} with its `priority` and
 `prioritySignalsOverrides` fields removed.
 `priority` and `prioritySignalsOverrides` are not included when interest group is passed to
 `generateBid()` because they can be modified by `generatedBid()` calls, so could theoretically be
@@ -2059,55 +2047,55 @@ An interest group is a [=struct=] with the following items:
 :: A [=boolean=], initially false. Being true if the interest group's priority should be
   calculated using vectors from bidding signals fetch.
 : <dfn>priority vector</dfn>
-:: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
+:: Undefined or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
   {{double}}. Its dot product with the {{AuctionAdConfig/perBuyerPrioritySignals}} will be used
   in place of [=interest group/priority=], if set.
 : <dfn>priority signals overrides</dfn>
-:: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
+:: Undefined or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
   {{double}}. Overrides the {{AuctionAdConfig}}'s corresponding priority signals.
 : <dfn>execution mode</dfn>
 :: A [=string=], initially "<code>compatibility</code>". Acceptable values are
   "<code>compatibility</code>" and "<code>group-by-origin</code>".
   TODO: Define spec for these execution modes, link to it from here and explain these modes.
 : <dfn>bidding url</dfn>
-:: Null or a [=URL=]. The URL to fetch the buyer's JavaScript from.
+:: Undefined or a [=URL=]. The URL to fetch the buyer's JavaScript from.
   <p class="note">
-    When non-null, the [=interest group/bidding url=]'s [=origin=] will always be [=same origin=]
+    When defined, the [=interest group/bidding url=]'s [=origin=] will always be [=same origin=]
     with [=interest group/owner=].
   </p>
 : <dfn>bidding wasm helper url</dfn>
-:: Null or a [=URL=]. Lets the bidder provide computationally-expensive subroutines in WebAssembly,
-  in addition to JavaScript, to be driven from the JavaScript function provided by
+:: Undefined or a [=URL=]. Lets the bidder provide computationally-expensive subroutines in
+  WebAssembly, in addition to JavaScript, to be driven from the JavaScript function provided by
   [=interest group/bidding url=].
   <p class="note">
-    When non-null, the [=interest group/bidding wasm helper url=]'s [=origin=] will always be
+    When defined, the [=interest group/bidding wasm helper url=]'s [=origin=] will always be
     [=same origin=] with [=interest group/owner=].
   </p>
 : <dfn>update url</dfn>
-:: Null or a [=URL=]. Provides a mechanism for the group's owner to periodically update the
+:: Undefined or a [=URL=]. Provides a mechanism for the group's owner to periodically update the
   attributes of the interest group. See [interest group updates](#interest-group-updates).
   <p class="note">
-    When non-null, the [=interest group/update url=]'s [=origin=] will always be [=same origin=]
+    When defined, the [=interest group/update url=]'s [=origin=] will always be [=same origin=]
     with [=interest group/owner=].
   </p>
 : <dfn>trusted bidding signals url</dfn>
-:: Null or a [=URL=]. Provide a mechanism for making real-time data available for use at bidding
-  time. See [=building trusted bidding signals url=].
+:: Undefined or a [=URL=]. Provide a mechanism for making real-time data available for use at
+  bidding time. See [=building trusted bidding signals url=].
   <p class="note">
-    When non-null, the [=interest group/trusted bidding signals url=]'s [=origin=] will always be
+    When defined, the [=interest group/trusted bidding signals url=]'s [=origin=] will always be
     [=same origin=] with [=interest group/owner=].
   </p>
 : <dfn>trusted bidding signals keys</dfn>
-:: Null or a [=list=] of [=string=]. See [=building trusted bidding signals url=].
+:: Undefined or a [=list=] of [=string=]. See [=building trusted bidding signals url=].
 : <dfn>user bidding signals</dfn>
-:: Null or a [=string=]. Additional metadata that the owner can use during on-device bidding.
+:: Undefined or a [=string=]. Additional metadata that the owner can use during on-device bidding.
 : <dfn>ads</dfn>
-:: Null or a [=list=] of [=interest group ad=]. Contains various ads that the interest group might
-  show.
+:: Undefined or a [=list=] of [=interest group ad=]. Contains various ads that the interest group
+  might show.
 : <dfn>ad components</dfn>
-:: Null or a [=list=] of [=interest group ad=]. Contains various ad components (or "products") that
-  can be used to construct ads composed of multiple pieces — a top-level ad template "container"
-  which includes some slots that can be filled in with specific "products".
+:: Undefined or a [=list=] of [=interest group ad=]. Contains various ad components (or "products")
+  that can be used to construct ads composed of multiple pieces — a top-level ad template
+  "container" which includes some slots that can be filled in with specific "products".
 : <dfn>joining origin</dfn>
 :: An [=origin=]. The top level page origin from where the interest group was joined.
 : <dfn>join counts</dfn>
@@ -2139,7 +2127,7 @@ An interest group ad is a [=struct=] with the following items:
   be returned by {{Navigator/runAdAuction()}}. This URL is intended to be loaded into an ad
   <{iframe}> (or a <{fencedframe}>).
 : <dfn>metadata</dfn>
-:: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
+:: Undefined or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
 
 </dl>
 
@@ -2239,6 +2227,8 @@ An auction config is a [=struct=] with the following items:
 :: An integer, initially 0. The number of [=auction config/auction signals=],
   [=auction config/per buyer signals=], [=auction config/per buyer timeouts=], or
   [=auction config/seller signals=] whose {{Promise}}s are not yet resolved.
+: <dfn>config idl</dfn>
+:: {{AuctionAdConfig}}.
 
 </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -30,11 +30,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/C
     text: immediately; url: immediately
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
-    text: abrupt completion; url: sec-completion-record-specification-type
-    text: Number; url: sec-ecmascript-language-types-number-type
     text: ParseScript; url: sec-parse-script
     text: ScriptEvaluation; url: sec-runtime-semantics-scriptevaluation
-    text: throw completion; url: sec-completion-record-specification-type
+    text: Number; url: sec-ecmascript-language-types-number-type
 spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
   type: dfn
     text: structured header; url: top
@@ -1429,7 +1427,7 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|:
     [=auction config/decision logic url=].
   1. Let |reportResultOutputJS| be the result of [=evaluating a reporting script=] with
      |sellerReportingScript|, "`reportResult`", and « |config|, |browserSignals|».
-  1. If |reportResultOutputJS| is an [=abrupt completion=], [=iteration/continue=].
+  1. If |reportResultOutputJS| is an [=ECMAScript/abrupt completion=], [=iteration/continue=].
   1. [=map/Remove=] |browserSignals|["`dataVersion`"].
   1. [=map/Remove=] |browserSignals|["`modifiedBid`"].
   1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].

--- a/spec.bs
+++ b/spec.bs
@@ -566,18 +566,19 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. Set |auctionConfig|'s [=auction config/auction signals=] to
       |config|["{{AuctionAdConfig/auctionSignals}}"].
     1. Increment |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/auction signals=] with |result|:
+    1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps
+      [=upon fulfillment=] of |auctionConfig|'s [=auction config/auction signals=] with |result|:    
       1. Let |auctionSignalsJSON| be the result of
         [=serializing a JavaScript value to a JSON string=], given |result|.
       1. If no exception was [=exception/thrown=] in the previous step:
         1. Set |auctionConfig|'s [=auction config/auction signals=] to |auctionSignalsJSON|.
-        1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"] to
-          |result|.
-      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon rejection=] of |auctionConfig|'s [=auction config/auction signals=]:
+        1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"]
+          to |result|.
+        1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+    1. [=Upon rejection=] of |resolvedAndTypeChecked|:
       1. Set |auctionConfig|'s [=auction config/auction signals=] to failure.
-      1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"] to
-        undefined.
+      1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"]
+        to undefined.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
   1. Otherwise, set |auctionConfig|'s [=auction config/auction signals=] to the result of
     [=serializing a JavaScript value to a JSON string=], given
@@ -794,8 +795,6 @@ a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
-  1. If |dataVersion| is not null:
-    1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.
@@ -928,6 +927,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
     1. Let « |allTrustedBiddingSignals|, |dataVersion| » be the result of [=fetching trusted signals=]
       with |biddingSignalsUrl| and true.
+    1. If |dataVersion| is not null:
+      1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
     1. [=map/For each=] joiningOrigin → |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. If |ig|'s [=interest group/bidding url=] is null, [=iteration/continue=].
@@ -1423,10 +1424,10 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|:
     [=auction config/decision logic url=].
   1. Let |reportResultOutputJS| be the result of [=evaluating a reporting script=] with
      |sellerReportingScript|, "`reportResult`", and « |config|, |browserSignals|».
-  1. If |reportResultOutputJS| is an [=ECMAScript/abrupt completion=], [=iteration/continue=].
   1. [=map/Remove=] |browserSignals|["`dataVersion`"].
   1. [=map/Remove=] |browserSignals|["`modifiedBid`"].
   1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].
+  1. If |reportResultOutputJS| is an [=ECMAScript/abrupt completion=], return « null, |browserSignals| ».
   1. Let |reportResultOutputIDL| be the result of [=converted to an IDL value|converting=]
      |reportResultOutputJS| to a {{ReportResultOutput}}.
   1. If an exception was [=exception/thrown=] in the previous step, return « null, |browserSignals| ».
@@ -2291,13 +2292,13 @@ dictionary PreviousWin {
 dictionary BiddingBrowserSignals {
   required DOMString topWindowHostname;
   required USVString seller;
-  required double joinCount;
-  required double bidCount;
+  required long joinCount;
+  required long bidCount;
 
   USVString topLevelSeller;
   sequence<PreviousWin> prevWinsMs;
-  object? wasmHelper;
-  long dataVersion;
+  object wasmHelper;
+  unsigned long dataVersion;
 };
 </xmp>
 

--- a/spec.bs
+++ b/spec.bs
@@ -817,7 +817,7 @@ a [=moment=] |auctionStartTime|:
     1. If |allTrustedBiddingSignals| is an [=ordered map=] and |allTrustedBiddingSignals|[|key|]
       [=map/exists=], then [=map/set=] |trustedBiddingSignals|[|key|] to
       |allTrustedBiddingSignals|[|key|].
-  1. Return tbe the result of [=evaluating a bidding script=] with |biddingScript|, |ig|,
+  1. Return the result of [=evaluating a bidding script=] with |biddingScript|, |ig|,
     |igGenerateBid|, |auctionSignals|, |perBuyerSignals|, |trustedBiddingSignals|, |browserSignals|,
     and |perBuyerTimeout|.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -136,7 +136,8 @@ are:
     |group|["{{AuctionAdInterestGroup/prioritySignalsOverrides}}"].
   1. Set |interestGroup|'s [=interest group/execution mode=] to
     |group|["{{AuctionAdInterestGroup/executionMode}}"].
-  1. For each |groupMember| and |interestGroupField| in the following table <table class="data">
+  1. For each |groupMember| and |interestGroupField| in the following table
+    <table class="data">
       <thead><tr><th>Group member</th><th>Interest group field</th></tr></thead>
       <tr>
         <td>"{{AuctionAdInterestGroup/biddingLogicURL}}"</td>
@@ -173,7 +174,8 @@ are:
       [=serializing a JavaScript value to a JSON string=], given
       |group|["{{AuctionAdInterestGroup/userBiddingSignals}}"]. This can [=exception/throw=] a
       {{TypeError}}.
-  1. For each |groupMember| and |interestGroupField| in the following table <table class="data">
+  1. For each |groupMember| and |interestGroupField| in the following table
+    <table class="data">
       <thead><tr><th>Group member</th><th>Interest group field</th></tr></thead>
       <tr>
         <td>"{{AuctionAdInterestGroup/ads}}"</td>
@@ -720,54 +722,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       1. [=list/For each=] |ig| of |groups|:
         1. TODO: If rerunning `generateBid()` with only k-anonymous ads, remember to swap out |ig|'s ads
           to just k-anonymous ones so that [=validating an ad url=] excludes the non-k-anonymous ones.
-        1. Let |igIDL| be a new {{AuctionAdInterestGroup}}.
-        1. [=map/Set=] |igIDL|["{{AuctionAdInterestGroup/owner}}"] to |ig|'s [=interest group/owner=].
-        1. [=map/Set=] |igIDL|["{{AuctionAdInterestGroup/name}}"] to |ig|'s [=interest group/name=].
-        1. For each |interestGroupField| and |groupMember| in the following table <table class="data">
-            <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead>
-            <tr>
-              <td>[=interest group/enable bidding signals prioritization=]</td>
-              <td>"{{AuctionAdInterestGroup/enableBiddingSignalsPrioritization}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/execution mode=]</td>
-              <td>"{{AuctionAdInterestGroup/executionMode}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/bidding url=]</td>
-              <td>"{{AuctionAdInterestGroup/biddingLogicURL}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/bidding wasm helper url=]</td>
-              <td>"{{AuctionAdInterestGroup/biddingWasmHelperURL}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/update url=]</td>
-              <td>"{{AuctionAdInterestGroup/updateURL}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/trusted bidding signals url=]</td>
-              <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsURL}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/trusted bidding signals keys=]</td>
-              <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsKeys}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/trusted bidding signals url=]</td>
-              <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsURL}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/ads=]</td>
-              <td>"{{AuctionAdInterestGroup/ads}}"</td>
-            </tr>
-            <tr>
-              <td>[=interest group/ad components=]</td>
-              <td>"{{AuctionAdInterestGroup/adComponents}}"</td>
-            </tr>           
-          </table>
-          1. If |ig|'s |interestGroupField| is not null, then [=map/set=] |igIDL|[|groupMember|] to it.
-
+        1. Let |igGenerateBid| be the result of [=building an interest group passed to generateBid=]
+          with |ig|.
         1. [=map/Set=] |browserSignals|["`joinCount`"] to the sum of |ig|'s
            [=interest group/join counts=] for all days within the last 30 days.
         1. [=map/Set=] |browserSignals|["`bidCount`"] to the sum of |ig|'s
@@ -794,8 +750,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             |allTrustedBiddingSignals|[|key|].
         1. Let |startTime| be the [=current wall time=].
         1. Let |generateBidOutputJS| be the result of [=evaluating a bidding script=] with
-           |biddingScript|, |ig|, « |igIDL|, |auctionSignals|, |perBuyerSignals|,
-           |trustedBiddingSignals|, |browserSignals| », and |perBuyerTimeout|.
+           |biddingScript|, |ig|, |igGenerateBid|, |auctionSignals|, |perBuyerSignals|,
+           |trustedBiddingSignals|, |browserSignals|, and |perBuyerTimeout|.
         1. Let |duration| be the [=current wall time=] minus |startTime| in milliseconds.
         1. If |generateBidOutputJS| is an [=abrupt completion=], [=iteration/continue=].
         1. Let |generateBidOutputIDL| be the result of [=converted to an IDL value|converting=]
@@ -822,6 +778,82 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. Run [=report win=] with |leadingBidInfo|, |sellerSignals|, and |reportResultBrowserSignals|.
 1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
 
+</div>
+
+<div algorithm>
+To <dfn>build an interest group passed to generateBid</dfn> given an [=interest group=] |ig|:
+  
+  1. Let |igGenerateBid| be a new {{GenerateBidInterestGroup}}.
+  1. For each |interestGroupField| and |groupMember| in the following table
+    <table class="data">
+      <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead>
+      <tr>
+        <td>[=interest group/name=]</td>
+        <td>"{{GenerateBidInterestGroup/name}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/owner=]</td>
+        <td>"{{GenerateBidInterestGroup/owner}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/enable bidding signals prioritization=]</td>
+        <td>"{{GenerateBidInterestGroup/enableBiddingSignalsPrioritization}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/execution mode=]</td>
+        <td>"{{GenerateBidInterestGroup/executionMode}}"</td>
+      </tr>
+    </table>
+    1. [=map/Set=] |igGenerateBid|[|groupMember|] to |ig|'s |interestGroupField|.
+
+  1. For each |interestGroupField| and |groupMember| in the following table
+    <table class="data">
+      <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead>
+      <tr>
+        <td>[=interest group/bidding url=]</td>
+        <td>"{{GenerateBidInterestGroup/biddingLogicURL}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/bidding wasm helper url=]</td>
+        <td>"{{GenerateBidInterestGroup/biddingWasmHelperURL}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/update url=]</td>
+        <td>"{{GenerateBidInterestGroup/updateURL}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/trusted bidding signals url=]</td>
+        <td>"{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}"</td>
+      </tr>
+    </table>
+    1. If |ig|'s |interestGroupField| is not null, then [=map/set=] |igGenerateBid|[|groupMember|]
+      to the [=URL serializer|serialization=] of it.
+
+  1. For each |interestGroupField| and |groupMember| in the following table
+    <table class="data">
+      <thead><tr><th>Interest group field</th><th>Group member</th></tr></thead> 
+      <tr>
+        <td>[=interest group/ads=]</td>
+        <td>"{{GenerateBidInterestGroup/ads}}"</td>
+      </tr>
+      <tr>
+        <td>[=interest group/ad components=]</td>
+        <td>"{{GenerateBidInterestGroup/adComponents}}"</td>
+      </tr>
+    </table>
+    1. If |ig|'s |interestGroupField| is not null:
+      1. Let |ads| be a new [=list=].
+      1. [=list/for each] |igAd| of it:
+        1. Let |ad| be a new {{AuctionAd}}.
+        1. [=map/Set=] |ad|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
+          |igAd|'s [=interest group ad/render url=].
+        1. If |igAd|'s [=interest group ad/metadata=] is not null, then [=map/set=]
+          |ad|["{{AuctionAd/metadata}}"] to it.
+        1. [=list/Append=] |ad| to |ads|.
+      1. [=map/Set=] |igGenerateBid|[|groupMember|] to |ads|.
+
+  1. If |ig|'s [=interest group/trusted bidding signals keys=] is not null, then [=map/set]
+    |igGenerateBid|{{GenerateBidInterestGroup/trustedBiddingSignalsKeys}} to it.
 </div>
 
 <div algorithm>
@@ -1296,26 +1328,32 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
 (initially null).
 
 <div algorithm>
-  To <dfn>evaluate a bidding script</dfn> given a [=string=] |script|, an [=interest group=] |ig|,
-  a [=list=] of arguments |arguments|, and an integer millisecond duration |timeout|:
+  To <dfn>evaluate a bidding script</dfn> given a [=string=] |script|, an [=interest group=] |ig|, a
+  {{GenerateBidInterestGroup}} |igGenerateBid|, a [=string=]-or-null |auctionSignals|, an
+  [=ordered map=]-or-null |perBuyerSignals|, an [=ordered map=] |trustedBiddingSignals|, an
+  [=ordered map=] |browserSignals|, and an integer millisecond [=duration=] |timeout|:
 
-    1. Let |groupHasAdComponents| be true.
-    1. If |ig|'s [=interest group/ad components=] is null:
-      1. Set |groupHasAdComponents| be false.
     1. Let |global| be a new {{InterestGroupBiddingScriptRunnerGlobalScope}}.
     1. Set |global|'s
-      [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=] to
-      |groupHasAdComponents|.
-    1. Let |numArguments| be |arguments|'s [=list/size=].
-    1. Let |browserSignals| be |arguments|[|numArguments| - 1].
-    1. Let |isComponentAuction| be false.
-    1. If |browserSignals|["`topLevelSeller`"] is not null:
-      1. Set |isComponentAuction| to true.
+      [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=] to true if |ig|'s
+      [=interest group/ad components=] is not null, or false otherwise.
     1. Set |global|'s
-      [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=] to |isComponentAuction|.
+      [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=] to true if
+      |browserSignals|["`topLevelSeller`"] is not null, or false otherwise.
     1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/interest group=] to |ig|.
+    1. Let |igJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
+      given |igGenerateBid|.
+    1. Let |auctionSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
+      given |auctionSignals|.
+    1. Let |perBuyerSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
+      given |perBuyerSignals|.
+    1. Let |trustedBiddingSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
+      given |trustedBiddingSignals|.
+    1. Let |browserSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
+      given |browserSignals|.      
     1. Return the result of [=evaluating a script=] with |global|, |script|, "`generateBid`",
-      |arguments|, and |timeout|.
+      [ |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS| ],
+      and |timeout|.
 </div>
 
 <div algorithm>
@@ -1370,8 +1408,9 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
 </div>
 
 <div algorithm>
-  To <dfn>evaluate a script</dfn> with a [=realm/global object=] |global|, [=string=] |script|, [=string=]
-  |functionName|, a [=list=] |arguments|, and an integer millisecond duration |timeout|, run these steps.
+  To <dfn>evaluate a script</dfn> with a [=realm/global object=] |global|, [=string=] |script|,
+  [=string=] |functionName|, an ECMAScript Array object |arguments|, and an integer millisecond
+  duration |timeout|, run these steps.
   They return a [=ECMAScript/Completion Record=], which is either an [=abrupt completion=] (in the case of
   a parse failure or execution error), or a normal completion populated with the
   [=ECMAScript/ECMAScript language value=] result of invoking |functionName|.
@@ -1429,11 +1468,8 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
        |finalCompletion| to |F| and jump to the step labeled <i><a
        href=#evaluate-script-return>return</a></i>.
 
-    1. Let |argumentsJS| be the result of
-      [=converted to ECMAScript values|converting to ECMAScript values=] given |arguments|.
-
     1. Set |finalCompletion| be [=ECMAScript/Completion Record|Completion=]([$Call$](F, `undefined`,
-       |argumentsJS|)). 
+       |arguments|)).
        
        In |timeout| milliseconds, if the invocation of [$Call$] has not completed,
        [=immediately=] interrupt the execution and set |finalCompletion| to a new
@@ -1899,6 +1935,34 @@ Issue(WICG/turtledove#522): Move from "`*`" to "`self`".
 
 
 # Structures # {#structures}
+
+
+<xmp class="idl">
+
+dictionary GenerateBidInterestGroup {
+  required USVString owner;
+  required USVString name;
+
+  double priority = 0.0;
+  boolean enableBiddingSignalsPrioritization = false;
+
+  DOMString executionMode = "compatibility";
+  USVString biddingLogicURL;
+  USVString biddingWasmHelperURL;
+  USVString updateURL;
+  USVString trustedBiddingSignalsURL;
+  sequence<USVString> trustedBiddingSignalsKeys;
+  any userBiddingSignals;
+  sequence<AuctionAd> ads;
+  sequence<AuctionAd> adComponents;
+};
+</xmp>
+
+{{GenerateBidInterestGroup}} is {{AuctionAdInterestGroup}} with its `priorityVector` and
+`prioritySignalsOverrides` fields removed.
+`priority` and `prioritySignalsOverrides` are not included when interest group is passed to
+`generateBid()` because they can be modified by `generatedBid()` calls, so could theoretically be
+used to create a cross-site profile of a user accessible to `generateBid()` methods, otherwise.
 
 <h3 dfn-type=dfn>Interest group</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -461,7 +461,7 @@ dictionary AuctionAdConfig {
   required USVString decisionLogicURL;
   USVString trustedScoringSignalsURL;
   sequence<USVString> interestGroupBuyers;
-  any auctionSignals;
+  Promise<any> auctionSignals;
   any sellerSignals;
   USVString directFromSellerSignals;
   unsigned long long sellerTimeout;
@@ -562,27 +562,23 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. [=list/Append=] |buyer| to |buyers|.
   1. Set |auctionConfig|'s [=auction config/interest group buyers=] to |buyers|.
 1. If |config|["{{AuctionAdConfig/auctionSignals}}"] [=map/exists=]:
-  1. If |config|["{{AuctionAdConfig/auctionSignals}}"] is a {{Promise}}:
-    1. Set |auctionConfig|'s [=auction config/auction signals=] to
-      |config|["{{AuctionAdConfig/auctionSignals}}"].
-    1. Increment |auctionConfig|'s [=auction config/pending promise count=].
-    1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps
-      [=upon fulfillment=] of |auctionConfig|'s [=auction config/auction signals=] with |result|:    
-      1. Let |auctionSignalsJSON| be the result of
-        [=serializing a JavaScript value to a JSON string=], given |result|.
-      1. If no exception was [=exception/thrown=] in the previous step:
-        1. Set |auctionConfig|'s [=auction config/auction signals=] to |auctionSignalsJSON|.
-        1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"]
-          to |result|.
-        1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon rejection=] of |resolvedAndTypeChecked|:
-      1. Set |auctionConfig|'s [=auction config/auction signals=] to failure.
-      1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"]
-        to undefined.
-      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. Otherwise, set |auctionConfig|'s [=auction config/auction signals=] to the result of
-    [=serializing a JavaScript value to a JSON string=], given
+  1. Set |auctionConfig|'s [=auction config/auction signals=] to
     |config|["{{AuctionAdConfig/auctionSignals}}"].
+  1. Increment |auctionConfig|'s [=auction config/pending promise count=].
+  1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps
+    [=upon fulfillment=] of |auctionConfig|'s [=auction config/auction signals=] with |result|:    
+    1. Let |auctionSignalsJSON| be the result of
+      [=serializing a JavaScript value to a JSON string=], given |result|.
+    1. If no exception was [=exception/thrown=] in the previous step:
+      1. Set |auctionConfig|'s [=auction config/auction signals=] to |auctionSignalsJSON|.
+      1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"]
+        to |result|.
+      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon rejection=] of |resolvedAndTypeChecked|:
+    1. Set |auctionConfig|'s [=auction config/auction signals=] to failure.
+    1. Set |auctionConfig|'s [=auction config/config idl=]["{{AuctionAdConfig/auctionSignals}}"]
+      to undefined.
+    1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/sellerSignals}}"] [=map/exists=]:
   1. If |config|["{{AuctionAdConfig/sellerSignals}}"] is a {{Promise}}:
     1. Set |auctionConfig|'s [=auction config/seller signals=] to

--- a/spec.bs
+++ b/spec.bs
@@ -265,34 +265,34 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 1. 8 bytes, which is the size of |ig|'s [=interest group/priority=].
 1. The [=string/length=] of |ig|'s [=interest group/execution mode=].
 1. 2 bytes, which is the size of |ig|'s [=interest group/enable bidding signals prioritization=].
-1. If |ig|'s [=interest group/priority vector=] is not undefined, [=map/for each=] |key| → |value|
-  of [=interest group/priority vector=]:
+1. If |ig|'s [=interest group/priority vector=] is not null, [=map/for each=] |key| → |value| of
+  [=interest group/priority vector=]:
   1. The [=string/length=] of |key|.
   1. 8 bytes, which is the size of |value|.
-1. If |ig|'s [=interest group/priority signals overrides=] is not undefined, [=map/for each=]
-  |key| → |value| of [=interest group/priority signals overrides=]:
+1. If |ig|'s [=interest group/priority signals overrides=] is not null, [=map/for each=] |key| → |value| of
+  [=interest group/priority signals overrides=]:
   1. The [=string/length=] of |key|.
   1. 8 bytes, which is the size of |value|.
 1. The size of [=interest group/execution mode=].
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/bidding url=], if the field is not undefined.
+  [=interest group/bidding url=], if the field is not null.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/bidding wasm helper url=], if the field is not undefined.
+  [=interest group/bidding wasm helper url=], if the field is not null.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/update url=], if the field is not undefined.
+  [=interest group/update url=], if the field is not null.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
-  [=interest group/trusted bidding signals url=], if the field is not undefined.
+  [=interest group/trusted bidding signals url=], if the field is not null.
 1. [=list/For each=] |key| of |ig|'s [=interest group/trusted bidding signals keys=]:
   1. The [=string/length=] of |key|.
 1. The [=string/length=] of |ig|'s [=interest group/user bidding signals=].
-1. If |ig|'s [=interest group/ads=] is not undefined, [=list/for each=] |ad| of it:
+1. If |ig|'s [=interest group/ads=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
-  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not undefined.
-1. If |ig|'s [=interest group/ad components=] is not undefined, [=list/for each=] |ad| of it:
+  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
+1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
-  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not undefined.
+  1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
 
 </div>
 
@@ -814,7 +814,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       with |biddingSignalsUrl| and true.
     1. [=map/For each=] joiningOrigin → |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
-        1. If |ig|'s [=interest group/bidding url=] is undefined, [=iteration/continue=].
+        1. If |ig|'s [=interest group/bidding url=] is null, [=iteration/continue=].
         1. TODO: If rerunning `generateBid()` with only k-anonymous ads, remember to swap out |ig|'s ads
           to just k-anonymous ones so that [=validating an ad url=] excludes the non-k-anonymous ones.
         1. Let |igGenerateBid| be the result of [=building an interest group passed to generateBid=]
@@ -833,7 +833,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
         1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
           [=interest group/bidding url=].
         1. If |biddingScript| is failure, [=iteration/continue=].
-        1. If |ig|'s [=interest group/bidding wasm helper url=] is not undefined:
+        1. If |ig|'s [=interest group/bidding wasm helper url=] is not null:
           1. Let |wasmModuleObject| be the result of [=fetching WebAssembly=] with |ig|'s
             [=interest group/bidding wasm helper url=].
           1. If |wasmModuleObject| is not failure:
@@ -886,7 +886,7 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dt>{{GenerateBidInterestGroup/enableBiddingSignalsPrioritization}}
       <dd>|ig|'s [=interest group/enable bidding signals prioritization=]
       <dt>{{GenerateBidInterestGroup/priorityVector}}
-      <dd>|ig|'s [=interest group/priority vector=]
+      <dd>|ig|'s [=interest group/priority vector=] if not null, otherwise undefined
       <dt>{{GenerateBidInterestGroup/executionMode}}
       <dd>|ig|'s [=interest group/execution mode=]
       <dt>{{GenerateBidInterestGroup/biddingLogicURL}}
@@ -910,22 +910,22 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
 </div>
 
 <div algorithm>
-To <dfn>serialize a URL</dfn> given a [=URL=]-or-undefined |url|:
+To <dfn>serialize a URL</dfn> given a [=URL=]-or-null |url|:
 
-  1. If |url| is undefined, then return undefined.
+  1. If |url| is null, then return undefined.
   1. Return the [=URL serializer|serialization=] of |url|.
 </div>
 
 <div algorithm>
-To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-undefined |ads|:
+To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
 
-  1. If |ads| is undefined, then return undefined.
+  1. If |ads| is null, then return undefined.
   1. Let |adsIDL| be a new [=list=].
   1. [=list/for each] |ad| of |ads|:
     1. Let |adIDL| be a new {{AuctionAd}}.
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
-    1. If |ad|'s [=interest group ad/metadata=] is not undefined, then [=map/set=]
+    1. If |ad|'s [=interest group ad/metadata=] is not null, then [=map/set=]
       |adIDL|["{{AuctionAd/metadata}}"] to the result of
       [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
     1. [=list/Append=] |adIDL| to |adsIDL|.
@@ -1894,7 +1894,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
 
         <dt>"`priorityVector`"
         <dd>
-        1. If |value| is undefined or an [=ordered map=] whose [=map/keys=] are [=strings=] and
+        1. If |value| is null or an [=ordered map=] whose [=map/keys=] are [=strings=] and
           whose [=map/values=] are {{double}}, set |ig|'s [=interest group/priority vector=] to
           |value|.
         1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
@@ -2036,55 +2036,55 @@ An interest group is a [=struct=] with the following items:
 :: A [=boolean=], initially false. Being true if the interest group's priority should be
   calculated using vectors from bidding signals fetch.
 : <dfn>priority vector</dfn>
-:: Undefined or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
+:: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
   {{double}}. Its dot product with the {{AuctionAdConfig/perBuyerPrioritySignals}} will be used
   in place of [=interest group/priority=], if set.
 : <dfn>priority signals overrides</dfn>
-:: Undefined or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
+:: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
   {{double}}. Overrides the {{AuctionAdConfig}}'s corresponding priority signals.
 : <dfn>execution mode</dfn>
 :: A [=string=], initially "<code>compatibility</code>". Acceptable values are
   "<code>compatibility</code>" and "<code>group-by-origin</code>".
   TODO: Define spec for these execution modes, link to it from here and explain these modes.
 : <dfn>bidding url</dfn>
-:: Undefined or a [=URL=]. The URL to fetch the buyer's JavaScript from.
+:: Null or a [=URL=]. The URL to fetch the buyer's JavaScript from.
   <p class="note">
-    When defined, the [=interest group/bidding url=]'s [=origin=] will always be [=same origin=]
+    When non-null, the [=interest group/bidding url=]'s [=origin=] will always be [=same origin=]
     with [=interest group/owner=].
   </p>
 : <dfn>bidding wasm helper url</dfn>
-:: Undefined or a [=URL=]. Lets the bidder provide computationally-expensive subroutines in
-  WebAssembly, in addition to JavaScript, to be driven from the JavaScript function provided by
+:: Null or a [=URL=]. Lets the bidder provide computationally-expensive subroutines in WebAssembly,
+  in addition to JavaScript, to be driven from the JavaScript function provided by
   [=interest group/bidding url=].
   <p class="note">
-    When defined, the [=interest group/bidding wasm helper url=]'s [=origin=] will always be
+    When non-null, the [=interest group/bidding wasm helper url=]'s [=origin=] will always be
     [=same origin=] with [=interest group/owner=].
   </p>
 : <dfn>update url</dfn>
-:: Undefined or a [=URL=]. Provides a mechanism for the group's owner to periodically update the
+:: Null or a [=URL=]. Provides a mechanism for the group's owner to periodically update the
   attributes of the interest group. See [interest group updates](#interest-group-updates).
   <p class="note">
-    When defined, the [=interest group/update url=]'s [=origin=] will always be [=same origin=]
+    When non-null, the [=interest group/update url=]'s [=origin=] will always be [=same origin=]
     with [=interest group/owner=].
   </p>
 : <dfn>trusted bidding signals url</dfn>
-:: Undefined or a [=URL=]. Provide a mechanism for making real-time data available for use at
-  bidding time. See [=building trusted bidding signals url=].
+:: Null or a [=URL=]. Provide a mechanism for making real-time data available for use at bidding
+  time. See [=building trusted bidding signals url=].
   <p class="note">
-    When defined, the [=interest group/trusted bidding signals url=]'s [=origin=] will always be
+    When non-null, the [=interest group/trusted bidding signals url=]'s [=origin=] will always be
     [=same origin=] with [=interest group/owner=].
   </p>
 : <dfn>trusted bidding signals keys</dfn>
-:: Undefined or a [=list=] of [=string=]. See [=building trusted bidding signals url=].
+:: Null or a [=list=] of [=string=]. See [=building trusted bidding signals url=].
 : <dfn>user bidding signals</dfn>
-:: Undefined or a [=string=]. Additional metadata that the owner can use during on-device bidding.
+:: Null or a [=string=]. Additional metadata that the owner can use during on-device bidding.
 : <dfn>ads</dfn>
-:: Undefined or a [=list=] of [=interest group ad=]. Contains various ads that the interest group
-  might show.
+:: Null or a [=list=] of [=interest group ad=]. Contains various ads that the interest group might
+  show.
 : <dfn>ad components</dfn>
-:: Undefined or a [=list=] of [=interest group ad=]. Contains various ad components (or "products")
-  that can be used to construct ads composed of multiple pieces — a top-level ad template
-  "container" which includes some slots that can be filled in with specific "products".
+:: Null or a [=list=] of [=interest group ad=]. Contains various ad components (or "products") that
+  can be used to construct ads composed of multiple pieces — a top-level ad template "container"
+  which includes some slots that can be filled in with specific "products".
 : <dfn>joining origin</dfn>
 :: An [=origin=]. The top level page origin from where the interest group was joined.
 : <dfn>join counts</dfn>
@@ -2116,7 +2116,7 @@ An interest group ad is a [=struct=] with the following items:
   be returned by {{Navigator/runAdAuction()}}. This URL is intended to be loaded into an ad
   <{iframe}> (or a <{fencedframe}>).
 : <dfn>metadata</dfn>
-:: Undefined or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
+:: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
 
 </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -574,13 +574,17 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       |config|["{{AuctionAdConfig/auctionSignals}}"].
     1. Increment |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/auction signals=] with |result|:
-      1. Set |auctionConfig|'s [=auction config/auction signals=] to the result of
+      1. Let |auctionSignalsJSON| be the result of
         [=serializing a JavaScript value to a JSON string=], given |result|.
-      1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}}.
+      1. If no exception was [=exception/thrown=] in the previous step:
+        1. Set |auctionConfig|'s [=auction config/auction signals=] to |auctionSignalsJSON|.
+        1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}} to
+          |result|.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon rejection=] of |auctionConfig|'s [=auction config/auction signals=]:
       1. Set |auctionConfig|'s [=auction config/auction signals=] to failure.
-      1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}}
+      1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}} to
+        undefined.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
   1. Otherwise, set |auctionConfig|'s [=auction config/auction signals=] to the result of
     [=serializing a JavaScript value to a JSON string=], given
@@ -777,35 +781,36 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
 <div algorithm="generate a bid">
 
 To <dfn>generate a bid</dfn> given an [=ordered map=] |allTrustedBiddingSignals|, a 
-[=string=] |auctionSignals|, an [=ordered map=] whose [=map/keys=] are [=strings=] and
-whose [=map/values=] are {{any}} |browserSignals|, a [=string=] |perBuyerSignals|, a
-[=duration=] |perBuyerTimeout| in milliseconds, an [=interest group=] |ig|, and a [=moment=]
-|auctionStartTime|:
+[=string=] |auctionSignals|, an {{BiddingBrowserSignals}} |browserSignals|, a [=string=]
+|perBuyerSignals|, a [=duration=] |perBuyerTimeout| in milliseconds, an [=interest group=] |ig|, and
+a [=moment=] |auctionStartTime|:
+  1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
+    [=interest group/bidding url=].
+  1. If |biddingScript| is failure, return failure.
   1. Let |igGenerateBid| be the result of [=building an interest group passed to generateBid=]
     with |ig|.
-  1. [=map/Set=] |browserSignals|["`joinCount`"] to the sum of |ig|'s
+  1. Set |browserSignals|["{{BiddingBrowserSignals/joinCount}}"] to the sum of |ig|'s
      [=interest group/join counts=] for all days within the last 30 days.
-  1. [=map/Set=] |browserSignals|["`bidCount`"] to the sum of |ig|'s
+  1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/bidCount}}"] to the sum of |ig|'s
      [=interest group/bid counts=] for all days within the last 30 days.
-  1. Let |prevWins| be a [=list=] of [=tuples=], with each [=tuple=] consisting of a timeDelta (a 
-    [=duration=] in milliseconds), and adJSON (a [=string=]).
+  1. Let |prevWins| be a new <code>[=sequence=]<{{PreviousWin}}></code>.
   1. [=list/For each] |prevWin| of |ig|'s [=interest group/previous wins=] for all days within the
     the last 30 days:
     1. Let |timeDelta| be |auctionStartTime| minus |prevWin|[=previous win/time=].
     1. Set |timeDelta| to 0 if |timeDelta| is negative, |timeDelta|'s nearest second (rounding down)
       otherwise.
-    1. [=list/Append=] (|timeDelta|, |prevWin|'s [=previous win/ad json=]) to |prevWins|.
-  1. [=map/Set=] |browserSignals|["`prevWinsMs`"] to |prevWins|.
+    1. Let |prevWinIDL| be a new {{PreviousWin}}.
+    1. [=map/Set=] |prevWinIDL|["{{PreviousWin/timeDelta}}"] to |timeDelta|.
+    1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
+    1. [=list/Append=] |prevWinIDL| to |prevWins|.
+  1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
   1. If |dataVersion| is not null:
-    1. [=map/Set=] |browserSignals|["`dataVersion`"] to |dataVersion|.
-  1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
-    [=interest group/bidding url=].
-  1. If |biddingScript| is failure, return failure.
+    1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
   1. If |ig|'s [=interest group/bidding wasm helper url=] is not null:
     1. Let |wasmModuleObject| be the result of [=fetching WebAssembly=] with |ig|'s
       [=interest group/bidding wasm helper url=].
     1. If |wasmModuleObject| is not failure:
-      1. [=map/Set=] |browserSignals|["`wasmHelper`"] to |wasmModuleObject|.
+      1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/wasmHelper}}"] to |wasmModuleObject|.
   1. Let |trustedBiddingSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=] and
     whose [=map/values=] are {{any}}.
   1. [=list/For each=] |key| of |ig|'s [=interest group/trusted bidding signals keys=]:
@@ -874,15 +879,15 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. If |auctionSignals|, |auctionConfig|'s [=auction config/seller signals=],
   [=auction config/per buyer signals=], or [=auction config/per buyer timeouts=] is failure, return
   failure.
-1. Let |browserSignals| be a [=record=]<{{DOMString}}, {{any}}>.
+1. Let |browserSignals| be a {{BiddingBrowserSignals}}.
 1. Let |topLevelHost| be the result of running the <a spec=url>host serializer</a> on [=this=]'s
   [=relevant settings object=]'s [=environment/top-level origin=]'s [=origin/host=].
-1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=string=] |topLevelHost|.
-1. [=map/Set=] |browserSignals|["seller"] to the [=serialization of an origin|serialization=] of
-  |auctionConfig|'s [=auction config/seller=].
+1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/topWindowHostname}}"] to |topLevelHost|.
+1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/seller}}"] to the [=serialization of an
+  origin|serialization=] of |auctionConfig|'s [=auction config/seller=].
 1. Let |auctionLevel| be "single-level-auction".
 1. If |topLevelAuctionConfig| is not null:
-  1. [=map/Set=] |browserSignals|["topLevelSeller"] to the
+  1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/topLevelSeller}}"]] to the
     [=serialization of an origin|serialization=] of |topLevelAuctionConfig|'s
     [=auction config/seller=].
   1. Set |auctionLevel| to "component-auction".
@@ -1635,7 +1640,7 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
   To <dfn>evaluate a bidding script</dfn> given a [=string=] |script|, an [=interest group=] |ig|, a
   {{GenerateBidInterestGroup}} |igGenerateBid|, a [=string=]-or-null |auctionSignals|, an
   [=string=]-or-null |perBuyerSignals|, an [=ordered map=] |trustedBiddingSignals|, a
-  [=record=]<{{DOMString}}, {{any}}> |browserSignals|, and an integer millisecond [=duration=] |timeout|:
+  {{BiddingBrowserSignals}} |browserSignals|, and an integer millisecond [=duration=] |timeout|:
 
     1. Let |global| be a new {{InterestGroupBiddingScriptRunnerGlobalScope}}.
     1. Set |global|'s
@@ -2280,6 +2285,26 @@ Issue(WICG/turtledove#522): Move from "`*`" to "`self`".
 
 
 # Structures # {#structures}
+
+<xmp class="idl">
+
+dictionary PreviousWin {
+  required long long timeDelta;
+  required DOMString adJSON;
+};
+
+dictionary BiddingBrowserSignals {
+  required DOMString topWindowHostname;
+  required USVString seller;
+  required double joinCount;
+  required double bidCount;
+
+  USVString topLevelSeller;
+  sequence<PreviousWin> prevWinsMs;
+  object? wasmHelper;
+  long dataVersion;
+};
+</xmp>
 
 <h3 dfn-type=dfn>Interest group</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -165,7 +165,7 @@ a user accessible to `generateBid()` methods, otherwise.
 The <dfn for=Navigator method>joinAdInterestGroup(|group|)</dfn> method steps are:
 <div class="note">
 
-Temporarily, Chromium does not include the <span class="allow-2119">required</span> keyword
+Temporarily, Chromium does not include the <a for="dictionary member"><span class="allow-2119">required</span></a> keyword
 for {{AuctionAdInterestGroup/lifetimeMs}}, and instead starts this algorithm with the step
 
 1. If |group|["{{AuctionAdInterestGroup/lifetimeMs}}"] does not [=map/exist=], throw a {{TypeError}}.
@@ -1011,8 +1011,8 @@ To <dfn>serialize a URL</dfn> given a [=URL=]-or-null |url|:
 To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
 
   1. If |ads| is null, then return {{undefined}}.
-  1. Let |adsIDL| be a new [=list=].
-  1. [=list/for each] |ad| of |ads|:
+  1. Let |adsIDL| be a new <code>{{sequence}}&lt;{{AuctionAd}}></code>.
+  1. [=list/For each] |ad| of |ads|:
     1. Let |adIDL| be a new {{AuctionAd}}.
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].

--- a/spec.bs
+++ b/spec.bs
@@ -31,13 +31,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/C
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
     text: abrupt completion; url: sec-completion-record-specification-type
-    text: Object; url: sec-object-type
-    text: CreateDataProperty; url: sec-createdataproperty
-    text: Get; url: sec-get-o-p
-    text: HasProperty; url: sec-hasproperty
-    text: IsArray; url: sec-runtime-semantics-scriptevaluation
     text: Number; url: sec-ecmascript-language-types-number-type
-    text: ordinary object; url: ordinary-object
     text: ParseScript; url: sec-parse-script
     text: ScriptEvaluation; url: sec-runtime-semantics-scriptevaluation
     text: throw completion; url: sec-completion-record-specification-type
@@ -788,10 +782,12 @@ whose [=map/values=] are {{any}} |browserSignals|, a [=string=] |perBuyerSignals
       [=interest group/bidding wasm helper url=].
     1. If |wasmModuleObject| is not failure:
       1. [=map/Set=] |browserSignals|["`wasmHelper`"] to |wasmModuleObject|.
-  1. Let |trustedBiddingSignals| be a new [=ordinary object=].
+  1. Let |trustedBiddingSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=] and
+    whose [=map/values=] are {{any}}.
   1. [=list/For each=] |key| of |ig|'s [=interest group/trusted bidding signals keys=]:
-    1. If [=HasProperty=](|allTrustedBiddingSignals|, |key|), then 
-      [=CreateDataProperty=](|trustedBiddingSignals|, [|key|], [=Get=](|allTrustedBiddingSignals|, [|key|]).
+    1. If |allTrustedBiddingSignals| is an [=ordered map=] and |allTrustedBiddingSignals|[|key|]
+      [=map/exists=], then [=map/set=] |trustedBiddingSignals|[|key|] to
+      |allTrustedBiddingSignals|[|key|].
   1. Return be the result of [=evaluating a bidding script=] with
      |biddingScript|, |ig|, |igGenerateBid|, |auctionSignals|, |perBuyerSignals|,
      |trustedBiddingSignals|, |browserSignals|, and |perBuyerTimeout|.
@@ -854,10 +850,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   [=auction config/per buyer signals=], or [=auction config/per buyer timeouts=] is failure, return
   failure.
 1. Let |browserSignals| be a [=record=]<{{DOMString}}, {{any}}>.
-1. Let |topLevelHost| be [=this=]'s [=relevant settings object=]'s
-  [=environment/top-level origin=]'s [=origin/host=].
-1. If |topLevelHost| is an integer:
-  1. Let |topLevelHost| be the result of [=serializing an integer=] given |topLevelHost|.
+1. Let |topLevelHost| be the result of running the <a spec=url>host serializer</a> on [=this=]'s
+  [=relevant settings object=]'s [=environment/top-level origin=]'s [=origin/host=].
 1. [=map/Set=] |browserSignals|["`topWindowHostname`"] to [=string=] |topLevelHost|.
 1. [=map/Set=] |browserSignals|["seller"] to the [=serialization of an origin|serialization=] of
   |auctionConfig|'s [=auction config/seller=].
@@ -1011,7 +1005,7 @@ To <dfn>serialize a URL</dfn> given a [=URL=]-or-null |url|:
 To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
 
   1. If |ads| is null, then return {{undefined}}.
-  1. Let |adsIDL| be a new <code>{{sequence}}&lt;{{AuctionAd}}></code>.
+  1. Let |adsIDL| be a new <code>[=sequence=]<{{AuctionAd}}></code>.
   1. [=list/For each] |ad| of |ads|:
     1. Let |adIDL| be a new {{AuctionAd}}.
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
@@ -1019,8 +1013,6 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
     1. If |ad|'s [=interest group ad/metadata=] is not null, then:
       1. [=map/Set=] |adIDL|["{{AuctionAd/metadata}}"] to the result of
         [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
-    1. Otherwise,
-      1. [=map/Set=] |adIDL|["{{AuctionAd/metadata}}"] to {{undefined}}
     1. [=list/Append=] |adIDL| to |adsIDL|.
   1. Return |adsIDL|.
 </div>
@@ -1258,17 +1250,15 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
     1. If |isBiddingSignal| is true:
       1. Set |formatVersion| to the result of [=header list/getting a structured field value=]
         given [:X-protected-audience-bidding-signals-format-version:] and "`item`" from |headers|.
-    1. Set |signals| to the result of [=parsing JSON bytes to a JavaScript value=] |responseBody|.
+    1. Set |signals| to the result of [=parsing JSON bytes to an Infra value=] |responseBody|.
   1. Wait for |signals| to be set.
-  1. Return « null, null » if any of the following conditions hold:
-    * |signals| is a parsing exception;
-    * |signals| is not an [=Object=];
-    * [=IsArray=](|signals|);
+  1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,
+    null ».
   1. If |formatVersion| is 2:
-    1. If ![=HasProperty=](|signals|, "`keys`"), return « null, null ».
-    1. Set |signals| to [=Get=](|signals|, "`keys`").
+    1. If |signals|["`keys`"] does not [=map/exist=], return « null, null ».
+    1. Set |signals| to |signals|["`keys`"].
+    1. If |signals| is not an [=ordered map=], return « null, null ».
     1. TODO: handle priority vector.
-    1. If |signals| is not an [=Object=], or [=IsArray=](|signals|), return « null, null ».
   1. Return « |signals|, |dataVersion| ».
 </div>
 
@@ -1391,12 +1381,13 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|:
   1. If |reportResultOutputJS| is an [=abrupt completion=], [=iteration/continue=].
   1. Let |reportResultOutputIDL| be the result of [=converted to an IDL value|converting=]
      |reportResultOutputJS| to a {{ReportResultOutput}}.
-  1. TODO: Store |reportResultOutputIDL|["{{ReportResultOutput/reportUrl}}"] and
-     |reportResultOutputIDL|["{{ReportResultOutput/reportingBeaconMap}}"] in the
-     {{FencedFrameConfig}} as appropriate.
   1. [=map/Remove=] |browserSignals|["`dataVersion`"].
   1. [=map/Remove=] |browserSignals|["`modifiedBid`"].
   1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].
+  1. If an exception was [=exception/thrown=] in the previous step, return « null, |browserSignals| ».
+  1. TODO: Store |reportResultOutputIDL|["{{ReportResultOutput/reportUrl}}"] and
+     |reportResultOutputIDL|["{{ReportResultOutput/reportingBeaconMap}}"] in the
+     {{FencedFrameConfig}} as appropriate.
   1. Return « |reportResultOutputIDL|["{{ReportResultOutput/signalsForWinner}}"], |browserSignals| ».
 </div>
 
@@ -1597,7 +1588,7 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
 <div algorithm>
   To <dfn>evaluate a bidding script</dfn> given a [=string=] |script|, an [=interest group=] |ig|, a
   {{GenerateBidInterestGroup}} |igGenerateBid|, a [=string=]-or-null |auctionSignals|, an
-  [=string=]-or-null |perBuyerSignals|, an [=ordinary object=] |trustedBiddingSignalsJS|, a
+  [=string=]-or-null |perBuyerSignals|, an [=ordered map=] |trustedBiddingSignals|, a
   [=record=]<{{DOMString}}, {{any}}> |browserSignals|, and an integer millisecond [=duration=] |timeout|:
 
     1. Let |global| be a new {{InterestGroupBiddingScriptRunnerGlobalScope}}.
@@ -1619,7 +1610,8 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
       given |browserSignals|.
     1. Let |startTime| be the [=current wall time=].
     1. Let |result| be the result of [=evaluating a script=] with |global|, |script|, "`generateBid`",
-      « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS| », and |timeout|.
+      « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignals|, |browserSignalsJS| »,
+      and |timeout|.
     1. Let |duration| be the [=current wall time=] minus |startTime| in milliseconds.
     1. If |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] is not null:
       1. Set |ig|'s [=interest group/priority=] to |global|'s
@@ -1879,7 +1871,6 @@ an [=interest group=] |ig|, a [=boolean=] |isComponentAuction| and a [=boolean=]
     1. Let |adComponents| be |generateBidOutput|["{{GenerateBidOutput/adComponents}}"].
     1. Return failure if any of the following conditions hold:
       * |groupHasAdComponents| is false;
-      * |adComponents| is not a [=sequence=];
       * |adComponents|'s size is greater than 20.
     1. Let |adComponentDescriptors| be a new [=list=] of [=ad descriptors=].
     1. For |component| in |adComponents|:
@@ -2363,10 +2354,10 @@ An auction config is a [=struct=] with the following items:
   must be "<code>https</code>".
 : <dfn>auction signals</dfn>
 :: Null or a [=string=] or a {{Promise}} or failure.
-  Opaque JSON data, passed to both sellers' and buyers' script runners as [=Objects=].
+  Opaque JSON data passed to both sellers' and buyers' [=script runners=].
 : <dfn>seller signals</dfn>
 :: Null or a [=string=] or a {{Promise}} or failure.
-  Opaque JSON data, passed to the seller's script runner as an [=Object=].
+  Opaque JSON data passed to the seller's [=script runner=].
 : <dfn>seller timeout</dfn>
 :: A [=duration=] in milliseconds, initially 50 milliseconds.
   Restricts the runtime of the seller's `scoreAd()` script. If scoring does not complete before
@@ -2374,8 +2365,8 @@ An auction config is a [=struct=] with the following items:
 : <dfn>per buyer signals</dfn>
 :: Null or a {{Promise}} or failure or an [=ordered map=] whose [=map/keys=] are [=origins=] and
   whose [=map/values=] are [=strings=].
-  [=map/Keys=] are buyers and must be valid HTTPS origins. [=map/Values=] are opaque JSON data,
-  passed to corresponding buyer's script runner as [=Object=].
+  [=map/Keys=] are buyers and must be valid HTTPS origins. [=map/Values=] are opaque JSON data
+  passed to corresponding buyer's [=script runner=].
 : <dfn>per buyer timeouts</dfn>
 :: Null or a {{Promise}} or failure or an [=ordered map=] whose [=map/keys=] are [=origins=] and
   whose [=map/values=] are [=durations=] in milliseconds.

--- a/spec.bs
+++ b/spec.bs
@@ -29,10 +29,10 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/C
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
   type: dfn
     text: abrupt completion; url: sec-completion-record-specification-type
+    text: Object; url: sec-object-type
     text: CreateDataProperty; url: sec-createdataproperty
     text: Get; url: sec-get-o-p
     text: HasProperty; url: sec-hasproperty
-    text: is not an Object; url: sec-object-type
     text: IsArray; url: sec-runtime-semantics-scriptevaluation
     text: ordinary object; url: ordinary-object
     text: ParseScript; url: sec-parse-script
@@ -508,9 +508,11 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/auction signals=] with |result|:
       1. Set |auctionConfig|'s [=auction config/auction signals=] to the result of
         [=serializing a JavaScript value to a JSON string=], given |result|.
+      1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}}.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon rejection=] of |auctionConfig|'s [=auction config/auction signals=]:
       1. Set |auctionConfig|'s [=auction config/auction signals=] to failure.
+      1. Set |auctionConfig|'s [=auction config/config idl=]{{AuctionAdConfig/auctionSignals}}
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
   1. Otherwise, set |auctionConfig|'s [=auction config/auction signals=] to the result of
     [=serializing a JavaScript value to a JSON string=], given
@@ -886,7 +888,7 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dt>{{GenerateBidInterestGroup/enableBiddingSignalsPrioritization}}
       <dd>|ig|'s [=interest group/enable bidding signals prioritization=]
       <dt>{{GenerateBidInterestGroup/priorityVector}}
-      <dd>|ig|'s [=interest group/priority vector=] if not null, otherwise undefined
+      <dd>|ig|'s [=interest group/priority vector=] if not null, otherwise {{undefined}}
       <dt>{{GenerateBidInterestGroup/executionMode}}
       <dd>|ig|'s [=interest group/execution mode=]
       <dt>{{GenerateBidInterestGroup/biddingLogicURL}}
@@ -912,22 +914,24 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
 <div algorithm>
 To <dfn>serialize a URL</dfn> given a [=URL=]-or-null |url|:
 
-  1. If |url| is null, then return undefined.
+  1. If |url| is null, then return {{undefined}}.
   1. Return the [=URL serializer|serialization=] of |url|.
 </div>
 
 <div algorithm>
 To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
 
-  1. If |ads| is null, then return undefined.
+  1. If |ads| is null, then return {{undefined}}.
   1. Let |adsIDL| be a new [=list=].
   1. [=list/for each] |ad| of |ads|:
     1. Let |adIDL| be a new {{AuctionAd}}.
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
-    1. If |ad|'s [=interest group ad/metadata=] is not null, then [=map/set=]
-      |adIDL|["{{AuctionAd/metadata}}"] to the result of
-      [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
+    1. If |ad|'s [=interest group ad/metadata=] is not null, then:
+      1. [=map/Set=] |adIDL|["{{AuctionAd/metadata}}"] to the result of
+        [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
+    1. Otherwise,
+      1. [=map/Set=] |adIDL|["{{AuctionAd/metadata}}"] to {{undefined}}
     1. [=list/Append=] |adIDL| to |adsIDL|.
   1. Return |adsIDL|.
 </div>
@@ -1170,13 +1174,13 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
   1. Wait for |signals| to be set.
   1. Return « null, null » if any of the following conditions hold:
     * |signals| is a parsing exception;
-    * |signals| [=is not an Object=];
+    * |signals| is not an [=Object=];
     * [=IsArray=](|signals|);
   1. If |formatVersion| is 2:
     1. If ![=HasProperty=](|signals|, "`keys`"), return « null, null ».
     1. Set |signals| to [=Get=](|signals|, "`keys`").
     1. TODO: handle priority vector.
-    1. If |signals| [=is not an Object=], or [=IsArray=](|signals|), return « null, null ».
+    1. If |signals| is not an [=Object=], or [=IsArray=](|signals|), return « null, null ».
   1. Return « |signals|, |dataVersion| ».
 </div>
 
@@ -1408,7 +1412,7 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
 <div algorithm>
   To <dfn>evaluate a bidding script</dfn> given a [=string=] |script|, an [=interest group=] |ig|, a
   {{GenerateBidInterestGroup}} |igGenerateBid|, a [=string=]-or-null |auctionSignals|, an
-  [=ordered map=]-or-null |perBuyerSignals|, an [=ordinary object=] |trustedBiddingSignals|, a
+  [=string=]-or-null |perBuyerSignals|, an [=ordinary object=] |trustedBiddingSignalsJS|, a
   [=record=]<{{DOMString}}, {{any}}> |browserSignals|, and an integer millisecond [=duration=] |timeout|:
 
     1. Let |global| be a new {{InterestGroupBiddingScriptRunnerGlobalScope}}.
@@ -1421,14 +1425,12 @@ an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] a
     1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/interest group=] to |ig|.
     1. Let |igJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
       given |igGenerateBid|.
-    1. Let |auctionSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
-      given |auctionSignals|.
-    1. Let |perBuyerSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
-      given |perBuyerSignals|.
-    1. Let |trustedBiddingSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
-      given |trustedBiddingSignals|.
+    1. Let |auctionSignalsJS| be the result of [=parsing a JSON string to a JavaScript value=] given
+      |auctionSignals| if |auctionSignals| is not null, otherwise undefined.
+    1. Let |perBuyerSignalsJS| be the result of [=parsing a JSON string to a JavaScript value=]
+      given |perBuyerSignals| if |perBuyerSignals| is not null, otherwise undefined.
     1. Let |browserSignalsJS| be the result of [=converted to ECMAScript values|converting to ECMAScript values=]
-      given |browserSignals|.      
+      given |browserSignals|.
     1. Return the result of [=evaluating a script=] with |global|, |script|, "`generateBid`",
       « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS| »,
       and |timeout|.
@@ -1665,7 +1667,7 @@ an [=interest group=] |ig|, a [=boolean=] |isComponentAuction| and a [=boolean=]
     1. Let |adComponents| be |generateBidOutput|["{{GenerateBidOutput/adComponents}}"].
     1. Return failure if any of the following conditions hold:
       * |groupHasAdComponents| is false;
-      * |adComponents| is not an array;
+      * |adComponents| is not a [=sequence=];
       * |adComponents|'s size is greater than 20.
     1. Let |adComponentDescriptors| be a new [=list=] of [=ad descriptors=].
     1. For |component| in |adComponents|:
@@ -2149,10 +2151,10 @@ An auction config is a [=struct=] with the following items:
   must be "<code>https</code>".
 : <dfn>auction signals</dfn>
 :: Null or a [=string=] or a {{Promise}} or failure.
-  Opaque JSON data passed to both sellers' and buyers' script runners.
+  Opaque JSON data, passed to both sellers' and buyers' script runners as [=Objects=].
 : <dfn>seller signals</dfn>
 :: Null or a [=string=] or a {{Promise}} or failure.
-  Opaque JSON data passed to the seller's script runner.
+  Opaque JSON data, passed to the seller's script runner as an [=Object=].
 : <dfn>seller timeout</dfn>
 :: A [=duration=] in milliseconds, initially 50 milliseconds.
   Restricts the runtime of the seller's `scoreAd()` script. If scoring does not complete before
@@ -2160,8 +2162,8 @@ An auction config is a [=struct=] with the following items:
 : <dfn>per buyer signals</dfn>
 :: Null or a {{Promise}} or failure or an [=ordered map=] whose [=map/keys=] are [=origins=] and
   whose [=map/values=] are [=strings=].
-  [=map/Keys=] are buyers and must be valid HTTPS origins. [=map/Values=] are opaque JSON data
-  passed to corresponding buyer's script runner.
+  [=map/Keys=] are buyers and must be valid HTTPS origins. [=map/Values=] are opaque JSON data,
+  passed to corresponding buyer's script runner as [=Object=].
 : <dfn>per buyer timeouts</dfn>
 :: Null or a {{Promise}} or failure or an [=ordered map=] whose [=map/keys=] are [=origins=] and
   whose [=map/values=] are [=durations=] in milliseconds.


### PR DESCRIPTION
Infra list arguments must be converted to JS values before passed to Call (https://tc39.es/ecma262/multipage/abstract-operations.html#sec-call).

Also added an IDL type for ReportResultOutput, and added converting reportResult's output from JS values to it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/601.html" title="Last updated on Jun 16, 2023, 6:09 PM UTC (22f72fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/601/a218d03...qingxinwu:22f72fd.html" title="Last updated on Jun 16, 2023, 6:09 PM UTC (22f72fd)">Diff</a>