### PR TITLE
[Spec] Duplicate adSlot detection and handling

### DIFF
--- a/fledge-tester-list.md
+++ b/fledge-tester-list.md
@@ -57,6 +57,7 @@ The usefulness of this page depends on testers sharing information and updates.
 | MicroAd | SSP & DSP | | | privacysandbox@microad.co.jp |
 | Blendee | SSP & DSP | | | privacysandbox@blendee.com |
 | Adlook (subsidiary of RTB House) | DSP | Continuous testing ongoing; long term commitment. | | privacysandbox@adlook.com |
+| PrimeAudience (subsidiary of RTB House) | Ad Network | Continuous testing ongoing; long term commitment. | | contact@primeaudience.com |
 | Microsoft (Xandr, MSAN) | SSP + DSP(s) | Testing | | privacy_sandbox@microsoft.com |
 | Nexxen (Unruly/Tremor/Amobee) | SSP & DSP| 2023-2024 | coming soon | privacysandbox@nexxen.com |
 | Triplelift | SSP | Jan 2024 | | prod-privacysandbox@triplelift.com |

--- a/spec.bs
+++ b/spec.bs
@@ -3885,9 +3885,15 @@ The following algorithm will be added to the [[FETCH#fetching]] section:
     |adAuctionSignals|.
   1. If |parsedSignals| is failure, return.
   1. If |parsedSignals| is not a [=list=], return.
+  1. Let |headerAdSlots| be a new [=ordered set=].
   1. [=list/For each=] |signal| in |parsedSignals|:
     1. If |signal| is not an [=ordered map=], [=iteration/continue=].
     1. If |signal|["`adSlot`"] doesn't exist, [=iteration/continue=].
+    1. If |headerAdSlots| [=set/contains=] |signal|["`adSlot`"], [=iteration/continue=].
+
+      NOTE: Implementations can consider also issuing a diagnostic error message in this case
+      ([:Ad-Auction-Signals:] header with duplicate `adSlot` dictionaries).
+    1. [=set/Append=] |signal|["`adSlot`"] to |headerAdSlots|.
     1. Create a new [=direct from seller signals key=] |signalsKey|, with its
       [=direct from seller signals key/seller=] set to |requestOrigin| and its
       [=direct from seller signals key/ad slot=] set to |signal|["`adSlot`"].

--- a/spec.bs
+++ b/spec.bs
@@ -3914,10 +3914,9 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
   1. [=list/For each=] |signal| of |parsedSignals|:
     1. If |signal| is not an [=ordered map=], [=iteration/continue=].
     1. If |signal|["`adSlot`"] doesn't exist, [=iteration/continue=].
-    1. If |headerAdSlots| [=set/contains=] |signal|["`adSlot`"], [=iteration/continue=].
-
-      NOTE: Implementations can consider also issuing a diagnostic error message in this case
-      ([:Ad-Auction-Signals:] header with duplicate `adSlot` dictionaries).
+    1. If |headerAdSlots| [=set/contains=] |signal|["`adSlot`"], [=iteration/continue=]. Optionally,
+      [=report a warning to the console=] with a diagnostic error message indicating that duplicate
+      [:Ad-Auction-Signals:] `adSlot` dictionary was ignored.
     1. [=set/Append=] |signal|["`adSlot`"] to |headerAdSlots|.
     1. Let |signalsKey| be a new [=direct from seller signals key=], with its
       [=direct from seller signals key/seller=] set to |requestOrigin| and its

--- a/spec.bs
+++ b/spec.bs
@@ -3911,7 +3911,7 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
     |adAuctionSignals|.
   1. If |parsedSignals| is failure or not a [=list=], return.
   1. Let |headerAdSlots| be a new [=ordered set=].
-  1. [=list/For each=] |signal| in |parsedSignals|:
+  1. [=list/For each=] |signal| of |parsedSignals|:
     1. If |signal| is not an [=ordered map=], [=iteration/continue=].
     1. If |signal|["`adSlot`"] doesn't exist, [=iteration/continue=].
     1. If |headerAdSlots| [=set/contains=] |signal|["`adSlot`"], [=iteration/continue=]. Optionally,

--- a/spec.bs
+++ b/spec.bs
@@ -3915,8 +3915,8 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
     1. If |signal| is not an [=ordered map=], [=iteration/continue=].
     1. If |signal|["`adSlot`"] doesn't exist, [=iteration/continue=].
     1. If |headerAdSlots| [=set/contains=] |signal|["`adSlot`"], [=iteration/continue=]. Optionally,
-      [=report a warning to the console=] with a diagnostic error message indicating that duplicate
-      [:Ad-Auction-Signals:] `adSlot` dictionary was ignored.
+      [=report a warning to the console=] with a diagnostic error message indicating that a
+      duplicate [:Ad-Auction-Signals:] `adSlot` dictionary was ignored.
     1. [=set/Append=] |signal|["`adSlot`"] to |headerAdSlots|.
     1. Let |signalsKey| be a new [=direct from seller signals key=], with its
       [=direct from seller signals key/seller=] set to |requestOrigin| and its


### PR DESCRIPTION
Duplicate adSlot entries indicate a problem with the Ad-Auction-Signals response. Ignore such responses, and add a note that a diagnostic error can be issued.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/903.html" title="Last updated on Dec 5, 2023, 2:31 PM UTC (2fb73af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/903/ff421a5...caraitto:2fb73af.html" title="Last updated on Dec 5, 2023, 2:31 PM UTC (2fb73af)">Diff</a>