### PR TITLE
Fix attribution-report link error.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -41,9 +41,6 @@ spec: WebAssembly; urlPrefix: https://webassembly.github.io/spec/core/
 spec: WebAssembly-js-api; urlPrefix: https://webassembly.github.io/spec/js-api/
   type: dfn
     text: compiling a WebAssembly module; url: #compile-a-webassembly-module
-spec: attribution-reporting-api; urlPrefix: https://wicg.github.io/attribution-reporting-api/
-  type: dfn
-    text: attribution-reporting; url: #dom-permissionpolicy-attribution-reporting
 spec: Fenced Frame; urlPrefix: https://wicg.github.io/fenced-frame/
   type: dfn
     for: browsing context
@@ -602,7 +599,7 @@ To <dfn>construct a pending fenced frame config</dfn> given an [=auction config=
   : [=fenced frame config/effective enabled permissions=]
   :: a [=struct=] with the following [=struct/items=]:
     : [=effective enabled permissions/value=]
-    :: «"<code><a>attribution-reporting</a></code>",
+    :: «"{{PermissionPolicy/attribution-reporting}}",
         "<code>private-aggregation</code>" (TODO:ref), "<code>shared-storage</code>" (TODO:ref),
         "<code>shared-storage-select-url</code>" (TODO:ref)»
 
@@ -781,7 +778,7 @@ To <dfn>create nested configs</dfn> given [=generated bid/ad component descripto
     : [=fenced frame config/effective enabled permissions=]
     :: a [=struct=] with the following [=struct/items=]:
       : [=effective enabled permissions/value=]
-      :: «"<code><a>attribution-reporting</a></code>",
+      :: «"{{PermissionPolicy/attribution-reporting}}",
           "<code>private-aggregation</code>" (TODO:ref), "<code>shared-storage</code>" (TODO:ref),
           "<code>shared-storage-select-url</code>" (TODO:ref)»
 

--- a/spec.bs
+++ b/spec.bs
@@ -41,9 +41,9 @@ spec: WebAssembly; urlPrefix: https://webassembly.github.io/spec/core/
 spec: WebAssembly-js-api; urlPrefix: https://webassembly.github.io/spec/js-api/
   type: dfn
     text: compiling a WebAssembly module; url: #compile-a-webassembly-module
-spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-reporting-api/
+spec: attribution-reporting-api; urlPrefix: https://wicg.github.io/attribution-reporting-api/
   type: dfn
-    text: attribution-reporting
+    text: attribution-reporting; url: #dom-permissionpolicy-attribution-reporting
 spec: Fenced Frame; urlPrefix: https://wicg.github.io/fenced-frame/
   type: dfn
     for: browsing context
@@ -602,7 +602,7 @@ To <dfn>construct a pending fenced frame config</dfn> given an [=auction config=
   : [=fenced frame config/effective enabled permissions=]
   :: a [=struct=] with the following [=struct/items=]:
     : [=effective enabled permissions/value=]
-    :: «"<code><a spec="attribution-reporting-api">attribution-reporting</a></code>",
+    :: «"<code><a>attribution-reporting</a></code>",
         "<code>private-aggregation</code>" (TODO:ref), "<code>shared-storage</code>" (TODO:ref),
         "<code>shared-storage-select-url</code>" (TODO:ref)»
 
@@ -781,7 +781,7 @@ To <dfn>create nested configs</dfn> given [=generated bid/ad component descripto
     : [=fenced frame config/effective enabled permissions=]
     :: a [=struct=] with the following [=struct/items=]:
       : [=effective enabled permissions/value=]
-      :: «"<code><a spec="attribution-reporting-api">attribution-reporting</a></code>",
+      :: «"<code><a>attribution-reporting</a></code>",
           "<code>private-aggregation</code>" (TODO:ref), "<code>shared-storage</code>" (TODO:ref),
           "<code>shared-storage-select-url</code>" (TODO:ref)»
 

--- a/spec.bs
+++ b/spec.bs
@@ -599,7 +599,7 @@ To <dfn>construct a pending fenced frame config</dfn> given an [=auction config=
   : [=fenced frame config/effective enabled permissions=]
   :: a [=struct=] with the following [=struct/items=]:
     : [=effective enabled permissions/value=]
-    :: «"{{PermissionPolicy/attribution-reporting}}",
+    :: «"<code>{{PermissionPolicy/attribution-reporting}}</code>",
         "<code>private-aggregation</code>" (TODO:ref), "<code>shared-storage</code>" (TODO:ref),
         "<code>shared-storage-select-url</code>" (TODO:ref)»
 
@@ -778,7 +778,7 @@ To <dfn>create nested configs</dfn> given [=generated bid/ad component descripto
     : [=fenced frame config/effective enabled permissions=]
     :: a [=struct=] with the following [=struct/items=]:
       : [=effective enabled permissions/value=]
-      :: «"{{PermissionPolicy/attribution-reporting}}",
+      :: «"<code>{{PermissionPolicy/attribution-reporting}}</code>",
           "<code>private-aggregation</code>" (TODO:ref), "<code>shared-storage</code>" (TODO:ref),
           "<code>shared-storage-select-url</code>" (TODO:ref)»
 


### PR DESCRIPTION
Also let it link to the correct term in the spec, instead of the spec itself.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/698.html" title="Last updated on Jul 7, 2023, 6:47 PM UTC (2897895)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/698/aa7c04c...qingxinwu:2897895.html" title="Last updated on Jul 7, 2023, 6:47 PM UTC (2897895)">Diff</a>