### PR TITLE
setBid/generateBid return has field "render", not "adRender"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1940,7 +1940,7 @@ dictionary AdRender {
 dictionary GenerateBidOutput {
   required double bid;
   DOMString bidCurrency;
-  required (DOMString or AdRender) adRender;
+  required (DOMString or AdRender) render;
   any ad;
   sequence<(DOMString or AdRender)> adComponents;
   double adCost;
@@ -2003,15 +2003,15 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
     1. If |adJSON| is failure, return failure.
     1. Set |bid|'s [=generated bid/ad=] to |adJSON|.
   1. Let |adDescriptor| be a new [=ad descriptor=].
-  1. If |generateBidOutput|["{{GenerateBidOutput/adRender}}"] is a {{DOMString}}:
+  1. If |generateBidOutput|["{{GenerateBidOutput/render}}"] is a {{DOMString}}:
     1. Let |adUrl| be the result of running the [=URL parser=] on
-      |generateBidOutput|["{{GenerateBidOutput/adRender}}"].
+      |generateBidOutput|["{{GenerateBidOutput/render}}"].
     1. If |adUrl| is failure, return failure.
     1. If [=validating an ad url=] given |adUrl|, |ig|, and false returns false, return failure.
     1. Set |adDescriptor|'s [=ad descriptor/url=] to |adUrl|.
   1. Otherwise:
     1. Set |adDescriptor| to the result of [=converting an ad render=] given
-      |generateBidOutput|["{{GenerateBidOutput/adRender}}"], |ig| and false.
+      |generateBidOutput|["{{GenerateBidOutput/render}}"], |ig| and false.
     1. If |adDescriptor| is failure, return failure.
   1. Set |bid|'s [=generated bid/ad descriptor=] to |adDescriptor|.
   1. If |generateBidOutput|["{{GenerateBidOutput/adComponents}}"] [=map/exists=]:


### PR DESCRIPTION
Ref: https://github.com/WICG/turtledove/blob/main/FLEDGE.md#32-on-device-bidding and https://source.chromium.org/chromium/chromium/src/+/main:content/services/auction_worklet/set_bid_bindings.cc;drc=1cb8b66be9b3aeea93bbc28642abe8d8425415c0;l=276


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/656.html" title="Last updated on Jun 22, 2023, 2:48 PM UTC (4a6667a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/656/6ca983f...morlovich:4a6667a.html" title="Last updated on Jun 22, 2023, 2:48 PM UTC (4a6667a)">Diff</a>