### PR TITLE
Clarification on perBuyerExperimentIds, I Think

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1055,6 +1055,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     [=auction config/all buyer experiment group id=] to |value|, and [=iteration/continue=].
   1. Let |buyer| the result of [=parsing an https origin=] with |key|.
   1. If |buyer| is failure, then return failure.
+  1. If |value| is not an integer, then return failure.
   1. Set |auctionConfig|'s [=auction config/per buyer experiment group ids=][|buyer|] to |value|.
 1. If |config|["{{AuctionAdConfig/perBuyerPrioritySignals}}"] [=map/exists=], [=map/for each=]
   |key| → |value| of |config|["{{AuctionAdConfig/perBuyerPrioritySignals}}"]:


### PR DESCRIPTION
Small thing, was looking at perBuyerExperimentGroupIds, in the detailed spec I don't see anything about validating that the value given for the ID is an integer, but I do see both in the spec and in the code that it has to be a short int...so guessing the auction run will, or should fail, if the ID is not a short integer?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/thegreatfatzby/turtledove/pull/876.html" title="Last updated on Oct 24, 2023, 3:23 PM UTC (d610ce4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/876/285ba49...thegreatfatzby:d610ce4.html" title="Last updated on Oct 24, 2023, 3:23 PM UTC (d610ce4)">Diff</a>