### PR TITLE
Editorial: Put boxes around algorithms

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -66,6 +66,22 @@ spec: Shared Storage API; urlPrefix: https://wicg.github.io/shared-storage
 </pre>
 
 <style>
+/* Put nice boxes around each algorithm. */
+[data-algorithm]:not(.heading) {
+  padding: .5em;
+  border: thin solid #ddd; border-radius: .5em;
+  margin: .5em calc(-0.5em - 1px);
+}
+[data-algorithm]:not(.heading) > :first-child {
+  margin-top: 0;
+}
+[data-algorithm]:not(.heading) > :last-child {
+  margin-bottom: 0;
+}
+[data-algorithm] [data-algorithm] {
+  margin: 1em 0;
+}
+
 /* domintro from https://resources.whatwg.org/standard.css */
 .domintro {
   position: relative;


### PR DESCRIPTION
This is a readability improvement (related to https://github.com/WICG/turtledove/issues/646). Some bikeshed specs have these convenient boxes around the algorithms to make it clear when one algorithm/monkey patch starts, and another begins. I think it helps keep your bearings when reading the spec, and adds clear delimiters between sections. See the boxes around the algorithms in https://wicg.github.io/fenced-frame/#fenced-frame-config-mapping-store-a-pending-config for example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/pull/828.html" title="Last updated on Sep 25, 2023, 3:10 PM UTC (614bde6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/828/51a478a...614bde6.html" title="Last updated on Sep 25, 2023, 3:10 PM UTC (614bde6)">Diff</a>