### PR TITLE
Fix buglet in setPrioritySignals.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2299,7 +2299,7 @@ interface InterestGroupBiddingScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
   boolean setBid(optional GenerateBidOutput generateBidOutput = {});
   undefined setPriority(double priority);
-  undefined setPrioritySignalsOverride(DOMString key, double priority);
+  undefined setPrioritySignalsOverride(DOMString key, optional double? priority);
 };
 
 dictionary AdRender {
@@ -2328,7 +2328,7 @@ Each {{InterestGroupBiddingScriptRunnerGlobalScope}} has a
 : <dfn>priority</dfn>
 :: Null or a {{double}}
 : <dfn>priority signals</dfn>
-:: An [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are {{double}}
+:: An [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are {{double}} or null.
 : <dfn>interest group</dfn>
 :: An [=interest group=]
 : <dfn>expected currency</dfn>


### PR DESCRIPTION
The second argument can be omitted/set to null/undefined to erase mapping for a key. The actual handling logic was already dealing with that, but we were not accepting this in the signature, or permitting in the infra rep.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/712.html" title="Last updated on Jul 19, 2023, 4:38 PM UTC (5035860)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/712/5004d49...morlovich:5035860.html" title="Last updated on Jul 19, 2023, 4:38 PM UTC (5035860)">Diff</a>