### PR TITLE
Spec: Allow updating userBiddingSignals.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3633,9 +3633,8 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
 
         <dt>"`userBiddingSignals`"
         <dd>
-        1. If |value| is a [=string=],
-          set |ig|'s [=interest group/user bidding signals=] to the result of [=parse a JSON
-          string to an Infra value=] given |value|.
+        1. Set |ig|'s [=interest group/user bidding signals=] to the result of [=serialize an Infra
+          value to JSON bytes=] given |value|.
         1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
 
         <dt>"`ads`"

--- a/spec.bs
+++ b/spec.bs
@@ -3637,6 +3637,9 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
           value to JSON bytes=] given |value|.
         1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
 
+        Issue:  Serializing an Infra value to JSON bytes expects to be called within a valid ES realm. See
+        <a href="https://github.com/whatwg/infra/issues/625">infra/625</a>
+
         <dt>"`ads`"
         <dt>"`adComponents`"
         <dd>

--- a/spec.bs
+++ b/spec.bs
@@ -3631,6 +3631,13 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
           set |ig|'s [=interest group/trusted bidding signals keys=] to |value|.
         1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
 
+        <dt>"`userBiddingSignals`"
+        <dd>
+        1. If |value| is a [=string=],
+          set |ig|'s [=interest group/user bidding signals=] to the result of [=parse a JSON
+          string to an Infra value=] given |value|.
+        1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
+
         <dt>"`ads`"
         <dt>"`adComponents`"
         <dd>


### PR DESCRIPTION
Protected Audience now allows an interest group's userBiddingSignals property to be updated
when an interest group update occurs (see change [here](https://chromium-review.googlesource.com/c/chromium/src/+/4995298)).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HabibiYou/turtledove/pull/907.html" title="Last updated on Nov 20, 2023, 3:16 PM UTC (4b0ba72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/907/0582dcb...HabibiYou:4b0ba72.html" title="Last updated on Nov 20, 2023, 3:16 PM UTC (4b0ba72)">Diff</a>