### PR TITLE
Fix typing of field for perBuyerSignals in IDL, and refactor it some

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -529,7 +529,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer signals=]:
       1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |config|["{{AuctionAdConfig/perBuyerSignals}}"].
+  1. Otherwise, execute [=validate and convert per buyer signals=] with |auctionConfig| and |config|["{{AuctionAdConfig/perBuyerSignals}}"].
 1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=]:
   1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] is a {{Promise}}:
     1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to

--- a/spec.bs
+++ b/spec.bs
@@ -521,7 +521,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure, throw a {{TypeError}}.
       1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given |value|.
       1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to |signalsString|.
-    1. If the previous step did not [=exception/throw=] an exception:
+    1. If the previous steps did not [=exception/throw=] an exception:
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
   1. [=Upon rejection=] of |resolvedAndTypeChecked|:
     1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.

--- a/spec.bs
+++ b/spec.bs
@@ -385,7 +385,9 @@ dictionary AuctionAdConfig {
   USVString directFromSellerSignals;
   unsigned long long sellerTimeout;
   unsigned short sellerExperimentGroupId;
-  record<USVString, any> perBuyerSignals;
+
+  // Expects a record<USVString, any> or a Promise resolving to that.
+  any perBuyerSignals;
   record<USVString, unsigned long long> perBuyerTimeouts;
   record<USVString, unsigned short> perBuyerGroupLimits;
   record<USVString, unsigned short> perBuyerExperimentGroupIds;
@@ -518,36 +520,16 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. Increment |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
       1. Let |pendingException| be null.
-      1. If |result| is not a [=record=] mapping from {{USVString}} to {{any}}, set |pendingException| to
-        a {{TypeError}} and jump to the step labeled
-        <i><a href=#validate-per-buyer-signals-finish>finish</a></i>.
-      1. Set |auctionConfig|'s [=auction config/per buyer signals=] to a new [=ordered map=] whose
-        [=map/keys=] are [=origins=] and whose [=map/values=] are [=strings=].
-      1. [=map/For each=] |key| → |value| of |result|:
-        1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
-          set |pendingException| to a {{TypeError}} and jump to the step labeled
-          <i><a href=#validate-per-buyer-signals-finish>finish</a></i>.
-        1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given
-          |value|. If this [=exception/throws=] an exception |e|, set |pendingException| to |e| and jump
-          to the step labeled <i><a href=#validate-per-buyer-signals-finish>finish</a></i>.
-        1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to
-          |signalsString|.
-      1. <i id=validate-per-buyer-signals-finish>Finish</i>:
-        1. If |pendingException| is not null:
-          1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
-          1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-          1. [=exception/Throw=] |pendingException|.
-        1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
+      1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and result. If this [=exception/throws=] an exception |e|, set |pendingException| to |e|.
+      1. If |pendingException| is not null:
+        1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
+        1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+        1. [=exception/Throw=] |pendingException|.
+      1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer signals=]:
       1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. [=map/For each=] |key| → |value| of |config|["{{AuctionAdConfig/perBuyerSignals}}"]:
-    1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
-      [=exception/throw=] a {{TypeError}}.
-    1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given
-      |value|.
-    1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to
-      |signalsString|.
+  1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |config|["{{AuctionAdConfig/perBuyerSignals}}"].
 1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=]:
   1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] is a {{Promise}}:
     1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to
@@ -2103,6 +2085,19 @@ An auction config is a [=struct=] with the following items:
   [=auction config/seller signals=] whose {{Promise}}s are not yet resolved.
 
 </dl>
+
+<div algorithm="validate and convert per buyer signals">
+
+To <dfn>validate and convert per buyer signals</dfn> given an {{AuctionAdConfig}} |auctionConfig| and a JavaScript value |value|:
+1. If |value| is not a [=record=] mapping from {{USVString}} to {{any}}, throw a {{TypeError}}.
+1. Set |auctionConfig|'s [=auction config/per buyer signals=] to a new [=ordered map=] whose
+  [=map/keys=] are [=origins=] and whose [=map/values=] are [=strings=].
+1. [=map/For each=] |key| → |value| of |value|:
+  1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure, throw a {{TypeError}}.
+  1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given |value|.
+  1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to |signalsString|.
+
+</div>
 
 <h3 dfn-type=dfn>Per buyer bid generator</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -516,12 +516,11 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     |config|["{{AuctionAdConfig/perBuyerSignals}}"].
   1. Increment |auctionConfig|'s [=auction config/pending promise count=].
   1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
-    1. Let |pendingException| be null.
-    1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |result|. If this [=exception/throws=] an exception |e|, set |pendingException| to |e|.
-    1. If |pendingException| is not null:
+    1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |result|.
+    1. If the previous step [=exception/throws=] an exception |e|:
       1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-      1. [=exception/Throw=] |pendingException|.
+      1. [=exception/Throw=] |e|.
     1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
   1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer signals=]:
     1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.

--- a/spec.bs
+++ b/spec.bs
@@ -385,9 +385,7 @@ dictionary AuctionAdConfig {
   USVString directFromSellerSignals;
   unsigned long long sellerTimeout;
   unsigned short sellerExperimentGroupId;
-
-  // Expects a record<USVString, any> or a Promise resolving to that.
-  any perBuyerSignals;
+  Promise<record<USVString, any>> perBuyerSignals;
   record<USVString, unsigned long long> perBuyerTimeouts;
   record<USVString, unsigned short> perBuyerGroupLimits;
   record<USVString, unsigned short> perBuyerExperimentGroupIds;
@@ -514,22 +512,20 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. Set |auctionConfig|'s [=auction config/seller experiment group id=] to
     |config|["{{AuctionAdConfig/sellerExperimentGroupId}}"].
 1. If |config|["{{AuctionAdConfig/perBuyerSignals}}"] [=map/exists=]:
-  1. If |config|["{{AuctionAdConfig/perBuyerSignals}}"] is a {{Promise}}:
-    1. Set |auctionConfig|'s [=auction config/per buyer signals=] to
-      |config|["{{AuctionAdConfig/perBuyerSignals}}"].
-    1. Increment |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
-      1. Let |pendingException| be null.
-      1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |result|. If this [=exception/throws=] an exception |e|, set |pendingException| to |e|.
-      1. If |pendingException| is not null:
-        1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
-        1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-        1. [=exception/Throw=] |pendingException|.
-      1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer signals=]:
+  1. Set |auctionConfig|'s [=auction config/per buyer signals=] to
+    |config|["{{AuctionAdConfig/perBuyerSignals}}"].
+  1. Increment |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
+    1. Let |pendingException| be null.
+    1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |result|. If this [=exception/throws=] an exception |e|, set |pendingException| to |e|.
+    1. If |pendingException| is not null:
       1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. Otherwise, execute [=validate and convert per buyer signals=] with |auctionConfig| and |config|["{{AuctionAdConfig/perBuyerSignals}}"].
+      1. [=exception/Throw=] |pendingException|.
+    1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer signals=]:
+    1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
+    1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=]:
   1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] is a {{Promise}}:
     1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to

--- a/spec.bs
+++ b/spec.bs
@@ -515,14 +515,15 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. Set |auctionConfig|'s [=auction config/per buyer signals=] to
     |config|["{{AuctionAdConfig/perBuyerSignals}}"].
   1. Increment |auctionConfig|'s [=auction config/pending promise count=].
-  1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
-    1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |result|.
-    1. If the previous step [=exception/throws=] an exception |e|:
-      1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
+  1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps [=upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
+    1. Set |auctionConfig|'s [=auction config/per buyer signals=] to a new [=ordered map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=strings=].
+    1. [=map/For each=] |key| → |value| of |result|:
+      1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure, throw a {{TypeError}}.
+      1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given |value|.
+      1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to |signalsString|.
+    1. If the previous step did not [=exception/throw=] an exception:
       1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-      1. [=exception/Throw=] |e|.
-    1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer signals=]:
+  1. [=Upon rejection=] of |resolvedAndTypeChecked|:
     1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
     1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=]:
@@ -2080,19 +2081,6 @@ An auction config is a [=struct=] with the following items:
   [=auction config/seller signals=] whose {{Promise}}s are not yet resolved.
 
 </dl>
-
-<div algorithm="validate and convert per buyer signals">
-
-To <dfn>validate and convert per buyer signals</dfn> given an {{AuctionAdConfig}} |auctionConfig| and a JavaScript value |value|:
-1. If |value| is not a [=record=] mapping from {{USVString}} to {{any}}, throw a {{TypeError}}.
-1. Set |auctionConfig|'s [=auction config/per buyer signals=] to a new [=ordered map=] whose
-  [=map/keys=] are [=origins=] and whose [=map/values=] are [=strings=].
-1. [=map/For each=] |key| → |value| of |value|:
-  1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure, throw a {{TypeError}}.
-  1. Let |signalsString| be the result of [=serializing a JavaScript value to a JSON string=], given |value|.
-  1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to |signalsString|.
-
-</div>
 
 <h3 dfn-type=dfn>Per buyer bid generator</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -520,7 +520,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. Increment |auctionConfig|'s [=auction config/pending promise count=].
     1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer signals=] with |result|:
       1. Let |pendingException| be null.
-      1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and result. If this [=exception/throws=] an exception |e|, set |pendingException| to |e|.
+      1. Execute [=validate and convert per buyer signals=] with |auctionConfig| and |result|. If this [=exception/throws=] an exception |e|, set |pendingException| to |e|.
       1. If |pendingException| is not null:
         1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
         1. Decrement |auctionConfig|'s [=auction config/pending promise count=].


### PR DESCRIPTION
This will need to happen for all the promise-taking fields, but I think it makes sense to review it first before doing 4 or 5 other times.

One particular likely point of contention: I pushed the helper algorithm all the way down to the structures section for Auction Config. I personally find this way easier to read (especially since the main algorithm section is so overloaded).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/617.html" title="Last updated on Jun 16, 2023, 1:24 PM UTC (bdfeb87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/617/26d6645...morlovich:bdfeb87.html" title="Last updated on Jun 16, 2023, 1:24 PM UTC (bdfeb87)">Diff</a>