### PR TITLE
Spec: macro reporting support

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -268,8 +268,16 @@ This is detectable because it can change the set of fields that are read from th
           |igAd|'s [=interest group ad/buyer reporting ID=] to it.
         1. If |ad|["{{AuctionAd/buyerAndSellerReportingId}}"] [=map/exists=],
           then set |igAd|'s [=interest group ad/buyer and seller reporting ID=] to it.
-        1. If |ad|["{{AuctionAd/allowedReportingOrigins}}"] [=map/exists=],
-          then set |igAd|'s [=interest group ad/allowed reporting origins=] to it.
+        1. If |ad|["{{AuctionAd/allowedReportingOrigins}}"] [=map/exists=]:
+          1. Let |allowedReportingOrigins| be a new [=list=] of [=origins=].
+          1. [=list/For each=] |originStr| in |ad|["{{AuctionAd/allowedReportingOrigins}}"]:
+            1. Let |origin| be the result of [=parsing an origin=] on |originStr|.
+            1. If |origin| is failure, or its [=url/scheme=] is not "`https`", [=exception/throw=] a
+              {{TypeError}}.
+            1. [=list/Append=] |origin| to |allowedReportingOrigins|.
+            1. If [=list/size=] of |allowedReportingOrigins| is greater than 10, [=exception/throw=]
+              a {{TypeError}}.
+          1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
 1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
   [=exception/throw=] a {{TypeError}}.
@@ -333,8 +341,8 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer and seller reporting ID=] if the
     field is not null.
   1. If |ad|'s [=interest group ad/allowed reporting origins=] is not null, [=list/for each=]
-    |origin_str| of it:
-    1. The [=string/length=] of |origin_str|.
+    |origin| of it:
+    1. The [=string/length=] of the [=serialization of an origin|serialization=] of |origin|.
 1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
@@ -726,10 +734,13 @@ To <dfn>asynchronously finish reporting</dfn> given a
       1. Let |buyerMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/reporting beacon map=].
       1. If |buyerMap| is null, set |buyerMap| to an empty [=map=] «[]».
+      1. Let |allowedReportingOrigins| be |leadingBidInfo|'s [=leading bid info/leading bid=]'s
+        [=generated bid/bid ad=]'s [=interest group ad/allowed reporting origins=].
       1. Let |macroMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/reporting macro map=].
-      1. TODO: Pass |macroMap| to [=Finalize a reporting destination=] when it is updated to take
-        the parameter. May need to convert |macroMap| to a list, based on their need.
+      1. TODO: Pass |macroMap| and |allowedReportingOrigins| to [=Finalize a reporting destination=]
+        when it is updated to take the parameters. May need to convert |macroMap| to a list, based
+        on what that function expects.
       1. [=Finalize a reporting destination=] with |reportingMap|,
          {{FenceReportingDestination/buyer}}, and |buyerMap|.
       1. TODO: Fetch |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
@@ -1255,9 +1266,9 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. If |originalAds| is not null:
             1. Set |ig|'s [=interest group/ads=] to a new [=list=] of [=interest group ad=].
             1. [=list/For each=] |ad| in |originalAds|:
-            1. If [=query ad k-anonymity count=] given |ig| and |ad|'s
-              [=interest group ad/render url=] returns true, [=list/append=] |ad| to |ig|'s
-              [=interest group/ads=].
+              1. If [=query ad k-anonymity count=] given |ig| and |ad|'s
+                [=interest group ad/render url=] returns true, [=list/append=] |ad| to |ig|'s
+                [=interest group/ads=].
           1. Let |originalAdComponents| be |ig|'s [=interest group/ad components=].
           1. If |originalAdComponents| is not null:
             1. Set |ig|'s [=interest group/ad components=] to a new [=list=] of [=interest group ad=].
@@ -2395,13 +2406,15 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
     1. Let |adUrl| be the result of running the [=URL parser=] on
       |generateBidOutput|["{{GenerateBidOutput/render}}"].
     1. If |adUrl| is failure, return failure.
-    1. If [=validating an ad url=] given |adUrl|, |ig|, and false returns false, return failure.
     1. Set |adDescriptor|'s [=ad descriptor/url=] to |adUrl|.
   1. Otherwise:
     1. Set |adDescriptor| to the result of [=converting an ad render=] given
-      |generateBidOutput|["{{GenerateBidOutput/render}}"], |ig| and false.
+      |generateBidOutput|["{{GenerateBidOutput/render}}"].
     1. If |adDescriptor| is failure, return failure.
+  1. Let |bidAd| be the result of [=finding matching ad=] given |adDescriptor|, |ig|, and false.
+  1. If |bidAd| is null, return failure.
   1. Set |bid|'s [=generated bid/ad descriptor=] to |adDescriptor|.
+  1. Set |bid|'s [=generated bid/bid ad=] to |bidAd|.
   1. If |generateBidOutput|["{{GenerateBidOutput/adComponents}}"] [=map/exists=]:
     1. Let |adComponents| be |generateBidOutput|["{{GenerateBidOutput/adComponents}}"].
     1. Return failure if any of the following conditions hold:
@@ -2413,12 +2426,11 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
       1. If |component| is {{DOMString}}:
         1. Let |componentUrl| be the result of running the [=URL parser=] on |component|.
         1. If |componentUrl| is failure, return failure.
-        1. If [=validating an ad url=] given |componentUrl|, |ig|, and true returns false, return failure.
         1. Set |componentDescriptor|'s [=ad descriptor/url=] to |componentUrl|.
       1. Otherwise:
-        1. Set |componentDescriptor| to the result of [=converting an ad render=] given |component|, |ig|,
-          and true.
+        1. Set |componentDescriptor| to the result of [=converting an ad render=] given |component|.
         1. If |componentDescriptor| is failure, return failure.
+      1. If [=finding matching ad=] given |componentUrl|, |ig|, and true returns null, return failure.
       1. [=list/Append=] |componentDescriptor| to |adComponentDescriptors|.
     1. Set |bid|'s [=generated bid/ad component descriptors=] to |adComponentDescriptors|.
   1. If |generateBidOutput|["{{GenerateBidOutput/adCost}}"] [=map/exists=]:
@@ -2452,12 +2464,10 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
 </div>
 
 <div algorithm>
-  To <dfn>convert an ad render</dfn> given an {{AdRender}} |adRender|, an [=interest group=] |ig|,
-  and a [=boolean=] |isComponent|:
+  To <dfn>convert an ad render</dfn> given an {{AdRender}} |adRender|:
 
   1. Let |adUrl| be the result of running the [=URL parser=] on |adRender|["{{AdRender/url}}"].
   1. If |adUrl| is failure, return failure.
-  1. If [=validating an ad url=] given |adUrl|, |ig|, and |isComponent| returns false, return failure.
   1. Let |adDescriptor| be a new [=ad descriptor=].
   1. Set |adDescriptor|'s [=ad descriptor/url=] to |adUrl|.
   1. If |adRender|["{{AdRender/width}}"] [=map/exists=]:
@@ -2476,17 +2486,19 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
 </div>
 
 <div algorithm>
-  To <dfn>validate an ad url</dfn> given a [=URL=] |adUrl|, an [=interest group=] |ig|, and a
-  [=boolean=] |isComponent|:
+  To <dfn>find matching ad</dfn> given an [=ad descriptor=] |adDescriptor|, an [=interest group=]
+  |ig|, and a [=boolean=] |isComponent|:
 
-  1. If |adUrl|'s [=url/scheme=] is not "`https`", return false.
+  1. Let |adUrl| be |adDescriptor|'s [=ad descriptor/url=].
+  1. If |adUrl|'s [=url/scheme=] is not "`https`", return null.
+  1. TODO: Need to check [=ad descriptor/size=] as well.
   1. If |isComponent|:
     1. [=list/For each=] |ad| in |ig|'s [=interest group/ad components=]:
-      1. If |ad|'s [=interest group ad/render url=] equals |adUrl|, return true.
+      1. If |ad|'s [=interest group ad/render url=] equals |adUrl|, return |ad|.
   1. Otherwise:
     1. [=list/For each=] |ad| in |ig|'s [=interest group/ads=]:
-      1. If |ad|'s [=interest group ad/render url=] equals |adUrl|, return true.
-  1. Return false.
+      1. If |ad|'s [=interest group ad/render url=] equals |adUrl|, return |ad|.
+  1. Return null.
 </div>
 
 <div algorithm>
@@ -3085,8 +3097,9 @@ An interest group ad is a [=struct=] with the following [=struct/items=]:
   [=interest group/ad components=].
 : <dfn>allowed reporting origins</dfn>
 :: Null or a [=list=] of [=origins=]. A list of up to 10 reporting origins that can receive reports
-  with macros. All origins must be HTTPS and attested for Protected Audience (TODO: link). Only
-  meaningful in [=interest group/ads=], but ignored in [=interest group/ad components=].
+  with registered macros. All origins must be HTTPS origins and
+  <a href="https://github.com/privacysandbox/attestation">enrolled</a>. Only meaningful in
+  [=interest group/ads=], but ignored in [=interest group/ad components=].
 
 </dl>
 
@@ -3347,6 +3360,8 @@ the seller.
 :: Null or an {{unsigned short}}. A 0-4095 integer (12-bits) passed to `reportWin()`, with noising.
 : <dfn>interest group</dfn>
 :: An [=interest group=], whose `generateBid()` invocation generated this bid.
+: <dfn>bid ad</dfn>
+:: The [=interest group ad=] within [=generated bid/interest group=] to display.
 : <dfn>modified bid</dfn>
 :: Null or a [=bid with currency=]. Being null for top level auction.
   The bid value a component auction's `scoreAd()` script returns.

--- a/spec.bs
+++ b/spec.bs
@@ -728,9 +728,8 @@ To <dfn>asynchronously finish reporting</dfn> given a
       1. If |buyerMap| is null, set |buyerMap| to an empty [=map=] «[]».
       1. Let |macroMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/reporting macro map=].
-      1. If |macroMap| is null, set |macroMap| to an empty [=map=] «[]».
       1. TODO: Pass |macroMap| to [=Finalize a reporting destination=] when it is updated to take
-        the parameter.
+        the parameter. May need to convert |macroMap| to a list, based on their need.
       1. [=Finalize a reporting destination=] with |reportingMap|,
          {{FenceReportingDestination/buyer}}, and |buyerMap|.
       1. TODO: Fetch |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s

--- a/spec.bs
+++ b/spec.bs
@@ -726,7 +726,7 @@ To <dfn>asynchronously finish reporting</dfn> given a
 1. [=iteration/While=]:
    1. If |buyerDone|, |sellerDone|, and |componentSellerDone| are all true, then
       [=iteration/break=].
-   1. Wait until one of the following field of |leadingBidInfo| being not null:
+   1. Wait until one of the following fields of |leadingBidInfo| being not null:
       * [=leading bid info/buyer reporting result=];
       * [=leading bid info/seller reporting result=];
       * [=leading bid info/component seller reporting result=].
@@ -2573,7 +2573,8 @@ interface InterestGroupReportingScriptRunnerGlobalScope
 
 </pre>
 
-Note: Currently, registerAdMacro is only available in reportWin(), but not reportResult().
+Note: {{InterestGroupReportingScriptRunnerGlobalScope/registerAdMacro(name, value)}} is only
+available in [=report win=], but not [=report result=].
 
 Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
 <dl dfn-for="InterestGroupReportingScriptRunnerGlobalScope">
@@ -3092,12 +3093,12 @@ An interest group ad is a [=struct=] with the following [=struct/items=]:
 : <dfn>metadata</dfn>
 :: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
 : <dfn>buyer reporting ID</dfn>
-:: Null or a [=string=]. Will be passed in place of interest group name to `reportWin()`, subject to
-  k-anonymity checks. Only meaningful in [=interest group/ads=], but ignored in
+:: Null or a [=string=]. Will be passed in place of interest group name to [=report win=], subject
+  to k-anonymity checks. Only meaningful in [=interest group/ads=], but ignored in
   [=interest group/ad components=].
 : <dfn>buyer and seller reporting ID</dfn>
 :: Null or a [=string=]. Will be passed in place of interest group name or
-  [=interest group ad/buyer reporting ID=] to `reportWin()` and `reportResult()`, subject to
+  [=interest group ad/buyer reporting ID=] to [=report win=] and [=report result=], subject to
   k-anonymity checks. Only meaningful in [=interest group/ads=], but ignored in
   [=interest group/ad components=].
 : <dfn>allowed reporting origins</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -121,8 +121,10 @@ partial interface Navigator {
 dictionary AuctionAd {
   required USVString renderURL;
   any metadata;
+
   USVString buyerReportingId;
   USVString buyerAndSellerReportingId;
+  sequence<USVString> allowedReportingOrigins;
 };
 
 dictionary GenerateBidInterestGroup {
@@ -266,6 +268,8 @@ This is detectable because it can change the set of fields that are read from th
           |igAd|'s [=interest group ad/buyer reporting ID=] to it.
         1. If |ad|["{{AuctionAd/buyerAndSellerReportingId}}"] [=map/exists=],
           then set |igAd|'s [=interest group ad/buyer and seller reporting ID=] to it.
+        1. If |ad|["{{AuctionAd/allowedReportingOrigins}}"] [=map/exists=],
+          then set |igAd|'s [=interest group ad/allowed reporting origins=] to it.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
 1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
   [=exception/throw=] a {{TypeError}}.
@@ -328,6 +332,7 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer reporting ID=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer and seller reporting ID=] if the field is not null.
+  1. 
 1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
@@ -3045,9 +3050,12 @@ An interest group ad is a [=struct=] with the following [=struct/items=]:
 : <dfn>metadata</dfn>
 :: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
 : <dfn>buyer reporting ID</dfn>
-:: Null or a [=string=]. Will be passed in place of interest group name to `reportWin()`, subject to k-anonymity checks.
+:: Null or a [=string=]. Will be passed in place of interest group name to `reportWin()`, subject to k-anonymity checks. Not useful in ad components.
 : <dfn>buyer and seller reporting ID</dfn>
-:: Null or a [=string=]. Will be passed in place of interest group name or [=interest group ad/buyer reporting ID=] to `reportWin()` and `reportResult()`, subject to k-anonymity checks.
+:: Null or a [=string=]. Will be passed in place of interest group name or [=interest group ad/buyer reporting ID=] to `reportWin()` and `reportResult()`, subject to k-anonymity checks. Not useful in ad components.
+: <dfn>allowed reporting origins</dfn>
+:: Null or a [=map=] whose ... [=string=]. Not useful in ad components.
+
 
 </dl>
 

--- a/spec.bs
+++ b/spec.bs
@@ -314,7 +314,6 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   [=interest group/priority signals overrides=]:
   1. The [=string/length=] of |key|.
   1. 8 bytes, which is the size of |value|.
-1. The size of [=interest group/execution mode=].
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
   [=interest group/bidding url=], if the field is not null.
 1. The [=string/length=] of the [=URL serializer|serialization=] of |ig|'s
@@ -331,8 +330,11 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
     [=interest group ad/render url=].
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer reporting ID=] if the field is not null.
-  1. The [=string/length=] of |ad|'s [=interest group ad/buyer and seller reporting ID=] if the field is not null.
-  1. 
+  1. The [=string/length=] of |ad|'s [=interest group ad/buyer and seller reporting ID=] if the
+    field is not null.
+  1. If |ad|'s [=interest group ad/allowed reporting origins=] is not null, [=list/for each=]
+    |origin_str| of it:
+    1. The [=string/length=] of |origin_str|.
 1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
@@ -715,14 +717,20 @@ To <dfn>asynchronously finish reporting</dfn> given a
 1. [=iteration/While=]:
    1. If |buyerDone|, |sellerDone|, and |componentSellerDone| are all true, then
       [=iteration/break=].
-   1. Wait until |leadingBidInfo|'s [=leading bid info/buyer reporting result=] is not null,
-      or |leadingBidInfo|'s [=leading bid info/seller reporting result=] is not null, or
-      |leadingBidInfo|'s [=leading bid info/component seller reporting result=] is not null.
+   1. Wait until one of the following field of |leadingBidInfo| being not null:
+      * [=leading bid info/buyer reporting result=];
+      * [=leading bid info/seller reporting result=];
+      * [=leading bid info/component seller reporting result=].
    1. If |buyerDone| is false and |leadingBidInfo|'s [=leading bid info/buyer reporting result=]
       is not null:
       1. Let |buyerMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/reporting beacon map=].
       1. If |buyerMap| is null, set |buyerMap| to an empty [=map=] «[]».
+      1. Let |macroMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
+         [=reporting result/reporting macro map=].
+      1. If |macroMap| is null, set |macroMap| to an empty [=map=] «[]».
+      1. TODO: Pass |macroMap| to [=Finalize a reporting destination=] when it is updated to take
+        the parameter.
       1. [=Finalize a reporting destination=] with |reportingMap|,
          {{FenceReportingDestination/buyer}}, and |buyerMap|.
       1. TODO: Fetch |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
@@ -1817,7 +1825,7 @@ null |winningComponentConfig|:
     1. [=map/Set=] |browserSignals|["{{ReportingBrowserSignals/buyerAndSellerReportingId}}"] to |igAd|'s [=interest group ad/buyer and seller reporting ID=].
   1. Let |sellerReportingScript| be the result of [=fetching script=] with |config|'s
     [=auction config/decision logic url=].
-  1. Let « |sellerSignals|, |reportUrl|, |reportingBeaconMap| » be the result of
+  1. Let « |sellerSignals|, |reportUrl|, |reportingBeaconMap|, ignored » be the result of
     [=evaluating a reporting script=] with |sellerReportingScript|, "`reportResult`", and
     « |config|'s [=auction config/config idl=], |browserSignals| ».
    1. Let |reportingResult| be a [=reporting result=] with the following [=struct/items=]:
@@ -1882,8 +1890,8 @@ and a {{ReportingBrowserSignals}} |browserSignals|:
     1. Otherwise, [=map/Set=] |reportWinBrowserSignals|["{{ReportWinBrowserSignals/interestGroupName}}"] to |winner|'s [=generated bid/interest group=] [=interest group/name=].
   1. Let |buyerReportingScript| be the result of [=fetching script=] with |winner|'s
     [=generated bid/interest group=]'s [=interest group/bidding url=].
-  1. Let « ignored, |resultUrl|, |reportingBeaconMap| » be the result of [=evaluating a
-     reporting script=] with |buyerReportingScript|, "`reportWin`", and
+  1. Let « ignored, |resultUrl|, |reportingBeaconMap|, |reportingMacroMap| » be the result of
+    [=evaluating a reporting script=] with |buyerReportingScript|, "`reportWin`", and
      « |leadingBidInfo|'s [=leading bid info/auction config=]'s [=auction config/config idl=]'s
       {{AuctionAdConfig/auctionSignals}}, |perBuyerSignalsForBuyer|, |sellerSignals|,
       |reportWinBrowserSignals| ».
@@ -1894,6 +1902,9 @@ and a {{ReportingBrowserSignals}} |browserSignals|:
 
      : [=reporting result/reporting beacon map=]
      :: |reportingBeaconMap|
+
+     : [=reporting result/reporting macro map=]
+     :: |reportingMacroMap|
 </div>
 
 # K-anonymity # {#k-anonymity}
@@ -2229,8 +2240,10 @@ of the following global objects:
       exception was [=exception/thrown=] in the previous step, keep |resultJSON| as "null".
     1. Let |reportURL| be |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/report url=]
     1. If |reportURL| is failure, set |reportURL| to null.
+    1. Let |macroMap| be |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/reporting macro map=]
+      if |functionName| is "`reportWin`", null otherwise.
     1. Return « |resultJSON|, |reportURL|,
-       |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/reporting beacon map=] ».
+       |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/reporting beacon map=], |macroMap| ».
 </div>
 
 <div algorithm>
@@ -2540,9 +2553,12 @@ interface InterestGroupReportingScriptRunnerGlobalScope
         : InterestGroupScriptRunnerGlobalScope {
   undefined sendReportTo(DOMString url);
   undefined registerAdBeacon(record&lt;DOMString, USVString&gt; map);
+  undefined registerAdMacro(DOMString name, USVString value);
 };
 
 </pre>
+
+Note: Currently, registerAdMacro is only available in reportWin(), but not reportResult().
 
 Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
 <dl dfn-for="InterestGroupReportingScriptRunnerGlobalScope">
@@ -2551,6 +2567,9 @@ Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
 : <dfn>reporting beacon map</dfn>
 :: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
   [=URLs=]. Defaulting to null.
+: <dfn>reporting macro map</dfn>
+:: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
+  [=strings=]. Defaulting to null.
 
 </dl>
 
@@ -2591,6 +2610,13 @@ Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
      reporting beacon map=] to |map|.
 </div>
 
+<div algorithm>
+  The <dfn method for="InterestGroupReportingScriptRunnerGlobalScope">registerAdMacro(|name|,
+  |value|)</dfn> method steps are:
+
+  1. [=map/Set=] [=this=]'s [=relevant global object=]'s
+    [=InterestGroupReportingScriptRunnerGlobalScope/reporting macro map=][|name|] to |value|.
+</div>
 
 # Interest Group Updates # {#interest-group-updates}
 
@@ -3050,12 +3076,18 @@ An interest group ad is a [=struct=] with the following [=struct/items=]:
 : <dfn>metadata</dfn>
 :: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
 : <dfn>buyer reporting ID</dfn>
-:: Null or a [=string=]. Will be passed in place of interest group name to `reportWin()`, subject to k-anonymity checks. Not useful in ad components.
+:: Null or a [=string=]. Will be passed in place of interest group name to `reportWin()`, subject to
+  k-anonymity checks. Only meaningful in [=interest group/ads=], but ignored in
+  [=interest group/ad components=].
 : <dfn>buyer and seller reporting ID</dfn>
-:: Null or a [=string=]. Will be passed in place of interest group name or [=interest group ad/buyer reporting ID=] to `reportWin()` and `reportResult()`, subject to k-anonymity checks. Not useful in ad components.
+:: Null or a [=string=]. Will be passed in place of interest group name or
+  [=interest group ad/buyer reporting ID=] to `reportWin()` and `reportResult()`, subject to
+  k-anonymity checks. Only meaningful in [=interest group/ads=], but ignored in
+  [=interest group/ad components=].
 : <dfn>allowed reporting origins</dfn>
-:: Null or a [=map=] whose ... [=string=]. Not useful in ad components.
-
+:: Null or a [=list=] of [=origins=]. A list of up to 10 reporting origins that can receive reports
+  with macros. All origins must be HTTPS and attested for Protected Audience (TODO: link). Only
+  meaningful in [=interest group/ads=], but ignored in [=interest group/ad components=].
 
 </dl>
 
@@ -3480,6 +3512,11 @@ A <dfn>reporting result</dfn> is a [=struct=] with the following [=struct/items=
   :: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
      [=URLs=], initially null. Set by
      {{InterestGroupReportingScriptRunnerGlobalScope/registerAdBeacon(map)}}.
+
+  : <dfn>reporting macro map</dfn>
+  :: Null or an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are
+     [=strings=], initially null. Set by
+     {{InterestGroupReportingScriptRunnerGlobalScope/registerAdMacro(name, value)}}.  
 </dl>
 
 # Privacy Considerations # {#privacy-considerations}


### PR DESCRIPTION
Spec [macro reporting support](https://github.com/WICG/turtledove/issues/477) on the Protected Audience side, which includes:
1. Add a new allowedReportingOrigins field to IG's ad, and handles it.
2. Add a new API `registerAdMacro` to reporting script runner, and deal with registered macros.
3. Add a todo to pass the macro map to fenced frame config, once the fenced frame spec adds the variable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 11, 2023, 3:15 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fqingxinwu%2Fturtledove%2F4f93ce52d79ef7f2dec40ad04c7d090e238202dc%2Fspec.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/python310venv/bin/bikeshed", line 8, in 
    sys.exit(main())
  File "/sites/api.csswg.org/python310venv/lib/python3.10/site-packages/bikeshed/cli.py", line 449, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/python310venv/lib/python3.10/site-packages/bikeshed/cli.py", line 506, in handleSpec
    doc.preprocess()
  File "/sites/api.csswg.org/python310venv/lib/python3.10/site-packages/bikeshed/Spec.py", line 162, in preprocess
    self.processDocument()
  File "/sites/api.csswg.org/python310venv/lib/python3.10/site-packages/bikeshed/Spec.py", line 283, in processDocument
    u.inlineRemoteIssues(self)
  File "/sites/api.csswg.org/python310venv/lib/python3.10/site-packages/bikeshed/unsortedJunk.py", line 1280, in inlineRemoteIssues
    responses = json.loads(doc.dataFile.fetch("github-issues.json", str=True))
  File "/usr/local/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/turtledove%23762.)._
</details>
