### PR TITLE
Remove an obsolete todo about data-version.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1365,7 +1365,6 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
     1. If |dataVersion| is not null:
       1. If |dataVersion| is not an integer, or is less than 0 or more than 4294967295, set
         |signals| to failure and return.
-      1. TODO: Check whether version is consistent for all keys requested by this interest group.
     1. If |isBiddingSignal| is true:
       1. Set |formatVersion| to the result of [=header list/getting a structured field value=]
         given [:X-protected-audience-bidding-signals-format-version:] and "`item`" from |headers|.


### PR DESCRIPTION
The explainer mentioned requesting trusted bidding signals using multiple requests (for a `generateBid()`), and then need to make sure that the Data-Version header's value is consistent in these responses. That's only kept there as an open option (possible optimization), but not what's implemented. So removing the todo which is obsolete.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/661.html" title="Last updated on Jun 23, 2023, 8:34 PM UTC (f5d532d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/661/b67ce35...qingxinwu:f5d532d.html" title="Last updated on Jun 23, 2023, 8:34 PM UTC (f5d532d)">Diff</a>