### PR TITLE
Update spec.bs - make join permission imply leave permission.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -422,8 +422,10 @@ To <dfn>check interest group permissions</dfn> given an [=origin=]
 1. Let |permissions| be the result of [=parsing JSON bytes to an Infra value=] with |resource|,
   returning false on failure.
 1. If |permissions| is not an [=ordered map=], then return false.
-1. If |joinOrLeave| is "`join`" and |permissions|["`joinAdInterestGroup`"] [=map/exists=], then
-  return |permissions|["`joinAdInterestGroup`"].
+1. Set |joinPermission| to false.
+1. If |permissions|["`joinAdInterestGroup`"] [=map/exists=] set |joinPermission| to |permissions|["`joinAdInterestGroup`"].
+1. If |joinOrLeave| is "`join`" return |joinPermission|.
+1. If |joinOrLeave| is "`leave`" and |joinPermission| is true, return true.
 1. If |joinOrLeave| is "`leave`" and |permissions|["`leaveAdInterestGroup`"] [=map/exists=], then
   return |permissions|["`leaveAdInterestGroup`"].
 1. Return false.


### PR DESCRIPTION
joinAdInterestGroup() can leave an interest group by using a duration of 0, so make a join permission imply a leave permission.  Explainer has already been updated.

We could alternatively make denying leave permissions override allowing join permissions, if we thought that was safer, though would have to update the explainer as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MattMenke2/turtledove/pull/847.html" title="Last updated on Oct 9, 2023, 7:21 PM UTC (df8188e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/847/ae53482...MattMenke2:df8188e.html" title="Last updated on Oct 9, 2023, 7:21 PM UTC (df8188e)">Diff</a>