### PR TITLE
Finish a todo of setting browserSignal's data-version field.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1465,8 +1465,8 @@ null |winningComponentConfig|:
       [=leading bid info/highest scoring other bid=]'s [=generated bid/bid in seller currency=] (or
       0 if encountered a null).
     1. [=map/Set=] |browserSignals|["`highestScoringOtherBidCurrency`"] to |sellerCurrency|.
-  1. TODO: if trusted scoring signals response data version is not null, set
-    |browserSignals|["`dataVersion`"].
+  1. If |leadingBidInfo|'s [=leading bid info/scoring data version=] is not null, [=map/Set=]
+    |browserSignals|["`dataVersion`"] to it.
   1. If |leadingBidInfo|'s [=leading bid info/top level seller=] is not null, [=map/set=]
     |browserSignals|["`topLevelSeller`"] to it.
   1. If |leadingBidInfo|'s [=leading bid info/top level seller signals=] is not null, [=map/set=]

--- a/spec.bs
+++ b/spec.bs
@@ -1207,8 +1207,8 @@ To <dfn>validate fetching response</dfn> given a [=response=] |response|, null, 
 [=byte sequence=]|responseBody|, and a [=string=] |mimeType|:
 
   1. If |responseBody| is null or failure, return false.
-  1. If [=header list/getting a structured field value|getting=] "X-Allow-Protected-Audience" from
-    |response|'s [=response/header list=] does not return true, return false.
+  1. If [=header list/getting a structured field value|getting=] "X-Allow-Protected-Audience" and
+    "`item`" from |response|'s [=response/header list=] does not return true, return false.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |response|'s
     [=response/header list=].
   1. Return false if any of the following conditions hold:
@@ -1278,8 +1278,8 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url|:
     a [=response=] |response| and |responseBody|:
     1. Set |moduleObject| to failure and return, if any of the following conditions hold:
       * |responseBody| is null or failure;
-      * [=header list/getting a structured field value|Getting=] "X-Allow-Protected-Audience" from
-        |response|'s [=response/header list=] does not return true.
+      * [=header list/getting a structured field value|Getting=] "X-Allow-Protected-Audience" and
+        "`item`" from |response|'s [=response/header list=] does not return true.
     1. Let |module| be the result of [=compiling a WebAssembly module=] |response|.
     1. If |module| is [=error=], set |moduleObject| to failure.
     1. Otherwise, set |moduleObject| to |module|.

--- a/spec.bs
+++ b/spec.bs
@@ -2949,7 +2949,7 @@ JavaScript is controlled and limited as follows:
   {{Navigator/joinAdInterestGroup()}}.
 - URL schemes are required to be HTTPS.
 - Redirects are disallowed.
-- Responses are required to contain the `X-Allow-Protected-Audience: true` header.
+- Responses are required to contain the `X-Allow-Protected-Audience: ?1` header.
 - Fetches are uncredentialed.
 
 Protected Audience has the browser pass in several “browserSignals” to the bidding script that give the script


### PR DESCRIPTION
Also provides "list" as a parameter to get structured head list as it
needs.

Also changed header's "true" to "?1" since the latter is the correct
true value for headers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/657.html" title="Last updated on Jun 22, 2023, 3:30 PM UTC (0e75d59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/657/12611fb...qingxinwu:0e75d59.html" title="Last updated on Jun 22, 2023, 3:30 PM UTC (0e75d59)">Diff</a>