### PR TITLE
Update FLEDGE_browser_bidding_and_auction_API.md

### DIFF
--- a/FLEDGE_browser_bidding_and_auction_API.md
+++ b/FLEDGE_browser_bidding_and_auction_API.md
@@ -10,9 +10,9 @@ This document seeks to propose an API for web pages to perform FLEDGE auctions u
 
 #### Step 1: Get auction blob from browser
 
-To execute an on-server FLEDGE auction, sellers begin by calling `navigator.startServerAdAuction()` which returns a `Promise<Uint8Array>`:
+To execute an on-server FLEDGE auction, sellers begin by calling `navigator.getInterestGroupAdAuctionData()` which returns a `Promise<Uint8Array>`:
 ```
-const auctionBlob = await navigator.startServerAdAuction({
+const auctionBlob = await navigator.getInterestGroupAdAuctionData({
   // ‘seller’ works the same as for runAdAuction.
   'seller': 'https://www.example-ssp.com',
 });


### PR DESCRIPTION
The old function "startServerAdAuction()" does not exist in the source code anymore. It is now called "getInterestGroupAdAuctionData()".