### PR TITLE
Add clearOriginJoinedAdInterestGroup to spec.bs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -516,8 +516,8 @@ are:
 
 <h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups()</h3>
 {{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
-[=interest groups=] whose [=interest group/joining origin=] is the current top level page's
-origin.
+[=interest groups=] whose [=interest group/joining origin=] is the
+[=environment/top-level origin=].
 
 
 <xmp class="idl">

--- a/spec.bs
+++ b/spec.bs
@@ -516,8 +516,8 @@ are:
 
 <h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups()</h3>
 {{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
-[=interest groups=] whose [=interest group/joining origin=] is the
-[=environment/top-level origin=].
+[=interest groups=] whose [=interest group/joining origin=] is the associated
+{{Navigator}}'s [=relevant settings object=]'s [=environment/top-level origin=].
 
 
 <xmp class="idl">

--- a/spec.bs
+++ b/spec.bs
@@ -449,6 +449,7 @@ To <dfn>build an interest group permissions url</dfn> given a [=origin=] |ownerO
 
 <h2 id="leaving-interest-groups">Leaving Interest Groups</h2>
 
+<h3 id="leaveadinterestgroup">leaveAdInterestGroup</h3>
 {{Window/navigator}}.{{Navigator/leaveAdInterestGroup()}} removes a user from a particular interest
 group.
 
@@ -505,6 +506,49 @@ are:
     1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
     1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
       [=interest group/owner=] is |owner| and [=interest group/name=] is |name|.
+1. Return |p|.
+
+</div>
+
+<h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups</h3>
+{{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
+[=interest groups=] with the current page's [=interest group/joining origin=].
+
+
+<xmp class="idl">
+[SecureContext]
+partial interface Navigator {
+  Promise<undefined> clearOriginJoinedAdInterestGroups(
+      USVString owner, optional sequence<USVString> interestGroupsToKeep = []);
+};
+</xmp>
+
+<div algorithm>
+
+The <dfn for=Navigator method>clearOriginJoinedAdInterestGroups(group)</dfn> method steps
+are:
+
+1. Let |frameOrigin| be [=this=]'s [=relevant settings object=]'s
+  [=environment settings object/origin=].
+1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and its [=origin/scheme=] is "`https`".
+1. Let |p| be [=a new promise=].
+1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
+  "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
+  "{{NotAllowedError}}" {{DOMException}}.
+
+  Note: both joining and leaving interest groups use the "join-ad-interest-group" feature.
+1. Let |owner| be the result of [=parsing an https origin=] with |owner|.
+1. If |owner| is failure, [=exception/throw=] a {{TypeError}}.
+1. Run these steps [=in parallel=]:
+  1. Let |permission| be the result of [=checking interest group permissions=] with
+    |owner|, |frameOrigin|, and "`leave`".
+  1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
+     "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
+  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
+  1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
+    [=interest group/owner=] is |owner|,  [=interest group/joining origin=] is [=this=]'s
+    [=relevant settings object=]'s [=environment/top-level origin=], and
+    [=interest group/name=] is not in |interestGroupsToKeep|.
 1. Return |p|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -65,6 +65,10 @@ spec: Shared Storage API; urlPrefix: https://wicg.github.io/shared-storage
     text: shared-storage-select-url; url: #permissionspolicy-shared-storage-select-url
 </pre>
 
+<pre class=link-defaults>
+spec:infra; type:dfn; text:user agent
+</pre>
+
 <style>
 /* Put nice boxes around each algorithm. */
 [data-algorithm]:not(.heading) {
@@ -546,7 +550,7 @@ method steps are:
   1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
      "{{NotAllowedError}}" {{DOMException}} and abort these steps.
   1. [=Queue a task=] to [=resolve=] |p| with {{undefined}}.
-  1. [=list/Remove=] [=interest groups=] from the [=infra/user agent=]'s [=interest group set=]
+  1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=]
     whose [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is
     |frameOrigin|, and whose [=interest group/name=] is not in |interestGroupsToKeep|.
 1. Return |p|.

--- a/spec.bs
+++ b/spec.bs
@@ -546,8 +546,8 @@ method steps are:
   1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
      "{{NotAllowedError}}" {{DOMException}} and abort these steps.
   1. [=Queue a task=] to [=resolve=] |p| with {{undefined}}.
-  1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=] whose
-    [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is
+  1. [=list/Remove=] [=interest groups=] from the [=infra/user agent=]'s [=interest group set=]
+    whose [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is
     |frameOrigin|, and whose [=interest group/name=] is not in |interestGroupsToKeep|.
 1. Return |p|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -512,7 +512,8 @@ are:
 
 <h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups()</h3>
 {{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
-[=interest groups=] with the current page's [=interest group/joining origin=].
+[=interest groups=] whose [=interest group/joining origin=] is the current top level page's
+origin.
 
 
 <xmp class="idl">

--- a/spec.bs
+++ b/spec.bs
@@ -449,7 +449,7 @@ To <dfn>build an interest group permissions url</dfn> given a [=origin=] |ownerO
 
 <h2 id="leaving-interest-groups">Leaving Interest Groups</h2>
 
-<h3 id="leaveadinterestgroup">leaveAdInterestGroup</h3>
+<h3 id="leaveadinterestgroup">leaveAdInterestGroup()</h3>
 {{Window/navigator}}.{{Navigator/leaveAdInterestGroup()}} removes a user from a particular interest
 group.
 
@@ -510,7 +510,7 @@ are:
 
 </div>
 
-<h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups</h3>
+<h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups()</h3>
 {{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
 [=interest groups=] with the current page's [=interest group/joining origin=].
 
@@ -537,16 +537,16 @@ are:
   "{{NotAllowedError}}" {{DOMException}}.
 
   Note: both joining and leaving interest groups use the "join-ad-interest-group" feature.
-1. Let |owner| be the result of [=parsing an https origin=] with |owner|.
-1. If |owner| is failure, [=exception/throw=] a {{TypeError}}.
+1. Let |ownerOrigin| be the result of [=parsing an https origin=] with |owner|.
+1. If |ownerOrigin| is failure, [=exception/throw=] a {{TypeError}}.
 1. Run these steps [=in parallel=]:
   1. Let |permission| be the result of [=checking interest group permissions=] with
-    |owner|, |frameOrigin|, and "`leave`".
+    |ownerOrigin|, |frameOrigin|, and "`leave`".
   1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
      "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
   1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
   1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
-    [=interest group/owner=] is |owner|,  [=interest group/joining origin=] is [=this=]'s
+    [=interest group/owner=] is |ownerOrigin|,  [=interest group/joining origin=] is [=this=]'s
     [=relevant settings object=]'s [=environment/top-level origin=], and
     [=interest group/name=] is not in |interestGroupsToKeep|.
 1. Return |p|.

--- a/spec.bs
+++ b/spec.bs
@@ -548,9 +548,9 @@ method steps are:
 1. Run these steps [=in parallel=]:
   1. Let |permission| be the result of [=checking interest group permissions=] with
     |ownerOrigin|, |frameOrigin|, and "`leave`".
-  1. If |permission| is false, then [=queue a global task=] on [=DOM manipulation task source=],
+  1. If |permission| is false, then [=queue a global task=] on the [=DOM manipulation task source=]
     given |global|, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and abort these steps.
-  1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=] |p|
+  1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global|, to [=resolve=] |p|
     with {{undefined}}.
   1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=]
     whose [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is

--- a/spec.bs
+++ b/spec.bs
@@ -525,8 +525,8 @@ partial interface Navigator {
 
 <div algorithm>
 
-The <dfn for=Navigator method>clearOriginJoinedAdInterestGroups(group)</dfn> method steps
-are:
+The <dfn for=Navigator method>clearOriginJoinedAdInterestGroups(owner, interestGroupsToKeep)</dfn>
+method steps are:
 
 1. Let |frameOrigin| be [=this=]'s [=relevant settings object=]'s
   [=environment settings object/origin=].

--- a/spec.bs
+++ b/spec.bs
@@ -318,7 +318,7 @@ This is detectable because it can change the set of fields that are read from th
   1. Let |permission| be the result of [=checking interest group permissions=] with
     |interestGroup|'s [=interest group/owner=], |frameOrigin|, and "`join`".
   1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
-     "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
+     "{{NotAllowedError}}" {{DOMException}} and abort these steps.
   1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
   1. If the browser is currently storing an interest group with `owner` and `name` that matches
     |interestGroup|, then set the [=interest group/bid counts=],
@@ -502,7 +502,7 @@ are:
     1. Let |permission| be the result of [=checking interest group permissions=] with
       |owner|, |frameOrigin|, and "`leave`".
     1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
-       "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
+       "{{NotAllowedError}}" {{DOMException}} and abort these steps.
     1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
     1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
       [=interest group/owner=] is |owner| and [=interest group/name=] is |name|.
@@ -544,12 +544,11 @@ method steps are:
   1. Let |permission| be the result of [=checking interest group permissions=] with
     |ownerOrigin|, |frameOrigin|, and "`leave`".
   1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
-     "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
-  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
-  1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
-    [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is [=this=]'s
-    [=relevant settings object=]'s [=environment/top-level origin=], and whose
-    [=interest group/name=] is not in |interestGroupsToKeep|.
+     "{{NotAllowedError}}" {{DOMException}} and abort these steps.
+  1. [=Queue a task=] to [=resolve=] |p| with {{undefined}}.
+  1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=] whose
+    [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is
+    |frameOrigin|, and whose [=interest group/name=] is not in |interestGroupsToKeep|.
 1. Return |p|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -547,8 +547,8 @@ method steps are:
      "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
   1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
   1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
-    [=interest group/owner=] is |ownerOrigin|,  [=interest group/joining origin=] is [=this=]'s
-    [=relevant settings object=]'s [=environment/top-level origin=], and
+    [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is [=this=]'s
+    [=relevant settings object=]'s [=environment/top-level origin=], and whose
     [=interest group/name=] is not in |interestGroupsToKeep|.
 1. Return |p|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -631,7 +631,7 @@ The <dfn for=Navigator method>leaveAdInterestGroup(group)</dfn> method steps are
 
 *This first introductory paragraph is non-normative.*
 
-  {{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
+{{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
 [=interest groups=] whose [=interest group/joining origin=] is the associated
 {{Navigator}}'s [=relevant settings object=]'s [=environment/top-level origin=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -493,7 +493,7 @@ are:
     "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
     "{{NotAllowedError}}" {{DOMException}}.
 
-    Note: both joining and leaving interest groups use the "join-ad-interest-group" feature.
+    Note: Both joining and leaving interest groups use the "join-ad-interest-group" feature.
   1. Let |owner| be the result of [=parsing an https origin=] with
     |group|["{{AuctionAdInterestGroupKey/owner}}"].
   1. If |owner| is failure, [=exception/throw=] a {{TypeError}}.
@@ -537,7 +537,7 @@ method steps are:
   "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
   "{{NotAllowedError}}" {{DOMException}}.
 
-  Note: both joining and leaving interest groups use the "join-ad-interest-group" feature.
+  Note: Both joining and leaving interest groups use the "join-ad-interest-group" feature.
 1. Let |ownerOrigin| be the result of [=parsing an https origin=] with |owner|.
 1. If |ownerOrigin| is failure, [=exception/throw=] a {{TypeError}}.
 1. Run these steps [=in parallel=]:

--- a/spec.bs
+++ b/spec.bs
@@ -537,7 +537,8 @@ method steps are:
   [=environment settings object/origin=].
 1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and its [=origin/scheme=] is "`https`".
 1. Let |p| be [=a new promise=].
-1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. If |global|'s [=associated Document=] is not [=allowed to use=] the
   "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
   "{{NotAllowedError}}" {{DOMException}}.
 
@@ -547,9 +548,10 @@ method steps are:
 1. Run these steps [=in parallel=]:
   1. Let |permission| be the result of [=checking interest group permissions=] with
     |ownerOrigin|, |frameOrigin|, and "`leave`".
-  1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
-     "{{NotAllowedError}}" {{DOMException}} and abort these steps.
-  1. [=Queue a task=] to [=resolve=] |p| with {{undefined}}.
+  1. If |permission| is false, then [=queue a global task=] on [=DOM manipulation task source=],
+    given |global|, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and abort these steps.
+  1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=] |p|
+    with {{undefined}}.
   1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=]
     whose [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is
     |frameOrigin|, and whose [=interest group/name=] is not in |interestGroupsToKeep|.

--- a/spec.bs
+++ b/spec.bs
@@ -526,7 +526,7 @@ partial interface Navigator {
 
 <div algorithm>
 
-The <dfn for=Navigator method>clearOriginJoinedAdInterestGroups(owner, interestGroupsToKeep)</dfn>
+The <dfn for=Navigator method>clearOriginJoinedAdInterestGroups(|owner|, |interestGroupsToKeep|)</dfn>
 method steps are:
 
 1. Let |frameOrigin| be [=this=]'s [=relevant settings object=]'s


### PR DESCRIPTION
This adds the explainer changes from explainer PR #829 / issue  #475 to the spec.

Note that I have no idea how to preview this before creating a pull request, so there are likely bugs that I'll need to fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MattMenke2/turtledove/pull/844.html" title="Last updated on Oct 26, 2023, 3:37 PM UTC (79afd0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/844/07960ec...MattMenke2:79afd0d.html" title="Last updated on Oct 26, 2023, 3:37 PM UTC (79afd0d)">Diff</a>