### PR TITLE
Rename response headers to match implementation.

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -501,7 +501,7 @@ The response from the server should be a JSON object of the form:
 }
 ```
 
-and the server must include the HTTP response header `Ad-Auction-Bidding-Signals-Format-Version: 2`.  If the server does not include the header, the response will assumed to be an in older format, where the response is only the contents of the `keys` dictionary.
+and the server must include the HTTP response header `X-fledge-bidding-signals-format-version: 2`.  If the server does not include the header, the response will assumed to be an in older format, where the response is only the contents of the `keys` dictionary.
 
 The value of each key that an interest group has in its `trustedBiddingSignalsKeys` list will be passed from the `keys` dictionary to the interest group's generateBid() function as the `trustedBiddingSignals` parameter. Values missing from the JSON object will be set to null. If the JSON download fails, or there are no `trustedBiddingSignalsKeys` or `trustedBiddingSignalsURL` in the interest group, then the `trustedBiddingSignals` argument to generateBid() will be null.
 

--- a/spec.bs
+++ b/spec.bs
@@ -1596,8 +1596,8 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url|:
 
 The <dfn http-header><code>Data-Version</code></dfn> HTTP response header is a
 [=structured header=] whose value must be an [=structured header/integer=].
-The <dfn http-header><code>Ad-Auction-Bidding-Signals-Format-Version</code></dfn> HTTP response
-header is a [=structured header=] whose value must be an [=structured header/integer=].
+The <dfn http-header><code>X-fledge-bidding-signals-format-version</code></dfn> HTTP response header
+is a [=structured header=] whose value must be an [=structured header/integer=].
 
 <div algorithm>
 To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |isBiddingSignal|:
@@ -1636,7 +1636,7 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
         set |signals| to failure and return.
     1. If |isBiddingSignal| is true:
       1. Set |formatVersion| to the result of [=header list/getting a structured field value=]
-        given [:Ad-Auction-Bidding-Signals-Format-Version:] and "`item`" from |headers|.
+        given [:X-fledge-bidding-signals-format-version:] and "`item`" from |headers|.
     1. Set |signals| to the result of [=parsing JSON bytes to an Infra value=] |responseBody|.
   1. Wait for |signals| to be set.
   1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,

--- a/spec.bs
+++ b/spec.bs
@@ -36,6 +36,7 @@ spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
   type: dfn
     text: structured header; url: top
     for: structured header
+      text: boolean; url: boolean
       text: integer; url: integer
 spec: WebAssembly; urlPrefix: https://webassembly.github.io/spec/core/
   type: dfn
@@ -1503,13 +1504,16 @@ To <dfn>update highest scoring other bid</dfn> given a {{double}} |score|, a
         1. Set |leadingBidInfo|'s [=leading bid info/highest scoring other bid owner=] to null.
 </div>
 
+The <dfn http-header><code>Ad-Auction-Allowed</code></dfn> HTTP response header is a
+[=structured header=] whose value must be a [=structured header/boolean=].
+
 <div algorithm>
 To <dfn>validate fetching response</dfn> given a [=response=] |response|, null, failure, or a
 [=byte sequence=]|responseBody|, and a [=string=] |mimeType|:
 
   1. If |responseBody| is null or failure, return false.
-  1. If [=header list/getting a structured field value|getting=] "X-Allow-Protected-Audience" and
-    "`item`" from |response|'s [=response/header list=] does not return true, return false.
+  1. If [=header list/getting a structured field value|getting=] [:Ad-Auction-Allowed:] and
+    "`item`" from |response|'s [=response/header list=] does not return a true value, return false.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |response|'s
     [=response/header list=].
   1. Return false if any of the following conditions hold:
@@ -1581,8 +1585,8 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url|:
     a [=response=] |response| and null, failure, or a [=byte sequence=] |responseBody|:
     1. Set |moduleObject| to failure and return, if any of the following conditions hold:
       * |responseBody| is null or failure;
-      * [=header list/getting a structured field value|Getting=] "X-Allow-Protected-Audience" and
-        "`item`" from |response|'s [=response/header list=] does not return true.
+      * [=header list/getting a structured field value|Getting=] [:Ad-Auction-Allowed:] and "`item`"
+        from |response|'s [=response/header list=] does not return a true value.
     1. Let |module| be the result of [=compiling a WebAssembly module=] |response|.
     1. If |module| is [=error=], set |moduleObject| to failure.
     1. Otherwise, set |moduleObject| to |module|.
@@ -1592,8 +1596,8 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url|:
 
 The <dfn http-header><code>Data-Version</code></dfn> HTTP response header is a
 [=structured header=] whose value must be an [=structured header/integer=].
-The <dfn http-header><code>X-protected-audience-bidding-signals-format-version</code></dfn>
-HTTP response header is a [=structured header=] whose value must be an [=structured header/integer=].
+The <dfn http-header><code>Ad-Auction-Bidding-Signals-Format-Version</code></dfn> HTTP response
+header is a [=structured header=] whose value must be an [=structured header/integer=].
 
 <div algorithm>
 To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |isBiddingSignal|:
@@ -1632,7 +1636,7 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, and a [=boolean=] |is
         set |signals| to failure and return.
     1. If |isBiddingSignal| is true:
       1. Set |formatVersion| to the result of [=header list/getting a structured field value=]
-        given [:X-protected-audience-bidding-signals-format-version:] and "`item`" from |headers|.
+        given [:Ad-Auction-Bidding-Signals-Format-Version:] and "`item`" from |headers|.
     1. Set |signals| to the result of [=parsing JSON bytes to an Infra value=] |responseBody|.
   1. Wait for |signals| to be set.
   1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,
@@ -3512,7 +3516,7 @@ JavaScript is controlled and limited as follows:
   {{Navigator/joinAdInterestGroup()}}.
 - URL schemes are required to be HTTPS.
 - Redirects are disallowed.
-- Responses are required to contain the `X-Allow-Protected-Audience: ?1` header.
+- Responses are required to contain the `Ad-Auction-Allowed: ?1` header.
 - Fetches are uncredentialed.
 
 Protected Audience has the browser pass in several “browserSignals” to the bidding script that give the script


### PR DESCRIPTION
Rename response headers in both explainer and spec to use new headers in implementation. The request headers of "X-..." has been renamed (although the old headers are still supported to be backward compatible). See the [bug](https://crbug.com/1440204) that tracks the work.

* X-Allow-FLEDGE -> Ad-Auction-Allowed
* X-FLEDGE-Auction-Only -> Ad-Auction-Only

Not renaming X-fledge-bidding-signals-format-version since this header is going away soon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/772.html" title="Last updated on Sep 6, 2023, 5:30 PM UTC (6db87f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/772/6fd9003...qingxinwu:6db87f6.html" title="Last updated on Sep 6, 2023, 5:30 PM UTC (6db87f6)">Diff</a>