### PR TITLE
spec: fix "is empty|empty" to just empty

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -460,7 +460,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. Set |auctionConfig|'s [=auction config/trusted scoring signals url=] to
     |trustedScoringSignalsURL|.
 1. If |config|["{{AuctionAdConfig/interestGroupBuyers}}"] [=map/exists=], let |buyers| be a new
-  [=list/is empty|empty=] [=list=].
+  empty [=list=].
   1. [=list/For each=] |buyerString| in |config|["{{AuctionAdConfig/interestGroupBuyers}}"]:
     1. Let |buyer| be the result of [=parsing an origin=] with |buyerString|. If |buyer| is failure,
       or |buyer|'s [=url/scheme=] is not "`https`", then [=exception/throw=] a {{TypeError}}.
@@ -1085,7 +1085,7 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
 <div algorithm>
 
 To <dfn>encode trusted signals keys</dfn> given an [=ordered set=] of [=strings=] |keys|:
-1. Let |list| be a new [=list/is empty|empty=] [=list=].
+1. Let |list| be a new empty [=list=].
 1. Let |keysStr| be the result of [=string/concatenating=] |keys| with separator set to ",".
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |keysStr| using
   [=component percent-encode set=] to |list|.
@@ -1098,7 +1098,7 @@ To <dfn>encode trusted signals keys</dfn> given an [=ordered set=] of [=strings=
 To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
 [=strings=] |keys|, an [=ordered set=] of [=strings=] |igNames|, and an {{unsigned short}}-or-null
 |experimentGroupId|:
-1. Let |queryParamsList| be a new [=list/is empty|empty=] [=list=].
+1. Let |queryParamsList| be a new empty [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] [=this=]'s
   [=relevant settings object=]'s [=environment/top-level origin=] using
@@ -1125,13 +1125,13 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
 To <dfn>build trusted scoring signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
 [=URLs=] |renderURLs|, an [=ordered set=] of [=URLs=] |adComponentRenderUrls|, an {{unsigned short}}
 |experimentGroupId|, and an [=origin=] |topWindowOrigin|:
-1. Let |queryParamsList| be a new [=list/is empty|empty=] [=list=].
+1. Let |queryParamsList| be a new empty [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |topWindowOrigin| using
   [=component percent-encode set=] to |queryParamsList|.
 1. If |renderURLs| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&renderURLs=" to |queryParamsList|.
-  1. Let |renderURLsStrings| be a new [=list/is empty|empty=] [=list=].
+  1. Let |renderURLsStrings| be a new empty [=list=].
   1. [=list/For each=] |renderURL| of |renderURLs|:
     1. [=list/Append=] the result of [=URL serializer|serialization=] of |renderURL| to
       |renderURLsStrings|.
@@ -1139,7 +1139,7 @@ To <dfn>build trusted scoring signals url</dfn> given a [=URL=] |signalsUrl|, an
     |renderURLsStrings|.
 1. If |adComponentRenderUrls| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&adComponentRenderUrls=" to |queryParamsList|.
-  1. Let |adComponentRenderUrlsStrings| be a new [=list/is empty|empty=] [=list=].
+  1. Let |adComponentRenderUrlsStrings| be a new empty [=list=].
   1. [=list/For each=] |adComponentRenderUrl| of |adComponentRenderUrls|:
     1. [=list/Append=] the result of [=URL serializer|serialization=] of |adComponentRenderUrl| to
       |adComponentRenderUrlsStrings|.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/pull/612.html" title="Last updated on Jun 6, 2023, 11:16 PM UTC (2112aed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/612/f803aff...2112aed.html" title="Last updated on Jun 6, 2023, 11:16 PM UTC (2112aed)">Diff</a>