### PR TITLE
Further work on promise handling:

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -467,17 +467,17 @@ dictionary AuctionAdConfig {
   USVString trustedScoringSignalsURL;
   sequence<USVString> interestGroupBuyers;
   Promise<any> auctionSignals;
-  any sellerSignals;
-  USVString directFromSellerSignals;
+  Promise<any> sellerSignals;
+  Promise<USVString> directFromSellerSignals;
   unsigned long long sellerTimeout;
   unsigned short sellerExperimentGroupId;
   USVString sellerCurrency;
   Promise<record<USVString, any>> perBuyerSignals;
-  record<USVString, unsigned long long> perBuyerTimeouts;
+  Promise<record<USVString, unsigned long long>> perBuyerTimeouts;
   record<USVString, unsigned short> perBuyerGroupLimits;
   record<USVString, unsigned short> perBuyerExperimentGroupIds;
   record<USVString, record<USVString, double>> perBuyerPrioritySignals;
-  record<USVString, USVString> perBuyerCurrencies;
+  Promise<record<USVString, USVString>> perBuyerCurrencies;
   sequence<AuctionAdConfig> componentAuctions = [];
   AbortSignal? signal;
   Promise<boolean> resolveToConfig;
@@ -590,29 +590,35 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       to undefined.
     1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/sellerSignals}}"] [=map/exists=]:
-  1. If |config|["{{AuctionAdConfig/sellerSignals}}"] is a {{Promise}}:
-    1. Set |auctionConfig|'s [=auction config/seller signals=] to
-      |config|["{{AuctionAdConfig/sellerSignals}}"].
-    1. Increment |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/seller signals=] with |result|:
-      1. Set |auctionConfig|'s [=auction config/seller signals=] to the result of
-        [=serializing a JavaScript value to a JSON string=], given |result|.
-      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon rejection=] of |auctionConfig|'s [=auction config/seller signals=]:
-      1. Set |auctionConfig|'s [=auction config/seller signals=] to failure.
-      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. Otherwise, set |auctionConfig|'s [=auction config/seller signals=] to the result of
-    [=serializing a JavaScript value to a JSON string=], given
+  1. Set |auctionConfig|'s [=auction config/seller signals=] to
     |config|["{{AuctionAdConfig/sellerSignals}}"].
-1. If |config|["{{AuctionAdConfig/directFromSellerSignals}}"] [=map/exists=], let
-  |directFromSellerSignalsPrefix| be the result of running the [=URL parser=] on
-  |config|["{{AuctionAdConfig/directFromSellerSignals}}"].
-  1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
-    * |directFromSellerSignalsPrefix| is failure;
-    * |directFromSellerSignalsPrefix| is not [=same origin=] with |auctionConfig|'s
-      [=auction config/seller=];
-    * |directFromSellerSignalsPrefix|'s [=url/query=] is not null.
-  1. [=Assert=]: |directFromSellerSignalsPrefix|'s [=url/scheme=] is "`https`".
+  1. Increment |auctionConfig|'s [=auction config/pending promise count=].
+  1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps
+    [=upon fulfillment=] of |auctionConfig|'s [=auction config/seller signals=] with |result|:
+    1. Set |auctionConfig|'s [=auction config/seller signals=] to the result of
+      [=serializing a JavaScript value to a JSON string=], given |result|.
+    1. If the previous steps did not [=exception/throw=] an exception:
+      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon rejection=] of |resolvedAndTypeChecked|:
+    1. Set |auctionConfig|'s [=auction config/seller signals=] to failure.
+    1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+1. If |config|["{{AuctionAdConfig/directFromSellerSignals}}"] [=map/exists=]:
+  1. TODO: nothing actually looks at this!
+  1. Increment |auctionConfig|'s [=auction config/pending promise count=].
+  1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps
+    [=upon fulfillment=] of |config|["{{AuctionAdConfig/directFromSellerSignals}}"] with |result|:
+      1. Let |directFromSellerSignalsPrefix| be the result of running the [=URL parser=] on |result|.
+    1. [=exception/Throw=] a {{TypeError}} if any of the following conditions hold:
+      * |directFromSellerSignalsPrefix| is failure;
+      * |directFromSellerSignalsPrefix| is not [=same origin=] with |auctionConfig|'s
+        [=auction config/seller=];
+      * |directFromSellerSignalsPrefix|'s [=url/query=] is not null.
+    1. If the previous steps did not [=exception/throw=] an exception:
+      1. [=Assert=]: |directFromSellerSignalsPrefix|'s [=url/scheme=] is "`https`".
+      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon rejection=] of |resolvedAndTypeChecked|:
+    1. TODO: set the rep in |auctionConfig| to failure.
+    1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/sellerTimeout}}"] [=map/exists=], set |auctionConfig|'s
   [=auction config/seller timeout=] to |config|["{{AuctionAdConfig/sellerTimeout}}"] in milliseconds
   or 500 milliseconds, whichever is smaller.
@@ -641,41 +647,25 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     1. Set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
     1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=]:
-  1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] is a {{Promise}}:
-    1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to
+  1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to
       |config|["{{AuctionAdConfig/perBuyerTimeouts}}"].
-    1. Increment |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer timeouts=] with |result|:
-      1. Let |pendingException| be null.
-      1. If |result| is not a [=record=] mapping from {{USVString}} to {{unsigned long long}}, set
-        |pendingException| to a {{TypeError}} and jump to the step labeled
-        <i><a href=#validate-per-buyer-timeouts-finish>finish</a></i>.
-      1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to a new [=ordered map=] whose
-        [=map/keys=] are [=origins=] and whose [=map/values=] are [=durations=] in milliseconds.
-      1. [=map/For each=] |key| → |value| of |result|:
-        1. If |key| is "*", then set |auctionConfig|'s [=auction config/all buyers timeout=]
-          to |value| in milliseconds or 500 milliseconds, whichever is smaller, and [=iteration/continue=].
-        1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
-          set |pendingException| to a {{TypeError}} and jump to the step labeled
-          <i><a href=#validate-per-buyer-timeouts-finish>finish</a></i>.
-        1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer timeouts=][|buyer|] to
-          |value| in milliseconds or 500 milliseconds, whichever is smaller.
-      1. <i id=validate-per-buyer-timeouts-finish>Finish</i>:
-        1. If |pendingException| is not null:
-          1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to failure.
-          1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-          1. [=exception/Throw=] |pendingException|.
-        1. Otherwise, decrement |auctionConfig|'s [=auction config/pending promise count=].
-    1. [=Upon rejection=] of |auctionConfig|'s [=auction config/per buyer timeouts=]:
-      1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to failure.
-      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
-  1. [=map/for each=] |key| → |value| of |config|["{{AuctionAdConfig/perBuyerTimeouts}}"]:
-    1. If |key| is "*", then set |auctionConfig|'s [=auction config/all buyers timeout=]
-      to |value| in milliseconds or 500 milliseconds, whichever is smaller, and [=iteration/continue=].
-    1. Let |buyer| the result of [=parsing an origin=] with |key|. If |buyer| is failure,
-      [=exception/throw=] a {{TypeError}}.
-    1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer timeouts=][|buyer|] to
-      |value| in milliseconds or 500 milliseconds, whichever is smaller.
+  1. Increment |auctionConfig|'s [=auction config/pending promise count=].
+  1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps [=upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer timeouts=] with |result|:
+    1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to a new [=ordered map=] whose
+      [=map/keys=] are [=origins=] and whose [=map/values=] are [=durations=] in milliseconds.
+    1. [=map/For each=] |key| → |value| of |result|:
+      1. If |key| is "*", then set |auctionConfig|'s [=auction config/all buyers timeout=]
+        to |value| in milliseconds or 500 milliseconds, whichever is smaller, and [=iteration/continue=].
+      1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
+        [=exception/throw=] a {{TypeError}}.
+      1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer timeouts=][|buyer|] to
+        |value| in milliseconds or 500 milliseconds, whichever is smaller.
+      1. If the previous steps did not [=exception/throw=] an exception:
+        1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to failure.
+        1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon rejection=] of |resolvedAndTypeChecked|:
+    1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to failure.
+    1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. If |config|["{{AuctionAdConfig/perBuyerGroupLimits}}"] [=map/exists=], [=map/for each=]
   |key| → |value| of |config|["{{AuctionAdConfig/perBuyerGroupLimits}}"]:
   1. If |value| is 0, [=exception/throw=] a {{TypeError}}.
@@ -704,15 +694,25 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     a {{TypeError}}.
   1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer priority signals=][|buyer|] to
     |signals|.
-1. If |config|["{{AuctionAdConfig/perBuyerCurrencies}}"] [=map/exists=], [=map/for each=]
-  |key| → |value| of |config|["{{AuctionAdConfig/perBuyerCurrencies}}"]:
-  1. If the result of [=checking whether a string is a valid currency tag=] given |value| is false,
-    [=exception/throw=] a {{TypeError}}.
-  1. If |key| is "*", then set |auctionConfig|'s
-    [=auction config/all buyers currency=] to |value|, and [=iteration/continue=].
-  1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
-    [=exception/throw=] a {{TypeError}}.
-  1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer currencies=][|buyer|] to |value|.
+1. If |config|["{{AuctionAdConfig/perBuyerCurrencies}}"] [=map/exists=]:
+  1. Set |auctionConfig|'s [=auction config/per buyer currencies=] to |config|["{{AuctionAdConfig/perBuyerCurrencies}}"]
+  1. Increment |auctionConfig|'s [=auction config/pending promise count=].
+  1. Let |resolvedAndTypeChecked| be the promise representing performing the following steps
+    [=upon fulfillment=] of |auctionConfig|'s [=auction config/per buyer currencies=] with |result|:
+    1. Set |auctionConfig|'s [=auction config/per buyer currencies=] to a new [=ordered map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=currency tags=].
+    1. [=map/for each=] |key| → |value| of |result|:
+      1. If the result of [=checking whether a string is a valid currency tag=] given |value| is false,
+        [=exception/throw=] a {{TypeError}}.
+      1. If |key| is "*", then set |auctionConfig|'s
+        [=auction config/all buyers currency=] to |value|, and [=iteration/continue=].
+      1. Let |buyer| be the result of [=parsing an origin=] with |key|. If |buyer| is failure,
+        [=exception/throw=] a {{TypeError}}.
+      1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer currencies=][|buyer|] to |value|.
+    1. If the previous steps did not [=exception/throw=] an exception:
+      1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
+  1. [=Upon rejection=] of |resolvedAndTypeChecked|:
+    1. Set |auctionConfig|'s [=auction config/per buyer currencies=] to failure.
+    1. Decrement |auctionConfig|'s [=auction config/pending promise count=].
 1. [=list/For each=] |component| in |config|["{{AuctionAdConfig/componentAuctions}}"]:
   1. If |isTopLevel| is false, [=exception/throw=] a {{TypeError}}.
   1. Let |componentAuction| be the result of running [=validate and convert auction ad config=] with
@@ -722,6 +722,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 1. If |config|["{{AuctionAdConfig/resolveToConfig}}"] [=map/exists=]:
   1. Let |auctionConfig|'s [=auction config/resolve to config=] be
      |config|["{{AuctionAdConfig/resolveToConfig}}"].
+  1. TODO: What should happen if this rejects?
   1. [=Upon fulfillment=] of |auctionConfig|'s [=auction config/resolve to config=] with
      |resolveToConfig|, set |auctionConfig|'s [=auction config/resolve to config=] to
      |resolveToConfig|.
@@ -837,6 +838,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       |auctionConfig|, |global|, and |settings|.
     1. If |compWinner| is failure, return failure.
     1. If |compWinner| is not null:
+      1. If [=waiting until configuration input promises resolve=] given |auctionConfig| returns failure, return failure.
       1. Run [=score and rank a bid=] with |auctionConfig|, |compWinner|, |leadingBidInfo|,
         |decisionLogicScript|, null, "top-level-auction", null, and |settings|'s [=environment/top-level origin=].
 
@@ -860,17 +862,12 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. Run [=report win=] with |leadingBidInfo|, |sellerSignals|, and |reportResultBrowserSignals|.
   1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
 
+1. If [=waiting until configuration input promises resolve=] given |auctionConfig| returns failure, return failure.
 1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
   [=auction config/all buyer experiment group id=].
 1. Let |allBuyersGroupLimit| be |auctionConfig|'s
   [=auction config/all buyers group limit=].
-1. Wait until |auctionConfig|'s [=auction config/pending promise count=] is 0.
 1. Let |auctionSignals| be |auctionConfig|'s [=auction config/auction signals=].
-1. [=Assert=] |auctionSignals|, |auctionConfig|'s [=auction config/seller signals=],
-  [=auction config/per buyer signals=], and [=auction config/per buyer timeouts=] are not {{Promise}}s.
-1. If |auctionSignals|, |auctionConfig|'s [=auction config/seller signals=],
-  [=auction config/per buyer signals=], or [=auction config/per buyer timeouts=] is failure, return
-  failure.
 1. Let |browserSignals| be a {{BiddingBrowserSignals}}.
 1. Let |topLevelHost| be the result of running the <a spec=url>host serializer</a> on [=this=]'s
   [=relevant settings object=]'s [=environment/top-level origin=]'s [=origin/host=].
@@ -2671,8 +2668,7 @@ An auction config is a [=struct=] with the following items:
   trusted servers for buyers without a specified experiment group.
 : <dfn>pending promise count</dfn>
 :: An integer, initially 0. The number of [=auction config/auction signals=],
-  [=auction config/per buyer signals=], [=auction config/per buyer timeouts=], or
-  [=auction config/seller signals=] whose {{Promise}}s are not yet resolved.
+  [=auction config/per buyer signals=], [=auction config/per buyer currencies=], [=auction config/per buyer timeouts=], directFromSellerSignals, or [=auction config/seller signals=] whose {{Promise}}s are not yet resolved.
 : <dfn>config idl</dfn>
 :: {{AuctionAdConfig}}.
 : <dfn>resolve to config</dfn>
@@ -2683,8 +2679,7 @@ An auction config is a [=struct=] with the following items:
   which reporting for this auction will agree on.
 
 : <dfn>per buyer currencies</dfn>
-:: An [=ordered map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are
-  [=currency tags=]. Specifies the currency bids returned by `generateBid()` or `scoreAd()` in
+:: Null or a {{Promise}} or failure or an [=ordered map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=currency tags=]. Specifies the currency bids returned by `generateBid()` or `scoreAd()` in
   component auctions are expected to use.
 
 : <dfn>all buyers currency</dfn>
@@ -2696,10 +2691,20 @@ An auction config is a [=struct=] with the following items:
 </dl>
 
 <div algorithm>
+To <dfn>wait until configuration input promises resolve</dfn> given an [=auction config=] |auctionConfig|:
+1. Wait until |auctionConfig|'s [=auction config/pending promise count=] is 0.
+1. [=Assert=] |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=], [=auction config/per buyer signals=], [=auction config/per buyer currencies=], and [=auction config/per buyer timeouts=] are not {{Promise}}s.
+1. If |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
+  [=auction config/per buyer signals=], [=auction config/per buyer currencies=] or [=auction config/per buyer timeouts=] is failure, return failure.
+1. TODO: the above two steps should also check directFromSellerSignals once something handles it.
+
+</div>
+
+<div algorithm>
   To <dfn>look up per-buyer currency</dfn> given an [=auction config=] |auctionConfig|, and an [=origin=] |buyer|:
 
   1. Let |perBuyerCurrency| be |auctionConfig|'s [=auction config/all buyers currency=]
-  1. If |auctionConfig|'s [=auction config/per buyer currencies=][|buyer|] [=map/exists=]:
+  1. If |auctionConfig|'s [=auction config/per buyer currencies=] is an [=ordered map=] and |auctionConfig|'s [=auction config/per buyer currencies=][|buyer|] [=map/exists=]:
       1. Set |perBuyerCurrency| to |auctionConfig|'s [=auction config/per buyer currencies=][|buyer|].
   1. Return |perBuyerCurrency|
 </div>


### PR DESCRIPTION
1. Convert the other fields (except resolveToConfig, which is special) to behave the way perBuyerSignals does, simplifying the language some and making them more web-y.
2. Make perBuyerCurrencies handle promises as well.
3. Hopefully fix a bug where we weren't actually waiting on promises for top-level config in a 2-level auction.