### PR TITLE
Add kAnonStatus to ReportWinBrowserSignals in spec.bs.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2934,12 +2934,16 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   <dd>Only set if the Data-Version header was provided in the response headers from the trusted
     bidding signals server
   <dt>{{ReportWinBrowserSignals/kAnonStatus}}
-  <dd>Indicate the k-anonymity status of the ad.
+  <dd>Indicate the k-anonymity status of the ad with the following values:
+      * `"passedAndEnforced"`: The ad was k-anonymous and k-anonymity was required to win the auction.
+      * `"passedNotEnforced"`: The ad was k-anonymous though k-anonymity was not required to win the auction.
+      * `"belowThreshold"`: The ad was not k-anonymous but k-anonymity was not required to win the auction.
+      * `"notCalculated"`: The browser did not calculate the k-anonymity status of the ad, and k-anonymity was not required to win the auction.
 
-    Implementations may set kAnonStatus to unknown if they are not yet computing the k-anonymity status
-    for ads. Implementations may set kAnonStatus to nonKAnon if they are computing the k-anonymity status
-    but have not yet begun enforcing that ads are k-anonymous. This allows API users to determine the
-    future impact of enforcing that ads are k-anonymous.
+    From a long-term perspective, the status will always be set to `passedAndEnforced` after 
+    k-anonymity is enforced. However, as a temporary solution, current implementations may set 
+    `kAnonStatus` to one of the other three statuses to allow API users to assess the future 
+    impact of enforcing that ads are k-anonymous.
 </dl>
 
 <h3 dfn-type=dfn>Interest group</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -2910,7 +2910,7 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   KAnonStatus kAnonStatus;
 };
 
-enum KAnonStatus { "passedAndEnforced", "same-passedNotEnforced", "belowThreshold", "notCalculated" };
+enum KAnonStatus { "passedAndEnforced", "passedNotEnforced", "belowThreshold", "notCalculated" };
 </xmp>
 
 <dl class=domintro>
@@ -2937,10 +2937,10 @@ enum KAnonStatus { "passedAndEnforced", "same-passedNotEnforced", "belowThreshol
     bidding signals server
   <dt>{{ReportWinBrowserSignals/kAnonStatus}}
   <dd>Indicate the k-anonymity status of the ad with the following {{KAnonStatus}} enums:
-      * `"passedAndEnforced"`: The ad was k-anonymous and k-anonymity was required to win the auction.
-      * `"passedNotEnforced"`: The ad was k-anonymous though k-anonymity was not required to win the auction.
-      * `"belowThreshold"`: The ad was not k-anonymous but k-anonymity was not required to win the auction.
-      * `"notCalculated"`: The browser did not calculate the k-anonymity status of the ad, and k-anonymity was not required to win the auction.
+      * {{KAnonStatus/passedAndEnforced}}: The ad was k-anonymous and k-anonymity was required to win the auction.
+      * {{KAnonStatus/passedNotEnforced}}: The ad was k-anonymous though k-anonymity was not required to win the auction.
+      * {{KAnonStatus/belowThreshold}}: The ad was not k-anonymous but k-anonymity was not required to win the auction.
+      * {{KAnonStatus/notCalculated}}: The browser did not calculate the k-anonymity status of the ad, and k-anonymity was not required to win the auction.
 
     From a long-term perspective, the status will always be set to `passedAndEnforced` after 
     k-anonymity is enforced. However, as a temporary solution, current implementations may set 

--- a/spec.bs
+++ b/spec.bs
@@ -2907,6 +2907,7 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   DOMString buyerReportingId;
   unsigned short modelingSignals;
   unsigned long dataVersion;
+  DOMString kAnonStatus;
 };
 </xmp>
 
@@ -2932,6 +2933,13 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   <dt>{{ReportWinBrowserSignals/dataVersion}}
   <dd>Only set if the Data-Version header was provided in the response headers from the trusted
     bidding signals server
+  <dt>{{ReportWinBrowserSignals/kAnonStatus}}
+  <dd>Indicate the k-anonymity status of the ad.
+
+    Implementations may set kAnonStatus to unknown if they are not yet computing the k-anonymity status
+    for ads. Implementations may set kAnonStatus to nonKAnon if they are computing the k-anonymity status
+    but have not yet begun enforcing that ads are k-anonymous. This allows API users to determine the
+    future impact of enforcing that ads are k-anonymous.
 </dl>
 
 <h3 dfn-type=dfn>Interest group</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -2907,8 +2907,10 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   DOMString buyerReportingId;
   unsigned short modelingSignals;
   unsigned long dataVersion;
-  DOMString kAnonStatus;
+  KAnonStatus kAnonStatus;
 };
+
+enum KAnonStatus { "passedAndEnforced", "same-passedNotEnforced", "belowThreshold", "notCalculated" };
 </xmp>
 
 <dl class=domintro>
@@ -2934,7 +2936,7 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   <dd>Only set if the Data-Version header was provided in the response headers from the trusted
     bidding signals server
   <dt>{{ReportWinBrowserSignals/kAnonStatus}}
-  <dd>Indicate the k-anonymity status of the ad with the following values:
+  <dd>Indicate the k-anonymity status of the ad with the following {{KAnonStatus}} enums:
       * `"passedAndEnforced"`: The ad was k-anonymous and k-anonymity was required to win the auction.
       * `"passedNotEnforced"`: The ad was k-anonymous though k-anonymity was not required to win the auction.
       * `"belowThreshold"`: The ad was not k-anonymous but k-anonymity was not required to win the auction.


### PR DESCRIPTION
Add new parameter kAnonStatus and a short description to ReportWinBrowserSignals.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xtlsheep/turtledove/pull/858.html" title="Last updated on Oct 26, 2023, 8:37 PM UTC (b6b572a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/858/5004d49...xtlsheep:b6b572a.html" title="Last updated on Oct 26, 2023, 8:37 PM UTC (b6b572a)">Diff</a>