### PR TITLE
Set directFromSellerSignals dict members to null

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3373,15 +3373,15 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
 
 <xmp class="idl">
 dictionary DirectFromSellerSignalsForBuyer {
-  any auctionSignals;
-  any perBuyerSignals;
+  any auctionSignals = null;
+  any perBuyerSignals = null;
 };
 </xmp>
 
 <xmp class="idl">
 dictionary DirectFromSellerSignalsForSeller {
-  any auctionSignals;
-  any sellerSignals;
+  any auctionSignals = null;
+  any sellerSignals = null;
 };
 </xmp>
 


### PR DESCRIPTION
These default to null, not undefined, if not specified (or if there was an error loading).

Practically, I this this only matters for perBuyerSignals (since the other fields get set from string or null fields), but it's probably good to be consistent. 

This is related to this thread from the review: https://github.com/WICG/turtledove/pull/774#discussion_r1342844517


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/861.html" title="Last updated on Oct 13, 2023, 8:48 PM UTC (0584ee9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/861/82cbe4e...caraitto:0584ee9.html" title="Last updated on Oct 13, 2023, 8:48 PM UTC (0584ee9)">Diff</a>