### PR TITLE
Put quotes around 3 <a> hrefs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2079,8 +2079,8 @@ execution environment. In particular, they:
       1. If !|global|.\[[HasProperty]]("`Temporal`") is true, then perform
          !|global|.\[[Delete]]("`Temporal`").
 
-      Advisement: This is not the best way to perform such API neutering (see <a
-      href=https://github.com/tc39/ecma262/issues/1357#issuecomment-817560121>tc39/ecma262#1357</a>),
+      Advisement: This is not the best way to perform such API neutering (see
+      <a href="https://github.com/tc39/ecma262/issues/1357#issuecomment-817560121">tc39/ecma262#1357</a>),
       but at the moment it's the way that host environments do this.
 
       Note: Removing time-referencing APIs from the |global| object is imperative for privacy, as a
@@ -2222,12 +2222,12 @@ of the following global objects:
 
     1. Let |evaluationStatus| be the result of [$ScriptEvaluation$](result).
 
-    1. If |evaluationStatus| is an [=ECMAScript/abrupt completion=], jump to the step labeled <i><a
-       href=#evaluate-script-return>return</a></i>.
+    1. If |evaluationStatus| is an [=ECMAScript/abrupt completion=], jump to the step labeled <i>
+       <a href="#evaluate-script-return">return</a></i>.
 
     1. Let |F| be [$Get$](|global|, |functionName|). If that returns a [=ECMAScript/throw completion=],
-       set |finalCompletion| to |F| and jump to the step labeled <i><a
-       href=#evaluate-script-return>return</a></i>.
+       set |finalCompletion| to |F| and jump to the step labeled <i>
+       <a href="#evaluate-script-return">return</a></i>.
 
     1. Set |finalCompletion| be [=ECMAScript/Completion Record|Completion=]([$Call$](F, `undefined`,
        |arguments|)).


### PR DESCRIPTION
Should fix some pr-preview errors. It may be worth going through and ensuring all other tags have these quotes too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 18, 2023, 4:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fturtledove%2F66cc6c278ed3ee179a79f7a068b11a8d793bda7f%2Fspec.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Garbage at 2082:81 in &lt;a>.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/turtledove%23708.)._
</details>
