### PR TITLE
Fix a build error.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -153,9 +153,9 @@ The <dfn for=Navigator method>joinAdInterestGroup(|group|)</dfn> method steps ar
 <div class="note">
 
 Temporarily, Chromium does not include the <a for="dictionary member"><span class="allow-2119">required</span></a> keyword
-for {{AuctionAdInterestGroup/lifetimeMs}}, and instead starts this algorithm with the step
+for {{GenerateBidInterestGroup/lifetimeMs}}, and instead starts this algorithm with the step
 
-1. If |group|["{{AuctionAdInterestGroup/lifetimeMs}}"] does not [=map/exist=], throw a {{TypeError}}.
+1. If |group|["{{GenerateBidInterestGroup/lifetimeMs}}"] does not [=map/exist=], throw a {{TypeError}}.
 
 This is detectable because it can change the set of fields that are read from the argument when a
 {{TypeError}} is eventually thrown, but it will never change whether the call succeeds or fails.
@@ -169,43 +169,43 @@ This is detectable because it can change the set of fields that are read from th
 1. Let |interestGroup| be a new [=interest group=].
 1. Validate the given |group| and set |interestGroup|'s fields accordingly.
   1. Set |interestGroup|'s [=interest group/expiry=] to the [=current wall time=] plus
-    |group|["{{AuctionAdInterestGroup/lifetimeMs}}"] milliseconds.
+    |group|["{{GenerateBidInterestGroup/lifetimeMs}}"] milliseconds.
   1. Set |interestGroup|'s [=interest group/next update after=] to the [=current wall time=] plus 24
     hours.
   1. Set |interestGroup|'s [=interest group/owner=] to the result of [=parsing an origin=] on
-    |group|["{{AuctionAdInterestGroup/owner}}"].
+    |group|["{{GenerateBidInterestGroup/owner}}"].
   1. If |interestGroup|'s [=interest group/owner=] is failure, or its [=url/scheme=] is not
     "`https`", [=exception/throw=] a {{TypeError}}.
-  1. Set |interestGroup|'s [=interest group/name=] to |group|["{{AuctionAdInterestGroup/name}}"].
+  1. Set |interestGroup|'s [=interest group/name=] to |group|["{{GenerateBidInterestGroup/name}}"].
   1. Set |interestGroup|'s [=interest group/priority=] to
     |group|["{{AuctionAdInterestGroup/priority}}"].
   1. Set |interestGroup|'s [=interest group/enable bidding signals prioritization=] to
-    |group|["{{AuctionAdInterestGroup/enableBiddingSignalsPrioritization}}"].
-  1. If |group|["{{AuctionAdInterestGroup/priorityVector}}"] [=map/exists=], then set
+    |group|["{{GenerateBidInterestGroup/enableBiddingSignalsPrioritization}}"].
+  1. If |group|["{{GenerateBidInterestGroup/priorityVector}}"] [=map/exists=], then set
     |interestGroup|'s [=interest group/priority vector=] to
-    |group|["{{AuctionAdInterestGroup/priorityVector}}"].
+    |group|["{{GenerateBidInterestGroup/priorityVector}}"].
   1. If |group|["{{AuctionAdInterestGroup/prioritySignalsOverrides}}"] [=map/exists=], then set
     |interestGroup|'s [=interest group/priority signals overrides=] to
     |group|["{{AuctionAdInterestGroup/prioritySignalsOverrides}}"].
   1. Set |interestGroup|'s [=interest group/execution mode=] to
-    |group|["{{AuctionAdInterestGroup/executionMode}}"].
+    |group|["{{GenerateBidInterestGroup/executionMode}}"].
   1. For each |groupMember| and |interestGroupField| in the following table
     <table class="data">
       <thead><tr><th>Group member</th><th>Interest group field</th></tr></thead>
       <tr>
-        <td>"{{AuctionAdInterestGroup/biddingLogicURL}}"</td>
+        <td>"{{GenerateBidInterestGroup/biddingLogicURL}}"</td>
         <td>[=interest group/bidding url=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/biddingWasmHelperURL}}"</td>
+        <td>"{{GenerateBidInterestGroup/biddingWasmHelperURL}}"</td>
         <td>[=interest group/bidding wasm helper url=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/updateURL}}"</td>
+        <td>"{{GenerateBidInterestGroup/updateURL}}"</td>
         <td>[=interest group/update url=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/trustedBiddingSignalsURL}}"</td>
+        <td>"{{GenerateBidInterestGroup/trustedBiddingSignalsURL}}"</td>
         <td>[=interest group/trusted bidding signals url=]</td>
       </tr>
     </table>
@@ -219,23 +219,23 @@ This is detectable because it can change the set of fields that are read from th
       1. Set |interestGroup|'s |interestGroupField| to |parsedUrl|.
   1. If |interestGroup|'s [=interest group/trusted bidding signals url=]'s [=url/query=] is not
     null, then [=exception/throw=] a {{TypeError}}.
-  1. If |group|["{{AuctionAdInterestGroup/trustedBiddingSignalsKeys}}"] [=map/exists=], then set
+  1. If |group|["{{GenerateBidInterestGroup/trustedBiddingSignalsKeys}}"] [=map/exists=], then set
     |interestGroup|'s [=interest group/trusted bidding signals keys=] to
-    |group|["{{AuctionAdInterestGroup/trustedBiddingSignalsKeys}}"].
-  1. If |group|["{{AuctionAdInterestGroup/userBiddingSignals}}"] [=map/exists=]:
+    |group|["{{GenerateBidInterestGroup/trustedBiddingSignalsKeys}}"].
+  1. If |group|["{{GenerateBidInterestGroup/userBiddingSignals}}"] [=map/exists=]:
     1. Set |interestGroup|'s [=interest group/user bidding signals=] to the result of
       [=serializing a JavaScript value to a JSON string=], given
-      |group|["{{AuctionAdInterestGroup/userBiddingSignals}}"]. This can [=exception/throw=] a
+      |group|["{{GenerateBidInterestGroup/userBiddingSignals}}"]. This can [=exception/throw=] a
       {{TypeError}}.
   1. For each |groupMember| and |interestGroupField| in the following table
     <table class="data">
       <thead><tr><th>Group member</th><th>Interest group field</th></tr></thead>
       <tr>
-        <td>"{{AuctionAdInterestGroup/ads}}"</td>
+        <td>"{{GenerateBidInterestGroup/ads}}"</td>
         <td>[=interest group/ads=]</td>
       </tr>
       <tr>
-        <td>"{{AuctionAdInterestGroup/adComponents}}"</td>
+        <td>"{{GenerateBidInterestGroup/adComponents}}"</td>
         <td>[=interest group/ad components=]</td>
       </tr>
     </table>


### PR DESCRIPTION
AuctionAdInterestGroup inherits GenerateBidInterestGroup, need to use {{GenerateBidInterestGroup/xxx}} to reference inherited fields.

https://github.com/speced/bikeshed/issues/2231 covers the bug why the original CL that made the change didn't catch this error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/640.html" title="Last updated on Jun 20, 2023, 7:01 PM UTC (6bf0598)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/640/086895d...qingxinwu:6bf0598.html" title="Last updated on Jun 20, 2023, 7:01 PM UTC (6bf0598)">Diff</a>