### PR TITLE
Make Explicit TTL Impact of updateUrl Call

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -143,7 +143,7 @@ previously stored (except that the `name` and `owner` cannot be changed, and
 `prioritySignalsOverrides` will be merged with the previous value, with `null`
 meaning a value should be removed from the interest group's old dictionary). This
 will not include any metadata, so data such as the interest group `name` should be
-included within the URL. Note that the TTL of the Interest Group is not reset after the completion of the update.
+included within the URL. Note that the lifetime of an Interest Group is not affected by the update mechanism — ad targeting based on a person's activity on a site remains limited to 30 days after the most recent site visit.
 
 The updates are done after auctions so as not to slow down
 the auctions themselves.  The updates are rate limited to running at most daily to

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -141,7 +141,7 @@ The `updateURL` provides a mechanism for the group's owner to update the attribu
 of the interest group: any new values returned in this way overwrite the values
 previously stored (except that the `name` and `owner` cannot be changed, and
 `prioritySignalsOverrides` will be merged with the previous value, with `null`
-meaning a value should be removed from the interest group's old dictionary). This
+meaning a value should be removed from the interest group's old dictionary). The HTTP request 
 will not include any metadata, so data such as the interest group `name` should be
 included within the URL. Note that the lifetime of an Interest Group is not affected by the update mechanism — ad targeting based on a person's activity on a site remains limited to 30 days after the most recent site visit.
 

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -143,7 +143,9 @@ previously stored (except that the `name` and `owner` cannot be changed, and
 `prioritySignalsOverrides` will be merged with the previous value, with `null`
 meaning a value should be removed from the interest group's old dictionary). This
 will not include any metadata, so data such as the interest group `name` should be
-included within the URL. The updates are done after auctions so as not to slow down
+included within the URL. Note that the TTL of the Interest Group is not reset after the completion of the update.
+
+The updates are done after auctions so as not to slow down
 the auctions themselves.  The updates are rate limited to running at most daily to
 conserve resources.  An update request only contains information from the single site
 where the user was added to the interest group.  At a later date we can consider


### PR DESCRIPTION
This is one of my questions disguised as a PR that I think would be useful for clarity.

Based on what I'm reading [here](https://wicg.github.io/turtledove/#interest-group-updates), and in the keys list in Section 7, 1.1.12, the TTL is not reset given changes to the IG via the response from updateUrl.

Is that correct? Is that intentional? Why not allow the IG to return `lifetimeMs` and have the TTL reset?