### PR TITLE
Add kanonStatus description for reportWin()

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -766,7 +766,7 @@ The arguments to this function are:
     * `modelingSignals` is the `modelingSignals` returned from `generateBid()`, using the [noising scheme](#521-noised-and-bucketed-signals). This field is only present if `modelingSignals` was returned by `generateBid()`.
     * `kAnonStatus` indicates the k-anonymity status of the ad.  When k-anonymity is calculated but not enforced, this field can help bidders understand the impact of k-anonymity enforcement.
         * `passedAndEnforced` The ad was k-anonymous and k-anonymity was required to win the auction.
-        * `passedNotEnforced` If k-anonymity can determine the value and simulation is in action.
+        * `passedNotEnforced` The ad was k-anonymous though k-anonymity was not required to win the auction.
         * `belowThreshold` If the number of ad joins was below the k-anonymity threshold and simulation is active.
         * `notCalculated` If k-anonymity cannot determine the theoretical outcome, it will not report one.
 

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -765,7 +765,7 @@ The arguments to this function are:
     * The `recency` field is duration of time (in minutes) from when this device joined this interest group until now, using the [noising and bucketing scheme](#521-noised-and-bucketed-signals).
     * `modelingSignals` is the `modelingSignals` returned from `generateBid()`, using the [noising scheme](#521-noised-and-bucketed-signals). This field is only present if `modelingSignals` was returned by `generateBid()`.
     * `kAnonStatus` indicates the k-anonymity status of the ad.  When k-anonymity is calculated but not enforced, this field can help bidders understand the impact of k-anonymity enforcement.
-        * `passedAndEnforced` If k-anonymity was truly enforced and it passed.
+        * `passedAndEnforced` The ad was k-anonymous and k-anonymity was required to win the auction.
         * `passedNotEnforced` If k-anonymity can determine the value and simulation is in action.
         * `belowThreshold` If the number of ad joins was below the k-anonymity threshold and simulation is active.
         * `notCalculated` If k-anonymity cannot determine the theoretical outcome, it will not report one.

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -767,7 +767,7 @@ The arguments to this function are:
     * `kAnonStatus` indicates the k-anonymity status of the ad.  When k-anonymity is calculated but not enforced, this field can help bidders understand the impact of k-anonymity enforcement.
         * `passedAndEnforced` The ad was k-anonymous and k-anonymity was required to win the auction.
         * `passedNotEnforced` The ad was k-anonymous though k-anonymity was not required to win the auction.
-        * `belowThreshold` If the number of ad joins was below the k-anonymity threshold and simulation is active.
+        * `belowThreshold` The ad was not k-anonymous but k-anonymity was not required to win the auction.
         * `notCalculated` If k-anonymity cannot determine the theoretical outcome, it will not report one.
 
 *   `directFromSellerSignals` is an object that may contain the following fields:

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -768,7 +768,7 @@ The arguments to this function are:
         * `passedAndEnforced` The ad was k-anonymous and k-anonymity was required to win the auction.
         * `passedNotEnforced` The ad was k-anonymous though k-anonymity was not required to win the auction.
         * `belowThreshold` The ad was not k-anonymous but k-anonymity was not required to win the auction.
-        * `notCalculated` If k-anonymity cannot determine the theoretical outcome, it will not report one.
+        * `notCalculated` The browser did not calculate the k-anonymity status of the ad, and k-anonymity was not required to win the auction.
 
 *   `directFromSellerSignals` is an object that may contain the following fields:
     *   `perBuyerSignals`: Like `auctionConfig.perBuyerSignals`, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?perBuyerSignals=[origin]`.

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -764,7 +764,7 @@ The arguments to this function are:
     * The `joinCount` field is the number of times this device has joined this interest group in the last 30 days while the interest group has been continuously stored (that is, there are no gaps in the storage of the interest group on the device due to leaving or membership expiring), using the [noising and bucketing scheme](#521-noised-and-bucketed-signals).
     * The `recency` field is duration of time (in minutes) from when this device joined this interest group until now, using the [noising and bucketing scheme](#521-noised-and-bucketed-signals).
     * `modelingSignals` is the `modelingSignals` returned from `generateBid()`, using the [noising scheme](#521-noised-and-bucketed-signals). This field is only present if `modelingSignals` was returned by `generateBid()`.
-    * `kAnonStatus` is a field that provides bidders of k-anonymity an easy way to understand the impact of k-anonymity without strict enforcement that removes ads.
+    * `kAnonStatus` indicates the k-anonymity status of the ad.  When k-anonymity is calculated but not enforced, this field can help bidders understand the impact of k-anonymity enforcement.
         * `passedAndEnforced` If k-anonymity was truly enforced and it passed.
         * `passedNotEnforced` If k-anonymity can determine the value and simulation is in action.
         * `belowThreshold` If the number of ad joins was below the k-anonymity threshold and simulation is active.

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -764,6 +764,12 @@ The arguments to this function are:
     * The `joinCount` field is the number of times this device has joined this interest group in the last 30 days while the interest group has been continuously stored (that is, there are no gaps in the storage of the interest group on the device due to leaving or membership expiring), using the [noising and bucketing scheme](#521-noised-and-bucketed-signals).
     * The `recency` field is duration of time (in minutes) from when this device joined this interest group until now, using the [noising and bucketing scheme](#521-noised-and-bucketed-signals).
     * `modelingSignals` is the `modelingSignals` returned from `generateBid()`, using the [noising scheme](#521-noised-and-bucketed-signals). This field is only present if `modelingSignals` was returned by `generateBid()`.
+    * `kAnonStatus` is a field that provides bidders of k-anonymity an easy way to understand the impact of k-anonymity without strict enforcement that removes ads.
+        * `passedAndEnforced` If k-anonymity was truly enforced and it passed.
+        * `passedNotEnforced` If k-anonymity can determine the value and simulation is in action.
+        * `belowThreshold` If the number of ad joins was below the k-anonymity threshold and simulation is active.
+        * `notCalculated` If k-anonymity cannot determine the theoretical outcome, it will not report one.
+
 *   `directFromSellerSignals` is an object that may contain the following fields:
     *   `perBuyerSignals`: Like `auctionConfig.perBuyerSignals`, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?perBuyerSignals=[origin]`.
     *   `auctionSignals`: Like `auctionConfig.auctionSignals`, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?auctionSignals`.


### PR DESCRIPTION
Add description of a new field "kAnonStatus" in reportWin() to provide users of K-anon an easy way to understand the impact of K-anon without hard enforcement that removes ads.