### PR TITLE
Fix trusted scoring signals related steps.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1094,41 +1094,40 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
 "single-level-auction", "top-level-auction", or "component-auction", a [=currency tag=]
 |componentAuctionExpectedCurrency|, and an [=origin=] |topWindowOrigin|:
 
-1. Let |renderURLs| be a new [=set=].
-1. Let |adComponentRenderUrls| be a new [=set=].
-1. [=set/Append=] |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=] to |renderURLs|.
+1. Let |renderURL| be [=URL serializer|serialized=] |generatedBid|'s
+  [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
+1. Let |adComponentRenderURLs| be a new empty [=list=].
 1. If |generatedBid|'s [=generated bid/ad component descriptors=] is not null:
-  1. [=set/For each=] |adComponentDescriptor| in |generatedBid|'s
+  1. [=list/For each=] |adComponentDescriptor| in |generatedBid|'s
     [=generated bid/ad component descriptors=]:
-    1. [=set/Append=] |adComponentDescriptor|'s [=ad descriptor/url=] to |adComponentRenderUrls|.
+    1. [=list/Append=] [=URL serializer|serialized=] |adComponentDescriptor|'s [=ad descriptor/url=]
+      to |adComponentRenderURLs|.
 1. Let |fullSignalsUrl| be the result of [=building trusted scoring signals url=] with |auctionConfig|'s
-  [=auction config/trusted scoring signals url=], |renderURLs|, |adComponentRenderUrls|,
+  [=auction config/trusted scoring signals url=], «|renderURL|», |adComponentRenderURLs|,
   |auctionConfig|'s [=auction config/seller experiment group id=], and |topWindowOrigin|.
 
   Implementations may batch requests by collecting render URLs and ad component render URLs
   from multiple invocations of [=score and rank a bid=] and passing them all to a single invocation
-  of [=building trusted scoring signals url=] -- the network response has to be parsed to pull out the pieces
-  relevant to each [=evaluating a scoring script|evaluation of a scoring script=].
+  of [=building trusted scoring signals url=] -- the network response has to be parsed to pull out
+  the pieces relevant to each [=evaluating a scoring script|evaluation of a scoring script=].
 1. Let |trustedScoringSignals| be null.
-1. Let «|allTrustedScoringSignals|, |scoringDataVersion|» be the result of [=fetching trusted signals=] with
-  |fullSignalsUrl| and false.
+1. Let «|allTrustedScoringSignals|, |scoringDataVersion|» be the result of [=fetching trusted signals=]
+  with |fullSignalsUrl| and false.
 1. If |allTrustedScoringSignals| is an [=ordered map=]:
-  1. Let |trustedScoringSignals| be a new [=map=].
-  1. [=Assert=]: |renderURLs|'s [=set/size=] is 1.
-  1. [=set/For each=] |renderURL| in |renderURLs|:
-    1. If |allTrustedScoringSignals|["`renderURLs`"] [=map/exists=] and
-      |allTrustedScoringSignals|["`renderURLs`"][|renderURL|] [=map/exists=]:
-      1. Let |renderURLValue| be a new [=map=].
-      1. [=map/Set=] |renderURLValue|[|renderURL|] to |allTrustedScoringSignals|["`renderURLs`"][|renderURL|].
-      1. [=map/Set=] |trustedScoringSignals|["`renderURL`"] to |renderURLValue|.
-  1. Let |adComponentRenderUrlsValue| be a new [=map=].
-  1. [=set/For each=] |adComponentRenderUrl| in |adComponentRenderUrls|:
-    1. If |allTrustedScoringSignals|["`adComponentRenderUrls`"] [=map/exists=] and
-      |allTrustedScoringSignals|["`adComponentRenderUrls`"][|adComponentRenderUrl|] [=map/exists=]:
-      1. [=map/Set=] |adComponentRenderUrlsValue|[|adComponentRenderUrl|] to
-          |allTrustedScoringSignals|["`adComponentRenderUrls`"][|adComponentRenderUrl|].
-  1. If |adComponentRenderUrlsValue| is not [=map/is empty|empty=]:
-    1. [=map/Set=] |trustedScoringSignals|["`adComponentRenderUrls`"] to |adComponentRenderUrlsValue|.
+  1. Set |trustedScoringSignals| to a new empty [=map=].
+  1. [=map/Set=] |trustedScoringSignals|["`renderURL`"] to a new empty [=map=].
+  1. If |allTrustedScoringSignals|["`renderURLs`"] [=map/exists=] and
+    |allTrustedScoringSignals|["`renderURLs`"][|renderURL|] [=map/exists=]:
+    1. [=map/Set=] |trustedScoringSignals|["`renderURL`"][|renderURL|] to
+      |allTrustedScoringSignals|["`renderURLs`"][|renderURL|].
+  1. If |adComponentRenderURLs| is not [=list/empty=]:
+    1. Let |adComponentRenderURLsValue| be a new empty [=map=].
+    1. If |allTrustedScoringSignals|["`adComponentRenderURLs`"] [=map/exists=], [=set/for each=]
+      |adComponentRenderURL| in |adComponentRenderURLs|:
+      1. If |allTrustedScoringSignals|["`adComponentRenderURLs`"][|adComponentRenderURL|] [=map/exists=]:
+        1. [=map/Set=] |adComponentRenderURLsValue|[|adComponentRenderURL|] to
+          |allTrustedScoringSignals|["`adComponentRenderURLs`"][|adComponentRenderURL|].
+    1. [=map/Set=] |trustedScoringSignals|["`adComponentRenderURLs`"] to |adComponentRenderURLsValue|.
 1. Let |adMetadata| be |generatedBid|'s [=generated bid/ad=].
 1. Let |bidValue| be |generatedBid|'s [=generated bid/bid=].
 1. If |generatedBid|'s [=generated bid/modified bid=] is not null:
@@ -1433,29 +1432,24 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
 
 <div algorithm>
 
-To <dfn>build trusted scoring signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
-[=URLs=] |renderURLs|, an [=ordered set=] of [=URLs=] |adComponentRenderUrls|, an {{unsigned short}}
-|experimentGroupId|, and an [=origin=] |topWindowOrigin|:
+To <dfn>build trusted scoring signals url</dfn> given a [=URL=] |signalsUrl|, a [=list=] of
+[=strings=] |renderURLs|, an [=ordered set=] of [=strings=] |adComponentRenderURLs|, an
+{{unsigned short}} |experimentGroupId|, and an [=origin=] |topWindowOrigin|:
+
+Note: When trusted scoring signals fetches are not batched, |renderURLs|'s [=list/size=] is 1.
+
 1. Let |queryParamsList| be a new empty [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |topWindowOrigin| using
   [=component percent-encode set=] to |queryParamsList|.
 1. If |renderURLs| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&renderURLs=" to |queryParamsList|.
-  1. Let |renderURLsStrings| be a new empty [=list=].
-  1. [=list/For each=] |renderURL| of |renderURLs|:
-    1. [=list/Append=] the result of [=URL serializer|serialization=] of |renderURL| to
-      |renderURLsStrings|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
-    |renderURLsStrings|.
-1. If |adComponentRenderUrls| is not [=set/is empty|empty=]:
-  1. [=list/Append=] "&adComponentRenderUrls=" to |queryParamsList|.
-  1. Let |adComponentRenderUrlsStrings| be a new empty [=list=].
-  1. [=list/For each=] |adComponentRenderUrl| of |adComponentRenderUrls|:
-    1. [=list/Append=] the result of [=URL serializer|serialization=] of |adComponentRenderUrl| to
-      |adComponentRenderUrlsStrings|.
+    |renderURLs|.
+1. If |adComponentRenderURLs| is not [=set/is empty|empty=]:
+  1. [=list/Append=] "&adComponentRenderURLs=" to |queryParamsList|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
-    |adComponentRenderUrlsStrings|.
+    |adComponentRenderURLs|.
 1. If |experimentGroupId| is not null:
   1. [=list/Append=] "&experimentGroupId=" to |queryParamsList|.
   1. [=list/Append=] [=serialize an integer|serialized=] |experimentGroupId| to |queryParamsList|.
@@ -1914,9 +1908,14 @@ of the following global objects:
     1. Let |realm| be the result of [=creating a new script runner realm=] given
       {{InterestGroupScoringScriptRunnerGlobalScope}}.
     1. Let |browserSignalsJS| be |browserSignals| [=converted to ECMAScript values=].
-    1. TODO: convert |trustedScoringSignals| to a JS value.
+    1. Let |convertedTrustedScoringSignals| be a new empty [=map].
+    1. [=map/For each=] |key| -> |value| of |trustedScoringSignals|:
+      1. Let |valueString| be the result of [=serializing an Infra value to a JSON string=] given
+        |value|.
+      1. If the previous steps did not [=exception/throw=] an exception:
+        1. [=map/Set=] |convertedTrustedScoringSignals||key| to |valueString|.
     1. Return the result of [=evaluating a script=] with |realm|, |script|, "`scoreAd`",
-      «|adMetadata|, |bidValue|, |auctionConfigIDL|, |trustedScoringSignals|, |browserSignalsJS|»,
+      «|adMetadata|, |bidValue|, |auctionConfigIDL|, |convertedTrustedScoringSignals|, |browserSignalsJS|»,
       and |timeout|.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1622,10 +1622,8 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
   1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,
     null ».
   1. [=map/For each=] |key| → |value| of |signals|:
-    1. Let |serializedValue| be the result of [=serializing an Infra value to a JSON string=] given
-      |value|.
-    1. If |serializedValue| is not {{undefined}}:
-      1. [=map/Set=] |signals|[|key|] to |serializedValue|.
+    1. [=map/Set=] |signals|[|key|] to the result of [=serializing an Infra value to a JSON string=]
+      given |value|.
   1. If |formatVersion| is 2:
     1. If |signals|["`keys`"] does not [=map/exist=], return « null, null ».
     1. Set |signals| to |signals|["`keys`"].

--- a/spec.bs
+++ b/spec.bs
@@ -1621,6 +1621,11 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
   1. Wait for |signals| to be set.
   1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,
     null ».
+  1. [=map/For each=] |key| → |value| of |signals|:
+    1. Let |serializedValue| be the result of [=serializing an Infra value to a JSON string=] given
+      |value|.
+    1. If |serializedValue| is not {{undefined}}:
+      1. [=map/Set=] |signals|[|key|] to |serializedValue|.
   1. If |formatVersion| is 2:
     1. If |signals|["`keys`"] does not [=map/exist=], return « null, null ».
     1. Set |signals| to |signals|["`keys`"].
@@ -2120,10 +2125,11 @@ of the following global objects:
       |auctionSignals| if |auctionSignals| is not null, otherwise {{undefined}}.
     1. Let |perBuyerSignalsJS| be the result of [=parsing a JSON string to a JavaScript value=]
       given |perBuyerSignals| if |perBuyerSignals| is not null, otherwise {{undefined}}.
+    1. Let |trustedBiddingSignalsJS| be |trustedBiddingSignals| [=converted to ECMAScript values=]. 
     1. Let |browserSignalsJS| be |browserSignals| [=converted to ECMAScript values=].
     1. Let |startTime| be the [=current wall time=].
     1. Let |result| be the result of [=evaluating a script=] with |realm|, |script|, "`generateBid`",
-      « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignals|, |browserSignalsJS| »,
+      « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS| »,
       and |timeout|.
     1. Let |duration| be the [=current wall time=] minus |startTime| in milliseconds.
     1. If |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] is not null:
@@ -2163,17 +2169,8 @@ of the following global objects:
     1. Let |realm| be the result of [=creating a new script runner realm=] given
       {{InterestGroupScoringScriptRunnerGlobalScope}}.
     1. Let |browserSignalsJS| be |browserSignals| [=converted to ECMAScript values=].
-    1. Let |convertedTrustedScoringSignals| be a new empty [=map].
-    1. [=map/For each=] |key| -> |value| of |trustedScoringSignals|:
-      1. Let |valueString| be the result of [=serializing an Infra value to a JSON string=] given
-        |value|.
-      1. If the previous steps did not [=exception/throw=] an exception:
-        1. [=map/Set=] |convertedTrustedScoringSignals||key| to |valueString|.
-    1. Let |auctionConfigJS| be the result of [=converted to ECMAScript values|converting=]
-      |auctionConfigIDL| to an ECMAScript value.
-    1. Let |trustedScoringSignalsJS| be the result of
-      [=converting an Infra value to a JSON-compatible JavaScript value=] given
-      |convertedTrustedScoringSignals|.
+    1. Let |auctionConfigJS| be |auctionConfigIDL| [=converted to ECMAScript values=].
+    1. Let |trustedScoringSignalsJS| be |trustedScoringSignals| [=converted to ECMAScript values=].
     1. Return the result of [=evaluating a script=] with |realm|, |script|, "`scoreAd`",
       «|adMetadata|, |bidValue|, |auctionConfigJS|, |trustedScoringSignalsJS|, |browserSignalsJS|»,
       and |timeout|.

--- a/spec.bs
+++ b/spec.bs
@@ -29,6 +29,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/C
     text: create an agent; url: create-an-agent
     text: immediately; url: immediately
     text: valid floating-point number; url: valid-floating-point-number
+spec: infra; urlPrefix: https://infra.spec.whatwg.org/
+  type: dfn
+    text: convert an Infra value to a JSON-compatible JavaScript value; url: #convert-an-infra-value-to-a-json-compatible-javascript-value
 spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
   type: dfn
     text: structured header; url: top
@@ -1914,8 +1917,13 @@ of the following global objects:
         |value|.
       1. If the previous steps did not [=exception/throw=] an exception:
         1. [=map/Set=] |convertedTrustedScoringSignals||key| to |valueString|.
+    1. Let |auctionConfigJS| be the result of [=converted to ECMAScript values|converting=]
+      |auctionConfigIDL| to an ECMAScript value.
+    1. Let |trustedScoringSignalsJS| be the result of
+      [=converting an Infra value to a JSON-compatible JavaScript value=] given
+      |convertedTrustedScoringSignals|.
     1. Return the result of [=evaluating a script=] with |realm|, |script|, "`scoreAd`",
-      «|adMetadata|, |bidValue|, |auctionConfigIDL|, |convertedTrustedScoringSignals|, |browserSignalsJS|»,
+      «|adMetadata|, |bidValue|, |auctionConfigJS|, |trustedScoringSignalsJS|, |browserSignalsJS|»,
       and |timeout|.
 </div>
 


### PR DESCRIPTION
For trusted scoring signals fetch:
1. In [score and rank a bid](https://wicg.github.io/turtledove/#score-and-rank-a-bid), changed |renderURLs| to |renderURL| since we're not batching the fetches from multiple scoreAd() (we asserted that |renderURLs|'s size was 1). Also reword related steps.
2. In [=fetch trusted signals=], serialize values of the signals map, and it can be converted to a JS value using WebIDL convert algorithm since it (map<string, string>) can be treated as a record.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/685.html" title="Last updated on Jul 18, 2023, 5:43 PM UTC (e6bffe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/685/0854804...qingxinwu:e6bffe4.html" title="Last updated on Jul 18, 2023, 5:43 PM UTC (e6bffe4)">Diff</a>