### PR TITLE
prevWins Clarity

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -646,11 +646,12 @@ The arguments to `generateBid()` are:
       'joinCount': 3,
       'recency': 3600000,
       'bidCount': 17,
-      'prevWins': [[time1,ad1],[time2,ad2],...],
+      'prevWins': [{'timeDelta': time1, 'adJSON': prevWinningAd1JSONString}, {'timeDelta': time2, 'adJSON': prevWinningAd2JSONString}, ...],
       'wasmHelper': ... /* a WebAssembly.Module object based on interest group's biddingWasmHelperURL */
       'dataVersion': 1, /* Data-Version value from the trusted bidding signals server's response(s) */
     }
     ```
+    The `prevWins` is a list of [`PreviousWin` dictionaries](https://wicg.github.io/turtledove/#dictdef-previouswin), for all of the Interest Groups previous wins on the browser. `timeDelta` is the difference between the auction start time and the time of the previous win. `adJSON` is the stringified JSON of what was returned in the `ad` element by `generateBid` for that Interest Group's winning bid in that auction. 
 *   directFromSellerSignals is an object that may contain the following fields:
     *   perBuyerSignals: Like auctionConfig.perBuyerSignals, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?perBuyerSignals=[origin]`.
     *   auctionSignals: Like auctionConfig.auctionSignals, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?auctionSignals`.


### PR DESCRIPTION
While digging in on the nature of `prevWins`, I wasn't sure whether there's a gap between my understanding of the explainer (updated here) and the [full spec](https://wicg.github.io/turtledove/), in particular bullets 5-7 of the "To generate a bid" section (search for "Let prevWins be a new sequence<PreviousWin>.").

Based on the spec I think it's saying:
* The field in `browserSignals` is `prevWinsMs`. 
* `prevWins` as a whole is a list (sequence) and each element is a `PreviousWin` dictionary that has the `timeDelta` btw the win and now, and full serialized JSON from the `ad` component of what was returned by `generateBid` for that win.

This is a little different than what is written and maybe implied, or at least not clear to me, in the explainer:
* The field in `browserSignals` is `prevWins`.
* The value is a list, with element being itself a list of 2 elements, the first being the "time" and the second being the "ad". My initial assumption here had been that the "time" was the timestamp of the won auction, and the ad was the creative from the IGs ads list.

So my PR here hopes to reconcile this with the following hopes:
* That the name of the field in `browserSignals` is indeed `prevWins` rather than `prevWinsMs`, and that the spec needs a minor update here (or there's an alias I'm missing).
* That the contents of `prevWins` has the detail indicated in the spec.