### PR TITLE
Add iframe support for adAuctionHeaders to spec.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1110,7 +1110,11 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       |config|["{{AuctionAdConfig/additionalBids}}"] until an associated [=request=] whose
       [=request/initiator type=] is `"fetch"` and the {{RequestInit/adAuctionHeaders}} option set to
       `true` returns a response, or alternatively, not calling {{Navigator/runAdAuction()}} until the
-      [=request=] returns a response.
+      [=request=] returns a response. Another alternative is to issue an
+      <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+      request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a> set to `true`,
+      calling {{Navigator/runAdAuction()}} after that request has returned a response; in this case,
+      the JavaScript code can immediately resolve |config|["{{AuctionAdConfig/additionalBids}}"].
 
     * To parse the value |result|:
       1. Set |auctionConfig|'s [=auction config/expects additional bids=] to false.
@@ -1119,13 +1123,19 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 1. If |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"] [=map/exists=]:
   1. [=Handle an input promise in configuration=] given |auctionConfig| and
     |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"]:
-    
+
     Note: The JavaScript code calling {{Navigator/runAdAuction()}} is responsible for resolving
       |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"] only when the {{Promise}}
       returned from an associated [=request=], whose [=request/initiator type=] is `"fetch"` and the
       {{RequestInit/adAuctionHeaders}} option set to `true`, resolves or rejects. Otherwise, there
       will be a race condition that the worklet can run without the direct from seller signals that
-      it needs. See [[#fetch-patch-for-auction-headers]] for details.
+      it needs. See [[#fetch-patch-for-auction-headers]] for details. An alternative is to issue an
+      <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+      request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a> set to `true`,
+      calling {{Navigator/runAdAuction()}} after that request has returned a response; in this case,
+      the JavaScript code can immediately resolve
+      |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"].
+
     * To parse the value |result|:
       1. Set |auctionConfig|'s [=auction config/direct from seller signals header ad slot=] to
         |result|.
@@ -3742,7 +3752,10 @@ Any {{Document}} in a [=traversable navigable=] may run a Protected Audience auc
 derived from JSON from an [:Ad-Auction-Signals:] header, or [=additional bids=] derived from an
 [:Ad-Auction-Additional-Bid:] header, captured by a {{WindowOrWorkerGlobalScope/fetch()}} call
 (using the {{RequestInit/adAuctionHeaders}} option) initiated by any *other* {{Document}} in the
-*same* [=traversable navigable=].
+*same* [=traversable navigable=], or from an
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+request (using the <{iframe/adAuctionHeaders}>
+<a spec=html>content attribute</a> on the <{iframe}> element).
 
 <div algorithm="fetch per traversable navigable structures patch">
 Modify [[FETCH]]'s [[FETCH#infrastructure]] to add a new section called "Per Traversable Navigable
@@ -3753,7 +3766,10 @@ headers</dfn>, which is a [=map=] whose [=map/keys=] are [=direct from seller si
 whose [=map/values=] are [=direct from seller signals=].
 
 NOTE: This is only captured during a [=request=] whose [=request/initiator type=] is `"fetch"`, made
-with the {{RequestInit/adAuctionHeaders}} option set to `true`, as described in the
+with the {{RequestInit/adAuctionHeaders}} option set to `true`, or during an
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+request with the <{iframe/adAuctionHeaders}>
+<a spec=html>content attribute</a> set to `true`, as described in the
 [:Ad-Auction-Signals:] header description.
 
 Each [=traversable navigable=] has a <dfn for="traversable navigable">captured ad auction additional
@@ -3761,12 +3777,14 @@ bids headers</dfn>, which is a [=map=] whose [=map/keys=] are [=auction nonces=]
 [=map/values=] are [=strings=].
 
 NOTE: This is only captured during a [=request=] whose [=request/initiator type=] is `"fetch"`, made
-with the {{RequestInit/adAuctionHeaders}} option set to `true`, as described in the
-[:Ad-Auction-Additional-Bid:] header description.
+with the {{RequestInit/adAuctionHeaders}} option set to `true`, or during an
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>
+set to `true`, as described in the [:Ad-Auction-Additional-Bid:] header description.
 </div>
 
 <div algorithm="fetch capture adAuctionHeaders boolean patch">
-Modify the definition of a [=request=]: 
+Modify the definition of a [=request=]:
 
 A [=request=] has an associated boolean <dfn for=request>capture-ad-auction-headers</dfn>.
 Unless stated otherwise it is false.
@@ -3792,6 +3810,30 @@ step "Set [=this=]'s [=Request/request=] to |request|":
 
 </div>
 
+<div algorithm="iframe navigation capture adAuctionHeaders attribute patch">
+Modify the <{iframe}> element to add a
+<dfn element-attr for="iframe">adAuctionHeaders</dfn> <a spec=html>content attribute</a>.
+The IDL attribute {{HTMLIFrameElement/adAuctionHeaders}} <a spec=html>reflects</a>
+the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>.
+
+<pre class=idl>
+partial interface HTMLIFrameElement {
+  [CEReactions] attribute boolean adAuctionHeaders;
+};
+</pre>
+</div>
+
+<div algorithm="iframe navigation patch">
+The following step will be added to the
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching">create navigation params by fetching steps</a>,
+after step "Let |request| be a new [=Request/request=], with ...":
+
+1. If <var ignore=''>navigable</var>'s [=navigable/container=] is an <{iframe}> element,
+  and if it has a <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>,
+  then set |request|'s [=request/capture-ad-auction-headers=] to true.
+
+</div>
+
 <div algorithm="fetch Sec-Ad-Auction-Fetch patch">
 The following step will be added to the [=HTTP-network-or-cache fetch=] algorithm, before step
 "Modify |httpRequest|'s [=request/header list=] per HTTP. ...":
@@ -3811,9 +3853,12 @@ request header</h3>
 The \`<dfn http-header><code>Sec-Ad-Auction-Fetch</code></dfn>\` request header is an optional
 [=structured header=] with of type [=structured header/boolean=]. [:Sec-Ad-Auction-Fetch:] will only
 be set on a [=request=] whose [=request/initiator type=] is `"fetch"`, made with the
-{{RequestInit/adAuctionHeaders}} option set to `true`. If [:Sec-Ad-Auction-Fetch:] is equal to `?1`,
+{{RequestInit/adAuctionHeaders}} option set to `true` or on an
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>
+set to `true`. If [:Sec-Ad-Auction-Fetch:] is equal to `?1`,
 the user agent will remove any [:Ad-Auction-Signals:] from the returned [=response=] -- the
-[:Ad-Auction-Signals:] value will instead only be used in Protected Audiences auctions. 
+[:Ad-Auction-Signals:] value will instead only be used in Protected Audiences auctions.
 
 <h3 id=ad-auction-signals-header>The \`<a http-header><code>Ad-Auction-Signals</code></a>\` HTTP
 response header</h3>

--- a/spec.bs.bak
+++ b/spec.bs.bak
@@ -75,10 +75,6 @@ spec: Shared Storage API; urlPrefix: https://wicg.github.io/shared-storage
     text: shared-storage-select-url; url: #permissionspolicy-shared-storage-select-url
 </pre>
 
-<pre class=link-defaults>
-spec:infra; type:dfn; text:user agent
-</pre>
-
 <style>
 /* Put nice boxes around each algorithm. */
 [data-algorithm]:not(.heading) {
@@ -151,11 +147,10 @@ When a user's interactions with a website indicate that the user may have a part
 advertiser or someone working on behalf of the advertiser (e.g. a demand side platform, DSP) can ask
 the user's browser to record this interest on-device by calling
 {{Window/navigator}}.{{Navigator/joinAdInterestGroup()}}. This indicates an intent to display an
-advertisement relevant to this interest to this user in the future. The [=user agent=] has an
+advertisement relevant to this interest to this user in the future. The user agent has an
 <dfn>interest group set</dfn>, a [=list=] of [=interest groups=] in which
 [=interest group/owner=] / [=interest group/name=] pairs are unique.
 
-<h3 id="join-ad-interest-groups">navigator.joinAdInterestGroup()</h3>
 
 <xmp class="idl">
 [SecureContext]
@@ -218,9 +213,9 @@ This is detectable because it can change the set of fields that are read from th
 {{TypeError}} is eventually thrown, but it will never change whether the call succeeds or fails.
 
 </div>
-1. Let |global| be [=this=]'s [=relevant global object=].
-1. If |global|'s [=associated Document=] is not [=allowed to use=] the "[=join-ad-interest-group=]"
-  [=policy-controlled feature=], then [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
+1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
+  "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
+  "{{NotAllowedError}}" {{DOMException}}.
 1. Let |frameOrigin| be [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=].
 1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and its [=origin/scheme=] is "`https`".
 1. Let |interestGroup| be a new [=interest group=].
@@ -234,9 +229,9 @@ This is detectable because it can change the set of fields that are read from th
   1. If |interestGroup|'s [=interest group/owner=] is failure, then [=exception/throw=] a {{TypeError}}.
   1. Optionally, [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
 
-    Note: This [=implementation-defined=] condition is intended to allow [=user agents=] to decline
-        for a number of reasons, for example the [=interest group/owner=]'s [=site=] not being
-        <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
+    Note: This [=implementation-defined=] condition is intended to allow user
+        agents to decline for a number of reasons, for example the [=interest group/owner=]'s [=site=]
+        not being <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
   1. Set |interestGroup|'s [=interest group/name=] to |group|["{{GenerateBidInterestGroup/name}}"].
   1. Set |interestGroup|'s [=interest group/priority=] to
     |group|["{{AuctionAdInterestGroup/priority}}"].
@@ -324,7 +319,7 @@ This is detectable because it can change the set of fields that are read from th
             1. Let |origin| be the result of [=parsing an https origin=] on |originStr|.
             1. If |origin| is failure, then [=exception/throw=] a {{TypeError}}.
             1. [=list/Append=] |origin| to |allowedReportingOrigins|.
-            1. If |allowedReportingOrigins|'s [=list/size=] &gt; 10, [=exception/throw=]
+            1. If [=list/size=] of |allowedReportingOrigins| is greater than 10, [=exception/throw=]
               a {{TypeError}}.
           1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
@@ -338,18 +333,16 @@ This is detectable because it can change the set of fields that are read from th
 
       * |group|["{{GenerateBidInterestGroup/updateURL}}"] [=map/exists=].
     1. Set |interestGroup|'s [=interest group/additional bid key=] to |decodedKey|.
-1. If |interestGroup|'s [=interest group/estimated size=] &gt; 1048576, then [=exception/throw=] a
-  {{TypeError}}.
+1. If |interestGroup|'s [=interest group/estimated size=] is greater than 50 KB, then
+  [=exception/throw=] a {{TypeError}}.
 1. Let |p| be [=a new promise=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
   1. Let |permission| be the result of [=checking interest group permissions=] with
     |interestGroup|'s [=interest group/owner=], |frameOrigin|, and "`join`".
-  1. If |permission| is false, then [=queue a global task=] on [=DOM manipulation task source=],
-    given |global|, to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and abort these
-    steps.
-  1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=] |p|
-    with `undefined`.
+  1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
+     "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
+  1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
   1. If the browser is currently storing an interest group with `owner` and `name` that matches
     |interestGroup|, then set the [=interest group/bid counts=],
     [=interest group/join counts=], and [=interest group/previous wins=] of
@@ -361,7 +354,7 @@ This is detectable because it can change the set of fields that are read from th
   1. If the most recent entry in |interestGroup|'s [=interest group/join counts=] corresponds to
     the current day in UTC, increment its count. If not, [=list/insert=] a new [=tuple=]
     the time set to the current UTC day and a count of 1.
-  1. Store |interestGroup| in the [=user agent=]'s [=interest group set=].
+  1. Store |interestGroup| in the browser’s [=interest group set=].
 1. Return |p|.
 
 </div>
@@ -415,22 +408,11 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 
 <div algorithm>
 
-To <dfn>check interest group permissions</dfn> given an [=origin=] |ownerOrigin|, an [=origin=]
-|frameOrigin|, and an enum |joinOrLeave| which is "`join`" or "`leave`":
+To <dfn>check interest group permissions</dfn> given an [=origin=]
+|ownerOrigin|, an [=origin=] |frameOrigin|, and an enum |joinOrLeave| which is "`join`" or "`leave`":
 1. If |ownerOrigin| is [=same origin=] with |frameOrigin|, then return true.
-1. Let |encodedFrameOrigin| be the result of [=string/UTF-8 percent-encoding=] the
-  [=serialization of an origin|serialized=] |frameOrigin| using [=component percent-encode set=].
-1. Let |permissionsUrl| be a new [=URL=] with the following [=struct/items=]:
-  :   [=url/scheme=]
-  ::  |ownerOrigin|'s [=origin/scheme=]
-  :   [=url/host=]
-  ::  |ownerOrigin|'s [=origin/host=]
-  :   [=url/port=]
-  ::  |ownerOrigin|'s [=origin/port=]
-  :   [=url/path=]
-  ::  « ".well-known", "interest-group", "permissions" »
-  :   [=url/query=]
-  ::  The result of [=string/concatenating=] « "origin=", |encodedFrameOrigin| »
+1. Let |permissionsUrl| be the result of [=building an interest group permissions url=] with
+  |ownerOrigin| and |frameOrigin|.
 1. Let |request| be a new [=request=] with the following properties:
   :   [=request/URL=]
   ::  |permissionsUrl|
@@ -479,95 +461,18 @@ prevents a leak of the user's ad interest group membership to the server.
 
 </div>
 
-<h3 id="interest-group-storage-maintenance">Interest Group Storage Maintenance</h3>
-
-There is a job that periodically [=performs storage maintenance=] on the [=user agent=]'s
-[=interest group set=]. It performs operations such as [=list/removing=] expired or excess
-[=interest groups=]. An [=interest group set=] must respect the following limits. Implementations
-may define their own values for the below constants, however we supply the below values as a
-starting point, inspired by what the initial implementation of this specification uses:
-  * <dfn>Interest group set max owners</dfn> is 1000, which defines the max number of
-    [=interest group/owners=] in the [=user agent=]'s [=interest group set=].
-  * <dfn>Max regular interest groups per owner</dfn> is 2000, which defines the max number of
-    [=regular interest groups=] in the [=user agent=]'s [=interest group set=] for an
-    [=interest group/owner=].
-  * <dfn>Max negative interest groups per owner</dfn> is 20000, which defines the max number of
-    [=negative interest groups=] in the [=user agent=]'s [=interest group set=] for an
-    [=interest group/owner=].
-  * <dfn>Max interest groups total size per owner</dfn> is <code>10\*1024\*1024</code>, which
-    defines the max total [=interest group/estimated size|sizes=] of [=interest groups=] in the
-    [=user agent=]'s [=interest group set=] for an [=interest group/owner=]. It includs both
-    [=regular interest groups=] and [=negative interest groups=].
-
 <div algorithm>
-To <dfn>perform storage maintenance</dfn>:
 
-1. Let |ownersAndExpiry| be a new [=ordered map=] whose [=map/keys=] are [=origins=] and
-  [=map/values=] are [=moments=].
-
-  Note: The [=map/key=] is from [=interest group/owner=], and [=map/value=] is from
-    [=interest group/expiry=]. It's used to determine a set of [=interest group/owners=] whose
-    [=interest groups=] will be removed from the [=user agent=]'s [=interest group set=] because the
-    number of distinct [=interest group/owners=] exceeds the [=Interest group set max owners=] limit.
-    It's sorted based on their [=map/values=] ([=interest group/expiry=]) in descending order, in
-    order to remove [=interest groups=] of [=interest group/owners=] expiring soonest first.
-
-1. Let |now| be the [=current wall time=].
-1. [=list/For each=] |ig| of the [=user agent=]'s [=interest group set=]:
-  1. Let |owner| be |ig|'s [=interest group/owner=].
-  1. If |ig|'s [=interest group/expiry=] is before |now|, then [=list/remove=] |ig| from the
-    [=user agent=]'s [=interest group set=] and [=iteration/continue=].
-  1. If |ownersAndExpiry|[|owner|] [=map/exists=], then [=map/set=] |ownersAndExpiry|[|owner|] to
-    |ig|'s [=interest group/expiry=] if it comes after |ownersAndExpiry|[|owner|].
-  1. Otherwise, [=map/set=] |ownersAndExpiry|[|owner|] to |ig|'s [=interest group/expiry=].
-1. If |ownersAndExpiry|'s [=map/size=] &gt; [=interest group set max owners=], then [=map/set=]
-  |ownersAndExpiry| to |ownersAndExpiry| [=map/sorted in descending order=] with |a| being less than
-  |b| if |a|'s [=map/value=] comes before |b|'s [=map/value=], where [=map/values=] are
-  [=interest group/expiry=].
-1. Let |owners| be the [=map/get the keys|keys=] of |ownersAndExpiry|.
-1. [=list/For each=] |i| in [=the range=] from 0 to |owners|'s [=set/size=], exclusive:
-  1. If |i| &ge; [=interest group set max owners=], then [=list/remove=] [=interest groups=] from
-    the [=user agent=]'s [=interest group set=] whose [=interest group/owner=] is |owners|[|i|], and
-    [=iteration/continue=].
-  1. Let |regularIgs| be a [=list=] of [=regular interest groups=] in the [=user agent=]'s
-    [=interest group set=] whose [=interest group/owner=] is |owners|[|i|].
-  1. If |regularIgs|'s [=list/size=] &gt; [=max regular interest groups per owner=], then
-    [=clear excess interest groups=] with |regularIgs| and [=max regular interest groups per owner=].
-  1. Let |negativeIgs| be a [=list=] of [=negative interest groups=] in the [=user agent=]'s
-    [=interest group set=] whose [=interest group/owner=] is |owners|[|i|].
-  1. If |negativeIgs|'s [=list/size=] &gt; [=max negative interest groups per owner=], then
-    [=clear excess interest groups=] with |negativeIgs| and [=max negative interest groups per owner=].
-1. [=list/For each=] |owner| of |owners|:
-  1. Let |igs| be a [=list=] of [=interest groups=] in the [=user agent=]'s [=interest group set=]
-    whose [=interest group/owner=] is |owner|, [=list/sorted in descending order=] with |a| being
-    less than |b| if |a|[=interest group/expiry=] comes before |b|[=interest group/expiry=].
-  1. Let |cumulativeSize| be 0.
-  1. [=list/For each=] |ig| of |igs|:
-    1. If the sum of |cumulativeSize| and |ig|'s [=interest group/estimated size=]
-      &gt; [=max interest groups total size per owner=], then [=list/remove=] |ig| from the
-      [=user agent=]'s [=interest group set=].
-    1. Otherwise, increment |cumulativeSize| by |ig|'s [=interest group/estimated size=].
-
-</div>
-
-<div algorithm>
-To <dfn>clear excess interest groups</dfn> with a [=list=] of [=interest groups=] |igs|, and an
-integer |maxIgs|:
-
-1. Let |sortedIgs| be |igs| [=list/sorted in descending order=] with |a| being less
-  than |b| if |a|'s [=interest group/expiry=] comes before |b|'s [=interest group/expiry=].
-
-  Note: In order to remove interest groups expiring soonest first, sort interest groups based on
-    their expiry in descending order.
-
-1. [=list/For each=] |i| in [=the range=] from |maxIgs| to |igs|'s [=list/size=], exclusive:
-  1. [=list/Remove=] |sortedIgs|[|i|] from the [=user agent=]'s [=interest group set=].
+To <dfn>build an interest group permissions url</dfn> given a [=origin=] |ownerOrigin| and a [=origin=] |frameOrigin|:
+1. Let |serializedFrameOrigin| be the result of [=serialization of an origin|serializing=] |frameOrigin|.
+1. Return the string formed by [=string/concatenating=]
+  * The [=serialization of an origin|serialization=] of |ownerOrigin|,
+  * The string "`/.well-known/interest-group/permissions/?origin=`", and
+  * The result of [=string/UTF-8 percent-encoding=] |serializedFrameOrigin| using [=component percent-encode set=].
 
 </div>
 
 <h2 id="leaving-interest-groups">Leaving Interest Groups</h2>
-
-<h3 id="leaveadinterestgroup">leaveAdInterestGroup()</h3>
 
 *This first introductory paragraph is non-normative.*
 
@@ -589,93 +494,44 @@ dictionary AuctionAdInterestGroupKey {
 
 <div algorithm>
 
-The <dfn for=Navigator method>leaveAdInterestGroup(group)</dfn> method steps are:
-
-1. Let |global| be [=this=]'s [=relevant global object=].
-1. Let |frameOrigin| be |global|'s [=environment settings object/origin=].
-1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and its [=origin/scheme=] is "`https`".
-1. Let |p| be [=a new promise=].
-1. If |group| [=map/is empty=]:
-  1. Let |instance| be |global|'s [=Window/browsing context=]'s
-    [=browsing context/fenced frame config instance=].
-  1. If |instance| is null, then return.
-  1. Let |interestGroup| be |instance|'s [=fenced frame config instance/interest group descriptor=].
-  1. Run these steps [=in parallel=]:
-    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=]
-      |p| with `undefined`.
-    1. If |interestGroup| is not null:
-      1. Let |owner| be |interestGroup|'s [=interest group descriptor/owner=].
-      1. If |owner| is [=same origin=] with |frameOrigin|, then [=list/remove=] [=interest groups=]
-        from the [=user agent=]'s [=interest group set=] whose [=interest group/owner=] is |owner| and
-        [=interest group/name=] is |interestGroup|'s [=interest group descriptor/name=].
-1. Otherwise:
-  1. If |global|'s [=associated Document=] is not [=allowed to use=] the
-    "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
-    "{{NotAllowedError}}" {{DOMException}}.
-
-    Note: Both joining and leaving interest groups use the "join-ad-interest-group" feature.
-  1. Let |owner| be the result of [=parsing an https origin=] with
-    |group|["{{AuctionAdInterestGroupKey/owner}}"].
-  1. If |owner| is failure, [=exception/throw=] a {{TypeError}}.
-  1. Run these steps [=in parallel=]:
-    1. Let |permission| be the result of [=checking interest group permissions=] with
-      |owner|, |frameOrigin|, and "`leave`".
-    1. If |permission| is false, then [=queue a global task=] on [=DOM manipulation task source=],
-      given |global|, to [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and abort
-      these steps.
-    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=]
-      |p| with `undefined`.
-    1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=] whose
-      [=interest group/owner=] is |owner| and [=interest group/name=] is
-      |group|["{{AuctionAdInterestGroupKey/name}}"].
-1. Return |p|.
-
-</div>
-
-<h3 id="clearoriginjoinedAdInterestGroups">clearOriginJoinedAdInterestGroups()</h3>
-
-*This first introductory paragraph is non-normative.*
-
-{{Window/navigator}}.{{Navigator/clearOriginJoinedAdInterestGroups()}} removes a user from
-[=interest groups=] whose [=interest group/joining origin=] is the associated
-{{Navigator}}'s [=relevant settings object=]'s [=environment/top-level origin=].
-
-
-<xmp class="idl">
-[SecureContext]
-partial interface Navigator {
-  Promise<undefined> clearOriginJoinedAdInterestGroups(
-      USVString owner, optional sequence<USVString> interestGroupsToKeep = []);
-};
-</xmp>
-
-<div algorithm>
-
-The <dfn for=Navigator method>clearOriginJoinedAdInterestGroups(|owner|, |interestGroupsToKeep|)</dfn>
-method steps are:
+The <dfn for=Navigator method>leaveAdInterestGroup(group)</dfn> method steps
+are:
 
 1. Let |frameOrigin| be [=this=]'s [=relevant settings object=]'s
   [=environment settings object/origin=].
 1. [=Assert=] that |frameOrigin| is not an [=opaque origin=] and its [=origin/scheme=] is "`https`".
 1. Let |p| be [=a new promise=].
-1. Let |global| be [=this=]'s [=relevant global object=].
-1. If |global|'s [=associated Document=] is not [=allowed to use=] the
-  "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
-  "{{NotAllowedError}}" {{DOMException}}.
+1. If |group| [=map/is empty=]:
+  1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
+    [=browsing context/fenced frame config instance=].
+  1. If |instance| is null, [=exception/throw=] a {{TypeError}}.
+  1. Let |interestGroup| be |instance|'s [=fenced frame config instance/interest group descriptor=].
+  1. Run these steps [=in parallel=]:
+    1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
+    1. If |interestGroup| is not null:
+      1. Let |owner| be |interestGroup|'s [=interest group descriptor/owner=].
+      1. Let |name| be |interestGroup|'s [=interest group descriptor/name=].
+      1. If |owner| is [=same origin=] with |frameOrigin|, then [=list/remove=] [=interest groups=]
+        from the user agent's [=interest group set=] whose [=interest group/owner=] is |owner| and
+        [=interest group/name=] is |name|.
+1. Otherwise:
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the
+    "[=join-ad-interest-group=]" [=policy-controlled feature=], then [=exception/throw=] a
+    "{{NotAllowedError}}" {{DOMException}}.
 
-  Note: Both joining and leaving interest groups use the "join-ad-interest-group" feature.
-1. Let |ownerOrigin| be the result of [=parsing an https origin=] with |owner|.
-1. If |ownerOrigin| is failure, [=exception/throw=] a {{TypeError}}.
-1. Run these steps [=in parallel=]:
-  1. Let |permission| be the result of [=checking interest group permissions=] with
-    |ownerOrigin|, |frameOrigin|, and "`leave`".
-  1. If |permission| is false, then [=queue a global task=] on the [=DOM manipulation task source=]
-    given |global|, [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and abort these steps.
-  1. [=Queue a global task=] on the [=DOM manipulation task source=] given |global|, to [=resolve=] |p|
-    with {{undefined}}.
-  1. [=list/Remove=] [=interest groups=] from the [=user agent=]'s [=interest group set=]
-    whose [=interest group/owner=] is |ownerOrigin|, whose [=interest group/joining origin=] is
-    |frameOrigin|, and whose [=interest group/name=] is not in |interestGroupsToKeep|.
+    Note: both joining and leaving interest groups use the "join-ad-interest-group" feature.
+  1. Let |owner| be the result of [=parsing an https origin=] with
+    |group|["{{AuctionAdInterestGroupKey/owner}}"].
+  1. If |owner| is failure, [=exception/throw=] a {{TypeError}}.
+  1. Let |name| be |group|["{{AuctionAdInterestGroupKey/name}}"].
+  1. Run these steps [=in parallel=]:
+    1. Let |permission| be the result of [=checking interest group permissions=] with
+      |owner|, |frameOrigin|, and "`leave`".
+    1. If |permission| is false, then [=queue a task=] to [=reject=] |p| with a
+       "{{NotAllowedError}}" {{DOMException}} and do not run the remaining steps.
+    1. [=Queue a task=] to [=resolve=] |p| with `undefined`.
+    1. [=list/Remove=] [=interest groups=] from the user agent's [=interest group set=] whose
+      [=interest group/owner=] is |owner| and [=interest group/name=] is |name|.
 1. Return |p|.
 
 </div>
@@ -711,7 +567,6 @@ dictionary AuctionAdConfig {
   USVString sellerCurrency;
   Promise<record<USVString, any>> perBuyerSignals;
   Promise<record<USVString, unsigned long long>> perBuyerTimeouts;
-  Promise<record<USVString, unsigned long long>> perBuyerCumulativeTimeouts;
   record<USVString, unsigned short> perBuyerGroupLimits;
   record<USVString, unsigned short> perBuyerExperimentGroupIds;
   record<USVString, record<USVString, double>> perBuyerPrioritySignals;
@@ -737,9 +592,9 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 1. If |auctionConfig| is failure, then [=exception/throw=] a {{TypeError}}.
 1. Optionally, [=exception/throw=] a "{{NotAllowedError}}" {{DOMException}}.
 
-    Note: This [=implementation-defined=] condition is intended to allow [=user agents=] to decline
-        for a number of reasons, for example the [=auction config/seller=]'s [=site=] not being
-        <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
+    Note: This [=implementation-defined=] condition is intended to allow user
+        agents to decline for a number of reasons, for example the [=auction config/seller=]'s
+        [=site=] not being <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
 1. Let |p| be [=a new promise=].
 1. Let |configMapping| be |global|'s [=associated Document=]'s [=node navigable=]'s
   [=navigable/traversable navigable=]'s [=traversable navigable/fenced frame config mapping=].
@@ -761,12 +616,12 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
   1. Let |winnerInfo| be the result of running [=generate and score bids=] with |auctionConfig|,
-     null, |global|, |settings|'s [=environment/top-level origin=], and |bidIgs|.
+     null, |global|, |settings|, and |bidIgs|.
   1. If |winnerInfo| is failure, then [=queue a global task=] on [=DOM manipulation task source=],
     given |global|, to [=reject=] |p| with a "{{TypeError}}".
-  1. If |winnerInfo| is null or |winnerInfo|'s [=leading bid info/leading bid=] is null, then
-    [=queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p| with
-    null.
+  1. If |winnerInfo| is null or |winnerInfo|'s [=leading bid info/leading bid=] is null:
+    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to resolve |p|
+      with null.
   1. Otherwise:
     1. Let |winner| be |winnerInfo|'s [=leading bid info/leading bid=].
     1. Let |fencedFrameConfig| be the result of [=filling in a pending fenced frame config=] with
@@ -890,22 +745,25 @@ To <dfn>fill in a pending fenced frame config</dfn> given a [=fenced frame confi
 
      : name
      :: |winningBid|'s [=generated bid/interest group=]'s [=interest group/name=]
-1. Let |fencedFrameReportingMap| be the [=map=] «[ "`buyer`" → «», "`seller`" → «» ]».
-1. If |auctionConfig|'s [=auction config/component auctions=] is [=list/empty=], then [=map/set=]
-  |fencedFrameReportingMap|["`component-seller`"] to an empty [=list=] «».
 1. Set |pendingConfig|'s [=fenced frame config/fenced frame reporting metadata=] to a [=struct=]
    with the following [=struct/items=]:
     : [=fenced frame reporting metadata/value=]
-    :: A [=struct=]  with the following [=struct/items=]:
+    :: If |auctionConfig|'s [=auction config/component auctions=] is [=list/empty=] (i.e., if
+       there was no component auction), then a [=struct=]  with the following [=struct/items=]:
        : [=fenced frame reporting metadata/fenced frame reporting map=]
-       :: |fencedFrameReportingMap|
+       :: a [=map=] «[ "<code>buyer</code>" → «», "<code>seller</code>" → «»]»
 
        : [=fenced frame reporting metadata/direct seller is seller=]
-       :: true if |auctionConfig|'s [=auction config/component auctions=] is [=list/empty=], false
-          otherwise
+       :: true
 
-       : [=fenced frame reporting metadata/allowed reporting origins=]
-       :: |winningBid|'s [=generated bid/bid ad=]'s [=interest group ad/allowed reporting origins=]
+       Otherwise (i.e., if there was a component auction), a [=struct=] with the following
+       [=struct/items=]:
+       : [=fenced frame reporting metadata/fenced frame reporting map=]
+       :: a [=map=] «[ "<code>buyer</code>" → «», "<code>seller</code>" → «»,
+          "<code>component-seller</code>" → «»]»
+
+       : [=fenced frame reporting metadata/direct seller is seller=]
+       :: false
 
     : [=fenced frame reporting metadata/visibility=]
     :: "<a for=visibility>`opaque`</a>"
@@ -942,10 +800,15 @@ To <dfn>asynchronously finish reporting</dfn> given a
       1. Let |buyerMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/reporting beacon map=].
       1. If |buyerMap| is null, set |buyerMap| to an empty [=map=] «[]».
+      1. Let |allowedReportingOrigins| be |leadingBidInfo|'s [=leading bid info/leading bid=]'s
+        [=generated bid/bid ad=]'s [=interest group ad/allowed reporting origins=].
       1. Let |macroMap| be |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/reporting macro map=].
+      1. TODO: Pass |macroMap| and |allowedReportingOrigins| to [=Finalize a reporting destination=]
+        when it is updated to take the parameters. May need to convert |macroMap| to a list, based
+        on what that function expects.
       1. [=Finalize a reporting destination=] with |reportingMap|,
-         {{FenceReportingDestination/buyer}}, |buyerMap|, and |macroMap|.
+         {{FenceReportingDestination/buyer}}, and |buyerMap|.
       1. [=Send report=] to |leadingBidInfo|'s [=leading bid info/buyer reporting result=]'s
          [=reporting result/report url=].
       1. Set |buyerDone| to true.
@@ -1106,23 +969,15 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. [=Handle an input promise in configuration=] given |auctionConfig| and
     |config|["{{AuctionAdConfig/additionalBids}}"]:
 
-    Note: The JavaScript code calling {{Navigator/runAdAuction()}} is responsible for *not*
-      resolving |config|["{{AuctionAdConfig/additionalBids}}"] until additional bids have been
-      retrieved from one or more [:Ad-Auction-Additional-Bid:] headers, as resolving this Promise
-      early would cause a race condition in which additional bids might not be included in the
-      auction. There are two ways that additional bids can be retrieved. The first is for the
-      JavaScript code to issue a [=request=] whose [=request/initiator type=] is `"fetch"` and whose
-      {{RequestInit/adAuctionHeaders}} option is set to `true`. The JavaScript code has to resolve
-      |config|["{{AuctionAdConfig/additionalBids}}"] after this request has returned a response.
-      The JavaScript code can also choose to wait to call {{Navigator/runAdAuction()}} until after
-      this `"fetch"` request has returned a response, and can then immediately resolve
-      |config|["{{AuctionAdConfig/additionalBids}}"].
-      The second way that additional bids can be retrieved is by issuing an
+    Note: The JavaScript code calling {{Navigator/runAdAuction()}} is responsible for not resolving
+      |config|["{{AuctionAdConfig/additionalBids}}"] until an associated [=request=] whose
+      [=request/initiator type=] is `"fetch"` and the {{RequestInit/adAuctionHeaders}} option set to
+      `true` returns a response, or alternatively, not calling {{Navigator/runAdAuction()}} until the
+      [=request=] returns a response. Another alternative is to issue an
       <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
-      request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a> set to `true`.
-      In this case, the JavaScript code is retrieved as part of the iframe navigation response,
-      at which point the JavaScript code makes the call to {{Navigator/runAdAuction()}},
-      and |config|["{{AuctionAdConfig/additionalBids}}"] can be immediately resolved.
+      request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a> set to `true`,
+      calling {{Navigator/runAdAuction()}} after that request has returned a response; in this case,
+      the JavaScript code can immediately resolve |config|["{{AuctionAdConfig/additionalBids}}"].
 
     * To parse the value |result|:
       1. Set |auctionConfig|'s [=auction config/expects additional bids=] to false.
@@ -1132,25 +987,18 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. [=Handle an input promise in configuration=] given |auctionConfig| and
     |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"]:
 
-    Note: The JavaScript code calling {{Navigator/runAdAuction()}} is responsible for *not*
-      resolving |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"]
-      until direct from seller signals have been retrieved from one or more [:Ad-Auction-Signals:]
-      headers, as resolving this Promise early would cause a race condition in which the worklet
-      might run without the direct from seller signals that it needs. There are two ways that
-      direct from seller signals can be retrieved. The first is for the JavaScript code to issue a
-      [=request=] whose [=request/initiator type=] is `"fetch"` and whose
-      {{RequestInit/adAuctionHeaders}} option is set to `true`. The JavaScript code has to resolve
-      |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"] after this request has
-      returned a response. The JavaScript code can also choose to wait to call
-      {{Navigator/runAdAuction()}} until after this `"fetch"` request has returned a response, and
-      can then immediately resolve
-      |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"].
-      The second way that direct from seller signals can be retrieved is by issuing an
+    Note: The JavaScript code calling {{Navigator/runAdAuction()}} is responsible for resolving
+      |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"] only when the {{Promise}}
+      returned from an associated [=request=], whose [=request/initiator type=] is `"fetch"` and the
+      {{RequestInit/adAuctionHeaders}} option set to `true`, resolves or rejects. Otherwise, there
+      will be a race condition that the worklet can run without the direct from seller signals that
+      it needs. See [handling direct from seller signals](#handling-direct-from-seller-signals) for
+      details. An alternative is to issue an
       <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
-      request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a> set to `true`.
-      In this case, the JavaScript code is retrieved as part of the iframe navigation response,
-      at which point the JavaScript code makes the call to {{Navigator/runAdAuction()}},
-      and |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"] can be immediately resolved.
+      request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a> set to `true`,
+      calling {{Navigator/runAdAuction()}} after that request has returned a response; in this case,
+      the JavaScript code can immediately resolve
+      |config|["{{AuctionAdConfig/directFromSellerSignalsHeaderAdSlot}}"].
 
     * To parse the value |result|:
       1. Set |auctionConfig|'s [=auction config/direct from seller signals header ad slot=] to
@@ -1185,36 +1033,23 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
         1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer signals=][|buyer|] to
           |signalsString|.
     * To handle an error, set |auctionConfig|'s [=auction config/per buyer signals=] to failure.
-1. For each |idlTimeoutMember|, |perBuyerTimeoutField|, |allBuyersTimeoutField| in the following table
-  <table class="data">
-    <thead><tr><th>IDL timeout member</th><th>Per buyer timeout field</th><th>All buyers timeout field</th></tr></thead>
-    <tr>
-      <td>"{{AuctionAdConfig/perBuyerTimeouts}}"</td>
-      <td>[=auction config/per buyer timeouts=]</td>
-      <td>[=auction config/all buyers timeout=]</td>
-    </tr>
-    <tr>
-      <td>"{{AuctionAdConfig/perBuyerCumulativeTimeouts}}"</td>
-      <td>[=auction config/per buyer cumulative timeouts=]</td>
-      <td>[=auction config/all buyers cumulative timeout=]</td>
-    </tr>
-  </table>
-  1. If |config| [=map/contains=] |idlTimeoutMember|:
-    1. Set |auctionConfig|'s |perBuyerTimeoutField| to |config|[|idlTimeoutMember|].
-    1. [=Handle an input promise in configuration=] given |auctionConfig| and |auctionConfig|'s
-      |perBuyerTimeoutField|:
-      * To parse the value |result|:
-        1. Set |auctionConfig|'s |perBuyerTimeoutField| to a new [=ordered map=] whose
-          [=map/keys=] are [=origins=] and whose [=map/values=] are [=durations=] in milliseconds.
-        1. [=map/For each=] |key| → |value| of |result|:
-          1. If |perBuyerTimeoutField| is "{{AuctionAdConfig/perBuyerTimeouts}}", and
-            |value| &gt; 500, then set |value| to 500.
-          1. If |key| is "*", then set |auctionConfig|'s |allBuyersTimeoutField| to |value| in
-            milliseconds, and [=iteration/continue=].
-          1. Let |buyer| be the result of [=parsing an https origin=] with |key|. If |buyer| is
-            failure, [=exception/throw=] a {{TypeError}}.
-          1. [=map/Set=] |auctionConfig|'s |perBuyerTimeoutField|[|buyer|] to |value| in milliseconds.
-      * To handle an error, set |auctionConfig|'s |perBuyerTimeoutField| to failure.
+1. If |config|["{{AuctionAdConfig/perBuyerTimeouts}}"] [=map/exists=]:
+  1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to
+      |config|["{{AuctionAdConfig/perBuyerTimeouts}}"].
+  1. [=Handle an input promise in configuration=] given |auctionConfig| and |auctionConfig|'s
+    [=auction config/per buyer timeouts=]:
+    * To parse the value |result|:
+      1. Set |auctionConfig|'s [=auction config/per buyer timeouts=] to a new [=ordered map=] whose
+        [=map/keys=] are [=origins=] and whose [=map/values=] are [=durations=] in milliseconds.
+      1. [=map/For each=] |key| → |value| of |result|:
+        1. If |key| is "*", then set |auctionConfig|'s [=auction config/all buyers timeout=]
+          to |value| in milliseconds or 500 milliseconds, whichever is smaller, and
+          [=iteration/continue=].
+        1. Let |buyer| be the result of [=parsing an https origin=] with |key|. If |buyer| is
+          failure, [=exception/throw=] a {{TypeError}}.
+        1. [=map/Set=] |auctionConfig|'s [=auction config/per buyer timeouts=][|buyer|] to
+          |value| in milliseconds or 500 milliseconds, whichever is smaller.
+    * To handle an error, set |auctionConfig|'s [=auction config/per buyer timeouts=] to failure.
 1. If |config|["{{AuctionAdConfig/perBuyerGroupLimits}}"] [=map/exists=], [=map/for each=]
   |key| → |value| of |config|["{{AuctionAdConfig/perBuyerGroupLimits}}"]:
   1. If |value| is 0, then return failure.
@@ -1294,14 +1129,14 @@ To <dfn>parse an https origin</dfn> given a [=string=] |input|:
 
   To <dfn>update bid count</dfn> given a [=list=] of [=interest group=]s |igs|:
   1. [=list/For each=] |ig| in |igs|:
-    1. Let |loadedIg| be the [=interest group=] from the [=user agent=]'s [=interest group set=]
+    1. Let |loadedIg| be the [=interest group=] from the user agent’s [=interest group set=]
       whose [=interest group/owner=] is |ig|'s [=interest group/owner=] and whose
       [=interest group/name=] is |ig|'s [=interest group/name=], [=iteration/continue=] if none found.
     1. If the most recent entry in |loadedIg|'s [=interest group/bid counts=] corresponds to
       the current day in UTC, increment its count. If not, [=list/insert=] a new [=tuple=] of
       the time set to the current UTC day and a count of 1.
     1. [=list/Replace=] the [=interest group=] that has |loadedIg|'s [=interest group/owner=] and
-      [=interest group/name=] in the [=user agent=]'s [=interest group set=] with |loadedIg|.
+      [=interest group/name=] in the browser’s [=interest group set=] with |loadedIg|.
 
 </div>
 
@@ -1309,7 +1144,7 @@ To <dfn>parse an https origin</dfn> given a [=string=] |input|:
 
   To <dfn>update previous wins</dfn> given a [=generated bid=] |bid|:
   1. Let |ig| be |bid|'s [=generated bid/interest group=].
-  1. Let |loadedIg| be the [=interest group=] from the [=user agent=]'s [=interest group set=]
+  1. Let |loadedIg| be the [=interest group=] from the user agent’s [=interest group set=]
     whose [=interest group/owner=] is |ig|'s [=interest group/owner=] and whose
     [=interest group/name=] is |ig|'s [=interest group/name=], return if none found.
   1. Let |win| be a new [=previous win=].
@@ -1321,7 +1156,7 @@ To <dfn>parse an https origin</dfn> given a [=string=] |input|:
     [=serializing an Infra value to a JSON string=] given |ad|.
   1. [=list/Append=] |win| to |loadedIg|'s [=interest group/previous wins=].
   1. [=list/Replace=] the [=interest group=] that has |loadedIg|'s [=interest group/owner=] and
-    [=interest group/name=] in the [=user agent=]'s [=interest group set=] with |loadedIg|.
+    [=interest group/name=] in the browser’s [=interest group set=] with |loadedIg|.
 
 </div>
 
@@ -1332,7 +1167,7 @@ To <dfn>build bid generators map</dfn> given an [=auction config=] |auctionConfi
   [=map/values=] are [=per buyer bid generators=].
 1. Let |negativeTargetInfo| be a new [=negative target info=].
 1. [=list/For each=] |buyer| in |auctionConfig|'s [=auction config/interest group buyers=]:
-  1. [=list/For each=] |ig| of the [=user agent=]'s [=interest group set=] whose
+  1. [=list/For each=] |ig| of the user agent's [=interest group set=] whose
     [=interest group/owner=] is |buyer|:
     1. Let |igName| be |ig|'s [=interest group/name=].
     1. If |ig|'s [=interest group/additional bid key=] is not null:
@@ -1414,8 +1249,8 @@ and a [=moment=] |auctionStartTime|:
 <div algorithm="generate and score bids">
 
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, an
-[=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|, an [=origin=]
-|topLevelOrigin|, and a [=list=] of [=interest groups=] |bidIgs|:
+[=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|, an
+[=environment settings object=] |settings|, and a [=list=] of [=interest groups=] |bidIgs|:
 1. [=Assert=] that these steps are running [=in parallel=].
 1. Let |auctionStartTime| be the [=current wall time=].
 1. Let |decisionLogicScript| be the result of [=fetching script=] with |auctionConfig|'s
@@ -1426,17 +1261,17 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Let |leadingBidInfo| be a new [=leading bid info=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. Let |capturedAuctionHeaders| be |global|'s [=associated Document's=] [=node navigable's=]
-  [=traversable navigable's=] [=traversable navigable/captured ad auction signals headers=].
+  [=traversable navigable's=] [=traversable navigable/captured ad auction headers=].
 1. If |auctionConfig|'s [=auction config/component auctions=] are not [=list/is empty|empty=]:
   1. [=Assert=] |topLevelAuctionConfig| is null.
-  1. Let |pendingComponentAuctions| be |auctionConfig|'s [=auction config/component auctions=]'s
-    [=list/size=].
+  1. Let |pendingComponentAuctions| be the [=list/size=] of |auctionConfig|'s
+    [=auction config/component auctions=].
   1. Let |topLevelDirectFromSellerSignalsForSeller| be null.
   1. Let |topLevelDirectFromSellerSignalsRetrieved| be false.
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=],
     [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
     1. Let |compWinner| be the result of running [=generate and score bids=] with |component|,
-      |auctionConfig|, |global|, and |topLevelOrigin|.
+      |auctionConfig|, |global|, and |settings|.
     1. If |compWinner| is failure, return failure.
     1. If [=recursively wait until configuration input promises resolve=] given |auctionConfig| returns
       failure, return failure.
@@ -1450,7 +1285,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       1. Set |topLevelDirectFromSellerSignalsRetrieved| to true.
     1. If |compWinner| is not null, then run [=score and rank a bid=] with |auctionConfig|,
       |compWinner|, |leadingBidInfo|, |decisionLogicScript|, null, "top-level-auction", null, and
-      |topLevelOrigin|.
+      |settings|'s [=environment/top-level origin=].
     1. Decrement |pendingComponentAuctions| by 1.
   1. Wait until |pendingComponentAuctions| is 0.
   1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, return null.
@@ -1459,8 +1294,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. Set |leadingBidInfo|'s [=leading bid info/component seller=] to |winningComponentConfig|'s
     [=auction config/seller=].
   1. Let « |topLevelSellerSignals|, unusedTopLevelReportResultBrowserSignals » be the result of
-    running [=report result=] with |leadingBidInfo|, |topLevelDirectFromSellerSignalsForSeller|,
-    |winningComponentConfig|, and |global|.
+    running [=report result=] with |leadingBidInfo|, |topLevelDirectFromSellerSignalsForSeller| and
+    |winningComponentConfig|.
   1. Set |leadingBidInfo|'s [=leading bid info/auction config=] to |winningComponentConfig|.
   1. Set |leadingBidInfo|'s [=leading bid info/component seller=] to null.
   1. Set |leadingBidInfo|'s [=leading bid info/top level seller=] to |auctionConfig|'s
@@ -1477,13 +1312,12 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     |leadingBidInfo|'s [=leading bid info/leading bid=]'s [=generated bid/interest group=]'s
     [=interest group/owner=].
   1. Let « |sellerSignals|, |reportResultBrowserSignals| » be the result of running
-    [=report result=] with |leadingBidInfo|, |directFromSellerSignalsForSeller|, null, and |global|.
+    [=report result=] with |leadingBidInfo|, |directFromSellerSignalsForSeller|, and null.
   1. Run [=report win=] with |leadingBidInfo|, |sellerSignals|, |reportResultBrowserSignals|, and
     |directFromSellerSignalsForBuyer|.
   1. Return |leadingBidInfo|'s [=leading bid info/leading bid=].
 
-1. If [=waiting until configuration input promises resolve=] given |auctionConfig| returns failure,
-  then return failure.
+1. If [=waiting until configuration input promises resolve=] given |auctionConfig| returns failure, return failure.
 1. Let |allBuyersExperimentGroupId| be |auctionConfig|'s
   [=auction config/all buyer experiment group id=].
 1. Let |allBuyersGroupLimit| be |auctionConfig|'s [=auction config/all buyers group limit=].
@@ -1494,8 +1328,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. Let |directFromSellerSignalsForSeller| be the result of running
   [=get direct from seller signals for a seller=] given |directFromSellerSignals|.
 1. Let |browserSignals| be a {{BiddingBrowserSignals}}.
-1. Let |topLevelHost| be the result of running the <a spec=url>host serializer</a> on
-  |topLevelOrigin|'s [=origin/host=].
+1. Let |topLevelHost| be the result of running the <a spec=url>host serializer</a> on [=this=]'s
+  [=relevant settings object=]'s [=environment/top-level origin=]'s [=origin/host=].
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/topWindowHostname}}"] to |topLevelHost|.
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/seller}}"] to the [=serialization of an
   origin|serialization=] of |auctionConfig|'s [=auction config/seller=].
@@ -1508,23 +1342,17 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. Set |auctionLevel| to "component-auction".
   1. Set |componentAuctionExpectedCurrency| to the result of [=looking up per-buyer currency=] with
     |topLevelAuctionConfig| and |auctionConfig|'s [=auction config/seller=].
-1. Let |pendingBuyers| be |bidGenerators|'s [=map/size=].
+1. Let |pendingBuyers| be the [=map/size=] of |bidGenerators|.
 1. Let |additionalBids| be the result of running [=validate and convert additional bids=] with
   |auctionConfig|, |topLevelAuctionConfig|, |negativeTargetInfo| and |global|.
 1. Let |pendingAdditionalBids| be the [=list/size=] of |additionalBids|.
 1. [=list/For each=] |additionalBid| of |additionalBids|, run the following steps [=in parallel=]:
   1. [=Score and rank a bid=] with |auctionConfig|, |additionalBid|, |leadingBidInfo|,
     |decisionLogicScript|, null, |auctionLevel|, |componentAuctionExpectedCurrency|, and
-    |topLevelOrigin|.
+    |settings|'s [=environment/top-level origin=].
   1. Decrement |pendingAdditionalBids| by 1.
 1. [=map/For each=] |buyer| → |perBuyerGenerator| of |bidGenerators|,
   [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
-  1. Let |perBuyerCumulativeTimeout| be |auctionConfig|'s
-    [=auction config/all buyers cumulative timeout=].
-  1. If |auctionConfig|'s [=auction config/per buyer cumulative timeouts=] is not null and
-    [=auction config/per buyer cumulative timeouts=][|buyer|] [=map/exists=], then set
-    |perBuyerCumulativeTimeout| to |auctionConfig|'s
-    [=auction config/per buyer cumulative timeouts=][|buyer|].
   1. Let |buyerExperimentGroupId| be |allBuyersExperimentGroupId|.
   1. Let |perBuyerExperimentGroupIds| be |auctionConfig|'s
     [=auction config/per buyer experiment group ids=].
@@ -1558,37 +1386,26 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. [=map/For each=] |signalsUrl| → |perSignalsUrlGenerator| of |perBuyerGenerator|:
     1. Let |keys| be a new [=ordered set=].
     1. Let |igNames| be a new [=ordered set=].
-    1. Let |fetchSignalStartTime| be |settings|'s [=environment settings object/current monotonic time=].
-
     1. [=map/For each=] joiningOrigin → |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. [=set/Append=] |ig|'s [=interest group/trusted bidding signals keys=] to |keys|.
         1. [=set/Append=] |ig|'s [=interest group/name=] to |igNames|.
     1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
-      |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|, and |topLevelOrigin|.
+      |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|.
     1. Let « |allTrustedBiddingSignals|, |dataVersion| » be the result of [=fetching trusted signals=]
       with |biddingSignalsUrl| and true.
     1. If |dataVersion| is not null, then [=map/set=]
       |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
-    1. Let |fetchSignalDuration| be the [=duration from=] |fetchSignalStartTime| to |settings|'s
-      [=environment settings object/current monotonic time=], in milliseconds.
-    1. If |perBuyerCumulativeTimeout| is not null:
-      1. Decrement |perBuyerCumulativeTimeout| by |fetchSignalDuration|.
-      1. If |perBuyerCumulativeTimeout| is negative, then [=iteration/break=];
     1. [=map/For each=] joiningOrigin → |groups| of |perSignalsUrlGenerator|:
       1. [=list/For each=] |ig| of |groups|:
         1. If |ig|'s [=interest group/bidding url=] is null, [=iteration/continue=].
-        1. If |perBuyerCumulativeTimeout| is not null and is less than |perBuyerTimeout|, then set
-          |perBuyerTimeout| to |perBuyerCumulativeTimeout|.
-        1. Let |generateBidStartTime| be |settings|'s
-          [=environment settings object/current monotonic time=].
-        1. Let |generatedBid| be the result of [=generate a bid=] given |allTrustedBiddingSignals|,
-          |auctionSignals|, a [=map/clone=] of |browserSignals|, |perBuyerSignals|,
-          |perBuyerTimeout|, |expectedCurrency|, |ig|, and |auctionStartTime|.
-        1. Let |generateBidDuration| be the [=duration from=] |generateBidStartTime| to |settings|'s
-          [=environment settings object/current monotonic time=], in milliseconds.
-        1. If |perBuyerCumulativeTimeout| is not null, decrement |perBuyerCumulativeTimeout| by
-          |generateBidDuration|.
+        1. Let |directFromSellerSignalsForBuyer| be the result of running
+            [=get direct from seller signals for a buyer=] with |directFromSellerSignals|, and
+            |ig|'s [=interest group/owner=].
+        1. Let |generatedBid| be the result of [=generate a bid=] given
+          |allTrustedBiddingSignals|, |auctionSignals|, a [=map/clone=] of |browserSignals|,
+          |perBuyerSignals|, |directFromSellerSignalsForBuyer|, |perBuyerTimeout|, |expectedCurrency|,
+          |ig|, and |auctionStartTime|.
         1. If |generatedBid| is failure, [=iteration/continue=].
         1. If [=query generated bid k-anonymity count=] given |generatedBid| returns false:
 
@@ -1616,31 +1433,24 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
               1. If [=query component ad k-anonymity count=] given |adComponent|'s
                 [=interest group ad/render url=] returns true, [=list/append=] |adComponent| to |ig|'s
                 [=interest group/ad components=].
-          1. If |perBuyerCumulativeTimeout| is not null and is less than |perBuyerTimeout|, then set
-            |perBuyerTimeout| to |perBuyerCumulativeTimeout|.
-          1. Let |generateBidStartTime| be |settings|'s
-            [=environment settings object/current monotonic time=].
           1. Set |generatedBid| to the result of [=generate a bid=] given
             |allTrustedBiddingSignals|, |auctionSignals|, a [=map/clone=] of |browserSignals|,
             |perBuyerSignals|, |directFromSellerSignalsForBuyer|, |perBuyerTimeout|, |expectedCurrency|,
             and |ig|.
+
           1. Set |ig|'s [=interest group/ads=] to |originalAds|.
           1. Set |ig|'s [=interest group/ad components=] to |originalAdComponents|.
-          1. Let |generateBidDuration| be the [=duration from=] |generateBidStartTime| to
-            |settings|'s [=environment settings object/current monotonic time=], in milliseconds.
-          1. If |perBuyerCumulativeTimeout| is not null, then decrement |perBuyerCumulativeTimeout|
-            by |generateBidDuration|.
           1. If |generatedBid| is failure, [=iteration/continue=].
         1. [=list/Insert=] |generatedBid|'s [=generated bid/interest group=] in |bidIgs|.
         1. [=Score and rank a bid=] with |auctionConfig|, |generatedBid|, |leadingBidInfo|,
           |decisionLogicScript|, |directFromSellerSignalsForSeller|, |dataVersion|, |auctionLevel|,
-          |componentAuctionExpectedCurrency|, and |topLevelOrigin|.
+          |componentAuctionExpectedCurrency|, and |settings|'s [=environment/top-level origin=].
   1. Decrement |pendingBuyers| by 1.
 1. Wait until both |pendingBuyers| and |pendingAdditionalBids| are 0.
 1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, return null.
 1. If |topLevelAuctionConfig| is null:
   1. Let « |sellerSignals|, |reportResultBrowserSignals| » be the result of running
-    [=report result=] with |leadingBidInfo|, |directFromSellerSignalsForSeller|, null, and |global|.
+    [=report result=] with |leadingBidInfo|, |directFromSellerSignalsForSeller|, and null.
   1. Let |directFromSellerSignalsForWinner| be the result of running
       [=get direct from seller signals for a buyer=] with |directFromSellerSignals|, and
       |leadingBidInfo|'s [=leading bid info/leading bid=]'s [=generated bid/interest group=]'s
@@ -1717,7 +1527,7 @@ To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, 
 {{DirectFromSellerSignalsForSeller}} |directFromSellerSignalsForSeller|, an {{unsigned long}}-or-null
 |biddingDataVersion|, an enum |auctionLevel|, which is "single-level-auction", "top-level-auction",
 or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, and an [=origin=]
-|topLevelOrigin|:
+|topWindowOrigin|:
 
 1. Let |renderURL| be [=URL serializer|serialized=] |generatedBid|'s
   [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
@@ -1729,7 +1539,7 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
       to |adComponentRenderURLs|.
 1. Let |fullSignalsUrl| be the result of [=building trusted scoring signals url=] with |auctionConfig|'s
   [=auction config/trusted scoring signals url=], «|renderURL|», |adComponentRenderURLs|,
-  |auctionConfig|'s [=auction config/seller experiment group id=], and |topLevelOrigin|.
+  |auctionConfig|'s [=auction config/seller experiment group id=], and |topWindowOrigin|.
 
   Implementations may batch requests by collecting render URLs and ad component render URLs
   from multiple invocations of [=score and rank a bid=] and passing them all to a single invocation
@@ -1760,7 +1570,7 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
 1. Let |browserSignals| be a {{ScoringBrowserSignals}} with the following fields:
   <dl>
     <dt>{{ScoringBrowserSignals/topWindowHostname}}
-    <dd>The result of running the <a spec=url>host serializer</a> on |topLevelOrigin|'s [=origin/host=]
+    <dd>The result of running the <a spec=url>host serializer</a> on |topWindowOrigin|'s [=origin/host=]
     <dt>{{ScoringBrowserSignals/interestGroupOwner}}
     <dd>[=serialization of an origin|Serialized=] |owner|
     <dt>{{ScoringBrowserSignals/renderURL}}
@@ -2039,9 +1849,6 @@ To <dfn>encode trusted signals keys</dfn> given an [=ordered set=] of [=strings=
 1. Let |keysStr| be the result of [=string/concatenating=] |keys| with separator set to ",".
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |keysStr| using
   [=component percent-encode set=] to |list|.
-
-  Issue: The Chrome implementation encodes 0x20 (SP) to U+002B (+), while [=string/UTF-8 percent-encoding=]
-    encodes it to "%20".
 1. Return |list|.
 
 </div>
@@ -2049,21 +1856,13 @@ To <dfn>encode trusted signals keys</dfn> given an [=ordered set=] of [=strings=
 <div algorithm>
 
 To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an [=ordered set=] of
-[=strings=] |keys|, an [=ordered set=] of [=strings=] |igNames|, an {{unsigned short}}-or-null
-|experimentGroupId|, and an [=origin=] |topLevelOrigin|:
+[=strings=] |keys|, an [=ordered set=] of [=strings=] |igNames|, and an {{unsigned short}}-or-null
+|experimentGroupId|:
 1. Let |queryParamsList| be a new empty [=list=].
-
-  Note: These steps create a [=url/query=] of the form "`&<name>=<values in comma-delimited list>`". E.g.,
-    "`hostname=publisher1.com&keys=key1,key2&interestGroupNames=ad+platform,name2&experimentGroupId=1234`".
-    <br><br>These steps don't use the [=urlencoded serializer|application/x-www-form-urlencoded serializer=]
-    to construct the query string because it repeats a key if it has multiple values instead of a
-    comma-demilited list (e.g., "keys=key1&keys=key2", instead of "keys=key1,key2"), and it also
-    uses a different percent encode set from the Chrome implementation.
-
 1. [=list/Append=] "hostname=" to |queryParamsList|.
-1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] the
-  [=serialization of an origin|serialized=] |topLevelOrigin| using [=component percent-encode set=]
-  to |queryParamsList|.
+1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] [=this=]'s
+  [=relevant settings object=]'s [=environment/top-level origin=] using
+  [=component percent-encode set=] to |queryParamsList|.
 1. If |keys| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&keys=" to |queryParamsList|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
@@ -2085,13 +1884,13 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
 
 To <dfn>build trusted scoring signals url</dfn> given a [=URL=] |signalsUrl|, a [=list=] of
 [=strings=] |renderURLs|, an [=ordered set=] of [=strings=] |adComponentRenderURLs|, an
-{{unsigned short}} |experimentGroupId|, and an [=origin=] |topLevelOrigin|:
+{{unsigned short}} |experimentGroupId|, and an [=origin=] |topWindowOrigin|:
 
 Note: When trusted scoring signals fetches are not batched, |renderURLs|'s [=list/size=] is 1.
 
 1. Let |queryParamsList| be a new empty [=list=].
 1. [=list/Append=] "hostname=" to |queryParamsList|.
-1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |topLevelOrigin| using
+1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |topWindowOrigin| using
   [=component percent-encode set=] to |queryParamsList|.
 1. If |renderURLs| is not [=set/is empty|empty=]:
   1. [=list/Append=] "&renderURLs=" to |queryParamsList|.
@@ -2208,8 +2007,8 @@ To <dfn>get direct from seller signals for a buyer</dfn> given a
 
 <div algorithm>
 To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|, a
-[=direct from seller signals=]-or-null |directFromSellerSignals|, an [=auction config=]-or-null 
-|winningComponentConfig|, and a [=global object=] |global|:
+[=direct from seller signals=]-or-null |directFromSellerSignals|, and an [=auction config=]-or-null 
+|winningComponentConfig|:
   1. Let |config| be |leadingBidInfo|'s [=leading bid info/auction config=].
   1. Let |bidCurrency| be null.
   1. If |winningComponentConfig| is not null:
@@ -2239,8 +2038,8 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|, a
   1. Let |browserSignals| be a {{ReportResultBrowserSignals}} with the following fields:
     <dl link-for-hint="ReportingBrowserSignals">
       <dt>{{topWindowHostname}}
-      <dd>The result of running the <a spec=url>host serializer</a> on |global|'s
-        [=environment/top-level origin=]'s [=origin/host=].
+      <dd>The result of running the <a spec=url>host serializer</a> on [=this=]'s
+        [=relevant settings object=]'s [=environment/top-level origin=]'s [=origin/host=].
       <dt>{{interestGroupOwner}}
       <dd>[=serialization of an origin|Serialized=] |winner|'s [=generated bid/interest group=]'s
         [=interest group/owner=].
@@ -2300,8 +2099,8 @@ To <dfn>report result</dfn> given a [=leading bid info=] |leadingBidInfo|, a
   1. [=map/Remove=] |browserSignals|["`topLevelSellerSignals`"].
   1. [=map/Remove=] |browserSignals|["`dataVersion`"].
 
-    Note: Remove fields specific to {{ReportResultBrowserSignals}} which only sellers can learn about,
-    so that they are not passed to "`reportWin()`".
+  Note: Remove fields specific to {{ReportResultBrowserSignals}} which only sellers can learn about,
+  so that they are not passed to "`reportWin()`".
 
   1. Return « |sellerSignals|, |browserSignals| ».
 </div>
@@ -2406,8 +2205,9 @@ The <dfn for=Navigator method>createAuctionNonce()</dfn> method steps are:
       * ...which gives browsers the freedom to generate this UUID in another process, and
         asynchronously send it back to the main thread at an arbitrary future time.
     </div>
-    1. [=Queue a global task=] on [=DOM manipulation task source=], given [=this=]'s
-      [=relevant global object=], to [=resolve=] |p| with |nonce|.
+    1. Let |global| be [=this=]'s [=relevant global object=].
+    1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=]
+      |p| with |nonce|.
   1. Return |p|.
 </div>
 
@@ -2424,7 +2224,7 @@ the [=additional bid=] to compete against other bids in a Protected Audience [=a
 
 <div id="additional-bid-example" class=example>
   <p> Each additional bid is expressed using the following JSON data structure:</p>
-  <pre highlight="js">
+  <pre class="highlight">
   const additionalBid = {
     "bid": {
       "ad": 'ad-metadata',
@@ -2751,7 +2551,7 @@ identified ahead of time in the [=additional bid=]'s `joiningOrigin` field. Any
 
 <div id="negative-igs-example" class=example>
   <p>Use `negativeInterestGroup` in additional bid's JSON:</p>
-  <pre highlight="js">
+  <pre class="highlight">
   const additionalBid = {
     ...
     "negativeInterestGroup": "example_advertiser_negative_interest_group",
@@ -2759,7 +2559,7 @@ identified ahead of time in the [=additional bid=]'s `joiningOrigin` field. Any
   }
   </pre>
   <p>Use `negativeInterestGroups` in additional bid's JSON:</p>
-  <pre highlight="js">
+  <pre class="highlight">
   const additionalBid = {
     ...
     "negativeInterestGroups": {
@@ -2878,7 +2678,7 @@ threshold when responding to [=query k-anonymity count=].
 
 <div algorithm>
   To <dfn>increment k-anonymity count</dfn> given a |hashCode|:
-    1. Ask the [=k-anonymity server=] to record that this [=user agent=] has seen |hashCode|.
+    1. Ask the [=k-anonymity server=] to record that this user agent has seen |hashCode|.
 </div>
 
 <div algorithm>
@@ -2922,8 +2722,8 @@ flexible implementation model.
 However, some key differences from traditional Worklets motivate us to create a new kind of script
 execution environment. In particular, they:
 
- * Are not scoped to a particular {{Document}}, but are rather scoped to a [=user agent=], as they
-   are spun up by [=interest groups=] in the [=user agent=]'s [=interest group set=].
+ * Are not scoped to a particular {{Document}}, but are rather scoped to a user agent, as they are
+   spun up by [=interest groups=] in the user agent's [=interest group set=].
  * Consequently have a different, more flexible [=ECMAScript/agent cluster=] allocation model —
    specifically, they need not execute in the same [=ECMAScript/agent cluster=] as any {{Document}},
    and for privacy reasons implementations may be motivated to enjoy this flexibility.
@@ -3023,10 +2823,6 @@ of the following global objects:
     1. Let |realm| be the result of [=creating a new script runner realm=] given
       {{InterestGroupBiddingScriptRunnerGlobalScope}}.
     1. Let |global| be |realm|'s [=realm/global object=].
-    1. Let |settings| be |realm|'s [=realm/settings object=].
-
-      Issue: <a href="https://github.com/WICG/turtledove/issues/676">WICG/turtledove#676</a> needs
-      to be fixed in order to get |realm|'s [=realm/settings object=].
     1. Set |global|'s
       [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=] to true if |ig|'s
       [=interest group/ad components=] is not null, or false otherwise.
@@ -3046,17 +2842,16 @@ of the following global objects:
     1. Let |browserSignalsJS| be |browserSignals| [=converted to ECMAScript values=].
     1. Let |directFromSellerSignalsJs| be |directFromSellerSignalsForBuyer|
       [=converted to ECMAScript values=].
-    1. Let |startTime| be |settings|'s [=environment settings object/current monotonic time=].
+    1. Let |startTime| be the [=current wall time=].
     1. Let |result| be the result of [=evaluating a script=] with |realm|, |script|, "`generateBid`",
       « |igJS|, |auctionSignalsJS|, |perBuyerSignalsJS|, |trustedBiddingSignalsJS|, |browserSignalsJS|,
       |directFromSellerSignalsJs| », and |timeout|.
-    1. Let |duration| be |settings|'s [=environment settings object/current monotonic time=] minus
-      |startTime| in milliseconds.
+    1. Let |duration| be the [=current wall time=] minus |startTime| in milliseconds.
     1. If |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] is not null and not failure:
       1. Set |ig|'s [=interest group/priority=] to |global|'s
         [=InterestGroupBiddingScriptRunnerGlobalScope/priority=].
       1. [=list/Replace=] the [=interest group=] that has |ig|'s [=interest group/owner=] and
-        [=interest group/name=] in the [=user agent=]'s [=interest group set=] with |ig|.
+        [=interest group/name=] in the browser’s [=interest group set=] with |ig|.
     1. If |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority signals=]
       [=map/is not empty=]:
       1. [=map/For each=] |k| → |v| of |global|'s
@@ -3064,7 +2859,7 @@ of the following global objects:
         1. If |v| is null, [=map/remove=] |ig|'s [=interest group/priority signals overrides=][|k|].
         1. Otherwise, [=map/set=] |ig|'s [=interest group/priority signals overrides=][|k|] to |v|.
       1. [=list/Replace=] the [=interest group=] that has |ig|'s [=interest group/owner=] and
-        [=interest group/name=] in the [=user agent=]'s [=interest group set=] with |ig|.
+        [=interest group/name=] in the browser’s [=interest group set=] with |ig|.
     1. Let |generatedBid| be |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=].
     1. If |result| is a [=ECMAScript/normal completion=]:
       1. Let |generatedBidIDL| be the result of [=converted to an IDL value|converting=]
@@ -3131,15 +2926,12 @@ of the following global objects:
 
 <div algorithm>
   To <dfn>evaluate a script</dfn> with a [=ECMAScript/realm=] |realm|, [=string=] |script|, [=string=]
-  |functionName|, a [=list=] |arguments|, and an integer millisecond [=duration=] |timeout|, run these steps.
+  |functionName|, a [=list=] |arguments|, and an integer millisecond duration |timeout|, run these steps.
   They return a [=ECMAScript/Completion Record=], which is either an [=ECMAScript/abrupt completion=] (in
   the case of a parse failure or execution error), or a [=ECMAScript/normal completion=] populated with the
   [=ECMAScript/ECMAScript language value=] result of invoking |functionName|.
 
     1. [=Assert=] that these steps are running [=in parallel=].
-
-    1. If |timeout| &le; 0, [=immediately=] interrupt the execution and set |finalCompletion| to a
-      new [=ECMAScript/throw completion=] given null.
 
     1. Let |global| be |realm|'s [=realm/global object=], and run these steps in |realm|'s [=realm/agent=]:
 
@@ -3311,7 +3103,7 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
     [=generated bid/ad cost=] to |generateBidOutput|["{{GenerateBidOutput/adCost}}"].
   1. If |generateBidOutput|["{{GenerateBidOutput/modelingSignals}}"] [=map/exists=]:
     1. Let |modelingSignals| be |generateBidOutput|["{{GenerateBidOutput/modelingSignals}}"].
-    1. If |modelingSignals| &ge; 0 and |modelingSignals| &lt; 4096, then set |bid|'s
+    1. If |modelingSignals| &ge; 0 and |modelingSignals| < 4096, then set |bid|'s
       [=generated bid/modeling signals=] to the result of [=converted to an IDL value|converting=]
       the ECMAScript value represented by |modelingSignals| to an {{unsigned short}}.
   1. Return |bid|.
@@ -3383,28 +3175,33 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   The <dfn method for="InterestGroupBiddingScriptRunnerGlobalScope">setBid(|generateBidOutput|)</dfn>
   method steps are:
 
-  1. Let |global| be [=this=]'s [=relevant global object=].
-  1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=] to null.
-  1. Let |ig| be |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/interest group=].
-  1. Let |expectedCurrency| be |global|'s
+  1. Set [=this=]'s [=relevant global object=]'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=]
+    to null.
+  1. Let |ig| be [=this=]'s [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/interest group=].
+  1. Let |expectedCurrency| be [=this=]'s [=relevant global object=]'s
     [=InterestGroupBiddingScriptRunnerGlobalScope/expected currency=].
   1. Let |bidToSet| be the result of [=converting GenerateBidOutput to generated bid=] with
-    |generateBidOutput|, |ig|, |expectedCurrency|, |global|'s
-    [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=], and |global|'s
+    |generateBidOutput|, |ig|, |expectedCurrency|, [=this=]'s [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/is component auction=], and [=this=]'s
+    [=relevant global object=]'s
     [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=].
   1. If |bidToSet| is failure, [=exception/throw=] a {{TypeError}}.
-  1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=] to |bidToSet|.
+  1. Set [=this=]'s [=relevant global object=]'s [=InterestGroupBiddingScriptRunnerGlobalScope/bid=]
+    to |bidToSet|.
 </div>
 
 <div algorithm>
   The <dfn method for="InterestGroupBiddingScriptRunnerGlobalScope">setPriority(|priority|)</dfn>
   method steps are:
 
-  1. Let |global| be [=this=]'s [=relevant global object=].
-  1. If |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] is not null, then set
-    |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] to failure, and
-    [=exception/throw=] a {{TypeError}}.
-  1. Set |global|'s [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] to |priority|.
+  1. If [=this=]'s [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] is not null:
+    1. Set [=this=]'s [=relevant global object=]'s
+      [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] to failure.
+    1. [=exception/Throw=] a {{TypeError}}.
+  1. Set [=this=]'s [=relevant global object=]'s
+    [=InterestGroupBiddingScriptRunnerGlobalScope/priority=] to |priority|.
 </div>
 
 <div algorithm>
@@ -3462,20 +3259,21 @@ Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
   The <dfn method for="InterestGroupReportingScriptRunnerGlobalScope">sendReportTo(|url|)</dfn>
   method steps are:
 
-  1. Let |global| be [=this=]'s [=relevant global object=].
-  1. If |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/report url=] is not null, then
-    set |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/report url=] to failure, and
-    [=exception/Throw=] a {{TypeError}}.
+  1. If [=this=]'s [=relevant global object=]'s
+    [=InterestGroupReportingScriptRunnerGlobalScope/report url=] is not null, then Set [=this=]'s
+    [=relevant global object=]'s [=InterestGroupReportingScriptRunnerGlobalScope/report url=] to
+    failure, and [=exception/Throw=] a {{TypeError}}.
   1. Let |parsedUrl| be the result of running the [=URL parser=] on |url|.
-  1. If |parsedUrl| is failure, or |parsedUrl|'s [=url/scheme=] is not "`https`", set |global|'s
-    [=InterestGroupReportingScriptRunnerGlobalScope/report url=] to failure, and [=exception/throw=]
-    a {{TypeError}}.
+  1. If |parsedUrl| is failure, or |parsedUrl|'s [=url/scheme=] is not "`https`", set [=this=]'s
+    [=relevant global object=]'s [=InterestGroupReportingScriptRunnerGlobalScope/report url=] to
+    failure, and [=exception/Throw=] a {{TypeError}}.
   1. Optionally, return.
 
-    Note: This [=implementation-defined=] condition is intended to allow [=user agents=] to decline
-        for a number of reasons, for example the |parsedUrl|'s [=site=] not being
-        <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
-  1. Set |global|'s [=InterestGroupReportingScriptRunnerGlobalScope/report url=] to |parsedUrl|.
+    Note: This [=implementation-defined=] condition is intended to allow user
+        agents to decline for a number of reasons, for example the |parsedUrl|'s [=site=]
+        not being <a href="https://github.com/privacysandbox/attestation">enrolled</a>.
+  1. Set [=this=]'s [=relevant global object=]'s
+    [=InterestGroupReportingScriptRunnerGlobalScope/report url=] to |parsedUrl|.
 </div>
 
 <div algorithm>
@@ -3534,7 +3332,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
   |owners|:
 
 1. [=list/For each=] |owner| of |owners|:
-  1. [=list/For each=] |originalInterestGroup| of the [=user agent=]'s [=interest group set=] whose
+  1. [=list/For each=] |originalInterestGroup| of the user agent's [=interest group set=] whose
     [=interest group/owner=] is |owner| and [=interest group/next update after=] is before
     the [=current wall time=]:
 
@@ -3717,7 +3515,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
       * |ig|'s [=interest group/estimated size=] is greater than 50 KB.
     1. Set |ig|'s [=interest group/next update after=] to the [=current wall time=] plus 24 hours.
     1. [=list/Replace=] the [=interest group=] that has |ig|'s [=interest group/owner=] and
-      [=interest group/name=] in the [=user agent=]'s [=interest group set=] with |ig|.
+      [=interest group/name=] in the browser’s [=interest group set=] with |ig|.
     1. <i id=abort-update>Abort update</i>: We jump here if some part of the
       [=interest group=] update failed. [=iteration/Continue=] to the next [=interest group=] update.
 
@@ -3757,47 +3555,19 @@ This specification defines two [=policy-controlled features=] identified by the 
 Issue(WICG/turtledove#522): Move from "`*`" to "`self`".
 
 
-# Fetch Patch for Auction Headers # {#fetch-patch-for-auction-headers}
+# Handling Direct from Seller Signals # {#handling-direct-from-seller-signals}
 
-This section specifies a manner by which some data, including [=additional bids=] and
-[=direct from seller signals=], may be provided to auctions such that the data is only used within
-their intended auction.
+This section specifies a manner by which signals may be provided to auctions such that the signals
+are only used within their intended auction.
 
 Any {{Document}} in a [=traversable navigable=] may run a Protected Audience auction (with
 {{Window/navigator}}.{{Navigator/runAdAuction()}}) whose worklet functions receive signal objects
-derived from JSON from an [:Ad-Auction-Signals:] header, or [=additional bids=] derived from an
-[:Ad-Auction-Additional-Bid:] header, captured by a {{WindowOrWorkerGlobalScope/fetch()}} call
-(using the {{RequestInit/adAuctionHeaders}} option) initiated by any *other* {{Document}} in the
-*same* [=traversable navigable=], or from an
+derived from JSON from an [:Ad-Auction-Signals:] header captured by a
+{{WindowOrWorkerGlobalScope/fetch()}} call (using the {{RequestInit/adAuctionHeaders}} option)
+initiated by any *other* {{Document}} in the *same* [=traversable navigable=], or from an
 <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
 request (using the <{iframe/adAuctionHeaders}>
 <a spec=html>content attribute</a> on the <{iframe}> element).
-
-<div algorithm="fetch per traversable navigable structures patch">
-Modify [[FETCH]]'s [[FETCH#infrastructure]] to add a new section called "Per Traversable Navigable
-Structures", with the following content:
-
-Each [=traversable navigable=] has a <dfn for="traversable navigable">captured ad auction signals
-headers</dfn>, which is a [=map=] whose [=map/keys=] are [=direct from seller signals keys=] and
-whose [=map/values=] are [=direct from seller signals=].
-
-NOTE: This is only captured during a [=request=] whose [=request/initiator type=] is `"fetch"`, made
-with the {{RequestInit/adAuctionHeaders}} option set to `true`, or during an
-<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
-request with the <{iframe/adAuctionHeaders}>
-<a spec=html>content attribute</a> set to `true`, as described in the
-[:Ad-Auction-Signals:] header description.
-
-Each [=traversable navigable=] has a <dfn for="traversable navigable">captured ad auction additional
-bids headers</dfn>, which is a [=map=] whose [=map/keys=] are [=auction nonces=] and whose
-[=map/values=] are [=strings=].
-
-NOTE: This is only captured during a [=request=] whose [=request/initiator type=] is `"fetch"`, made
-with the {{RequestInit/adAuctionHeaders}} option set to `true`, or during an
-<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
-request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>
-set to `true`, as described in the [:Ad-Auction-Additional-Bid:] header description.
-</div>
 
 <div algorithm="fetch capture adAuctionHeaders boolean patch">
 Modify the definition of a [=request=]:
@@ -3827,8 +3597,9 @@ step "Set [=this=]'s [=Request/request=] to |request|":
 </div>
 
 <div algorithm="iframe navigation capture adAuctionHeaders attribute patch">
-Modify the <{iframe}> element to add a
-<dfn element-attr for="iframe">adAuctionHeaders</dfn> <a spec=html>content attribute</a>.
+Modify the
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a>
+element to add a a <dfn element-attr for="iframe">adAuctionHeaders</dfn> <a spec=html>content attribute</a>.
 The IDL attribute {{HTMLIFrameElement/adAuctionHeaders}} <a spec=html>reflects</a>
 the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>.
 
@@ -3841,7 +3612,7 @@ partial interface HTMLIFrameElement {
 
 <div algorithm="iframe navigation patch">
 The following step will be added to the
-<a spec="html">create navigation params by fetching</a> steps
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching">create navigation params by fetching steps</a>,
 after step "Let |request| be a new [=Request/request=], with ...":
 
 1. If <var ignore=''>navigable</var>'s [=navigable/container=] is an <{iframe}> element,
@@ -3858,6 +3629,57 @@ The following step will be added to the [=HTTP-network-or-cache fetch=] algorith
   structured field value=] given «[:Sec-Ad-Auction-Fetch:], the [=structured header/boolean=] `?1`»
   in |httpRequest|'s [=header list=].
 
+</div>
+
+<div algorithm="fetch per traversable navigable structures patch">
+Modify [[FETCH]]'s [[FETCH#infrastructure]] to add a new section called "Per Traversable Navigable
+Structures", with the following content:
+
+<h3 id=direct-from-sellers-signals-key-struct>Direct from seller signals key</h3>
+A <dfn>direct from seller signals key</dfn> is a [=struct=] with the following [=struct/items=]:
+
+NOTE: This is only captured during a [=request=] whose [=request/initiator type=] is `"fetch"`, made
+with the {{RequestInit/adAuctionHeaders}} option set to `true`, or during an
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+request with the <{iframe/adAuctionHeaders}>
+<a spec=html>content attribute</a> set to `true`, as described in the
+[:Ad-Auction-Signals:] header description.
+
+<dl dfn-for="direct from seller signals key">
+: <dfn>seller</dfn>
+:: An [=origin=]. Matches the origin that served the captured [:Ad-Auction-Signals:] header.
+: <dfn>ad slot</dfn>
+:: A [=string=]. Matches the `adSlot` key of the JSON dictionaries in the top-level array of the
+  [:Ad-Auction-Signals:] value.
+
+</dl>
+
+<h3 id=direct-from-sellers-signals-struct>Direct from seller signals</h3>
+A <dfn>direct from seller signals</dfn> is a [=struct=] with the following [=struct/items=]:
+
+NOTE: This is only captured during a [=request=] whose [=request/initiator type=] is `"fetch"`, made
+with the {{RequestInit/adAuctionHeaders}} option set to `true`, or during an
+<a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame">iframe navigation</a>
+request with the <{iframe/adAuctionHeaders}> <a spec=html>content attribute</a>
+set to `true`, as described in the [:Ad-Auction-Signals:] header description.
+
+<dl dfn-for="direct from seller signals">
+: <dfn>auction signals</dfn>
+:: Null or a [=string=].
+  Opaque JSON data passed to both buyers' and the seller's [=script runners=].
+: <dfn>seller signals</dfn>
+:: Null or a [=string=].
+  Opaque JSON data passed to the seller's [=script runner=].
+: <dfn>per buyer signals</dfn>
+:: A [=map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=strings=].
+  [=map/Keys=] are buyers and must be valid HTTPS origins. [=map/Values=] are opaque JSON data
+  passed to corresponding buyer's [=script runner=].
+
+</dl>
+
+Each [=traversable navigable=] has a <dfn for="traversable navigable">captured ad auction headers
+</dfn>, which is a [=map=] whose [=map/keys=] are [=direct from seller signals keys=] and whose
+[=map/values=] are [=direct from seller signals=].
 </div>
 
 <div algorithm="fetch auction headers patch">
@@ -3888,17 +3710,15 @@ HTTP response header.</h3>
 
 The \`<dfn http-header><code>Ad-Auction-Additional-Bid</code></dfn>\` response header provides value
 of a string in the format of `<auction nonce>:<base64-encoding of the signed additional bid>`, which
-corresponds to a single [=additional bid=]. The response may include more than one [=additional bid=]
-by specifying multiple instances of the [:Ad-Auction-Additional-Bid:] response header.
+corresponds to a single additional bid. The response may include more than one additional bid by
+specifying multiple instances of the [:Ad-Auction-Additional-Bid:] response header.
 </div>
 
-<div algorithm="ad auction fetch redirect patch">
-The following steps will be added to the [=HTTP fetch=] algorithm, immediately under the step "If
+<div algorithm="fetch auction signals redirect patch">
+The following step will be added to the [=HTTP fetch=] algorithm, immediately under the step "If
 <var ignore>internalResponse</var>’s [=status=] is a [=redirect status=]:"
 
-1. [=header list/Delete=] "[:Ad-Auction-Signals:]" from |response|'s
-  [=response/header list=].
-1. [=header list/Delete=] "[:Ad-Auction-Additional-Bid:]" from |response|'s
+1. [=header list/Delete=] "[:Ad-Auction-Signals:]" from <var ignore>response</var>'s
   [=response/header list=].
 
 </div>
@@ -3909,65 +3729,40 @@ The following step will be added to the [=HTTP fetch=] algorithm, before step
 
 1. If |response| is not null, |response|'s [=status=] is not a [=redirect status=], |fetchParams|'s
   [=fetch params/task destination=] is a [=global object=] that's a {{Window}} object, and
-  |request|'s [=request/capture-ad-auction-headers=] is `true`:
-  1. Let |navigable| be |fetchParams|'s [=fetch params/task destination=]'s [=associated Document=]'s
-    [=node navigable=]'s [=traversable navigable=].
-  1. Run [=update captured headers=] with |navigable|'s
-    [=traversable navigable/captured ad auction signals headers=], |navigable|'s
-    [=traversable navigable/captured ad auction additional bids headers=], |response|'s
-    [=response/header list=], and |request|'s [=request/URL=]'s [=url/origin=].
+  |request|'s [=request/capture-ad-auction-headers=] is `true`, then run [=update captured headers=]
+  with |fetchParams|'s [=fetch params/task destination=]'s [=associated Document's=] [=node
+  navigable's=] [=traversable navigable's=] [=traversable navigable/captured ad auction headers=],
+  |response|'s [=response/header list=], and |request|'s [=request/URL=]'s [=url/origin=].
 
 </div>
 
 <div algorithm="fetch update captured headers patch">
 The following algorithm will be added to the [[FETCH#fetching]] section:
 
+<h3 id=update-captured-headers>Update captured headers</h3>
+
   To <dfn id=concept-update-captured-headers>update captured headers</dfn> with a [=traversable
-  navigable/captured ad auction signals headers=] |storedSignalsHeaders|,
-  [=traversable navigable/captured ad auction additional bids headers=] |storedAdditionalBidsHeaders|,
-  [=header list=] |responseHeaders|, and [=origin=] |requestOrigin|:
+  navigable/captured ad auction headers=] |storedHeaders|, [=header list=] |responseHeaders|, and
+  [=origin=] |requestOrigin|:
   1. Let |adAuctionSignals| be the result of [=header list/getting=] [:Ad-Auction-Signals:] from
     |responseHeaders|.
-  1. If |adAuctionSignals| is not null:
-    1. [=header list/Delete=] "[:Ad-Auction-Signals:]" from |responseHeaders|.
+  1. If |adAuctionSignals| is null, return.
+  1. [=header list/Delete=] "[:Ad-Auction-Signals:]" from |responseHeaders|.
 
-      NOTE: This step prevents the header value from being used outside the intended auctions --
-      that is, scripts making the {{WindowOrWorkerGlobalScope/fetch()}} request aren't able to load
-      the header value.
-    1. [=Handle ad auction signals header value=] given |adAuctionSignals|, |storedSignalsHeaders| and
-      |requestOrigin|.
-  1. Let |additionalBids| be the result of [=header list/getting, decoding, and splitting=]
-    [:Ad-Auction-Additional-Bid:] from |responseHeaders|.
-  1. If |additionalBids| is not null:
-    1. [=header list/Delete=] "[:Ad-Auction-Additional-Bid:]" from |responseHeaders|.
-
-      NOTE: This step prevents the header value from being used outside the intended auctions --
-      that is, scripts making the {{WindowOrWorkerGlobalScope/fetch()}} request aren't able to load
-      the header value.
-    1. [=list/For each=] |bid| of |additionalBids|:
-      1. Let |nonceAndAdditionalBid| be the result of [=strictly splitting=] |bid| on U+003A (:).
-      1. If |nonceAndAdditionalBid|'s [=list/size=] is not 2, then [=iteration/continue=].
-      1. Let |nonce| be |nonceAndAdditionalBid|[0].
-      1. If |nonce|'s [=string/length=] is not 36, then [=iteration/continue=].
-      1. Set |storedAdditionalBidsHeaders|[|nonce|] to |nonceAndAdditionalBid|[1].
-
-</div>
-
-<div algorithm>
-To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |adAuctionSignals|,
-[=traversable navigable/captured ad auction signals headers=] |storedSignalsHeaders|, and [=origin=]
-|requestOrigin|:
-
+    NOTE: This step prevents the header value from being used outside the intended auctions --
+    that is, scripts making the {{WindowOrWorkerGlobalScope/fetch()}} request aren't able to load
+    the header value.
   1. Let |parsedSignals| be the result of [=parsing JSON bytes to an Infra value=], given
     |adAuctionSignals|.
-  1. If |parsedSignals| is failure or not a [=list=], return.
-  1. [=list/For each=] |signal| of |parsedSignals|:
+  1. If |parsedSignals| is failure, return.
+  1. If |parsedSignals| is not a [=list=], return.
+  1. [=list/For each=] |signal| in |parsedSignals|:
     1. If |signal| is not an [=ordered map=], [=iteration/continue=].
     1. If |signal|["`adSlot`"] doesn't exist, [=iteration/continue=].
-    1. Let |signalsKey| be a new [=direct from seller signals key=], with its
+    1. Create a new [=direct from seller signals key=] |signalsKey|, with its
       [=direct from seller signals key/seller=] set to |requestOrigin| and its
       [=direct from seller signals key/ad slot=] set to |signal|["`adSlot`"].
-    1. Let |processedSignals| be a new [=direct from seller signals=].
+    1. Create a new [=direct from seller signals=] |processedSignals|.
     1. [=map/Remove=] |signal|["`adSlot`"].
     1. [=map/For each=] |key| → |value| of |signal|:
       1. Switch on |key|:
@@ -3986,15 +3781,17 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
           <dd>
           1. If |value| is not an [=ordered map=], [=iteration/continue=].
           1. For each |buyer| → |buyerSignals| of |value|:
-            1. Let |buyerOrigin| be the result of [=parsing an https origin=] on |buyer|.
-            1. If |buyerOrigin| is failure, [=iteration/continue=].
+            1. Let |buyerOrigin| be the result of [=parsing an https origin=] on |buyer|. If this
+              [=exception/throws=], [=iteration/continue=].
             1. Let |buyerSignalsString| be the result of
               [=serializing an Infra value to a JSON string=], given |buyerSignals|.
             1. Set |processedSignals|'s
               [=direct from seller signals/per buyer signals=][|buyerOrigin|] to |buyerSignalsString|.
+        
         </dl>
 
-    1. Set |storedSignalsHeaders|[|signalsKey|] to |processedSignals|.
+    1. Set |storedHeaders|[|signalsKey|] to |processedSignals|.
+
 </div>
 
 
@@ -4112,10 +3909,7 @@ dictionary ReportWinBrowserSignals : ReportingBrowserSignals {
   DOMString buyerReportingId;
   unsigned short modelingSignals;
   unsigned long dataVersion;
-  KAnonStatus kAnonStatus;
 };
-
-enum KAnonStatus { "passedAndEnforced", "passedNotEnforced", "belowThreshold", "notCalculated" };
 </xmp>
 
 <dl class=domintro>
@@ -4143,17 +3937,6 @@ enum KAnonStatus { "passedAndEnforced", "passedNotEnforced", "belowThreshold", "
   <dt>{{ReportWinBrowserSignals/dataVersion}}
   <dd>Only set if the Data-Version header was provided in the response headers from the trusted
     bidding signals server
-  <dt>{{ReportWinBrowserSignals/kAnonStatus}}
-  <dd>Indicate the k-anonymity status of the ad with the following {{KAnonStatus}} enums:
-      * {{KAnonStatus/passedAndEnforced}}: The ad was k-anonymous and k-anonymity was required to win the auction.
-      * {{KAnonStatus/passedNotEnforced}}: The ad was k-anonymous though k-anonymity was not required to win the auction.
-      * {{KAnonStatus/belowThreshold}}: The ad was not k-anonymous but k-anonymity was not required to win the auction.
-      * {{KAnonStatus/notCalculated}}: The browser did not calculate the k-anonymity status of the ad, and k-anonymity was not required to win the auction.
-
-    From a long-term perspective, the status will always be set to `passedAndEnforced` after 
-    k-anonymity is enforced. However, as a temporary solution, current implementations may set 
-    `kAnonStatus` to one of the other three statuses to allow API users to assess the future 
-    impact of enforcing that ads are k-anonymous.
 </dl>
 
 <xmp class="idl">
@@ -4264,7 +4047,7 @@ An interest group is a [=struct=] with the following [=struct/items=]:
 :: A [=list=] of [=previous wins=].
 : <dfn>next update after</dfn>
 :: A [=moment=] at which the browser will permit updating this interest group. See
-  [[#interest-group-updates]].
+  [interest group updates](#interest-group-updates).
 
 </dl>
 
@@ -4383,23 +4166,6 @@ An auction config is a [=struct=] with the following items:
   Restricts the `generateBid()` script's runtime for all buyers without a timeout specified in
   [=auction config/per buyer timeouts=]. If the timeout expires, only the bid submitted via
   `setBid()` is considered.
-: <dfn>per buyer cumulative timeouts</dfn>
-:: Null, a {{Promise}}, failure, or an [=ordered map=] whose [=map/keys=] are [=origins=] and
-  whose [=map/values=] are [=durations=] in milliseconds.
-  [=map/Keys=] are buyers and must be valid HTTPS [=origins=]. [=map/Values=] are collective
-  timeouts for all interest groups of the buyer represented by the [=map/key=]. Includes the time of
-  loading scripts and signals, and running the `generateBid()` functions. Once the timer expires,
-  the affected buyer's interest groups may no longer generate any bids. All bids generated before
-  the timeout will continue to participate in the auction.
-  Implementations should attempt, on a best-effort basis, to generate bids for each buyer in
-  priority order, so lower priority [=interest groups=] are the ones more likely to be timed out. If
-  {{Promise}}s are passed in to the [=auction config=] for fields that support them,
-  [=wait until configuration input promises resolve=] before starting the timer.
-
-: <dfn>all buyers cumulative timeout</dfn>
-:: Null or a [=duration=] in milliseconds, initially null.
-  Restricts a buyer's cumulative timeout for all buyers without one specified in
-  [=auction config/per buyer cumulative timeouts=].
 : <dfn>per buyer group limits</dfn>
 :: Null or an [=ordered map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are
   {{unsigned short}}s.
@@ -4485,13 +4251,12 @@ To <dfn>wait until configuration input promises resolve</dfn> given an [=auction
 1. Wait until |auctionConfig|'s [=auction config/pending promise count=] is 0.
 1. [=Assert=] |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
   [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
-  [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], and
-  [=auction config/direct from seller signals header ad slot=] are not {{Promise}}s, and
-  [=auction config/expects additional bids=] is false.
+  [=auction config/per buyer timeouts=], and [=auction config/direct from seller signals header ad slot=]
+  are not {{Promise}}s, and [=auction config/expects additional bids=] is false.
 1. If |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
   [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
-  [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], or
-  [=auction config/direct from seller signals header ad slot=] is failure, return failure.
+  [=auction config/per buyer timeouts=], or [=auction config/direct from seller signals header ad slot=]
+  is failure, return failure.
 1. Return.
 
 </div>
@@ -4612,6 +4377,7 @@ response headers.
 : <dfn>provided as additional bid</dfn>
 :: A [=boolean=], initially false.
 
+
 </dl>
 
 <h3 dfn-type=dfn>Ad descriptor</h3>
@@ -4640,33 +4406,6 @@ Width and height of an ad.
 : <dfn>height units</dfn>
 :: A [=string=]. Can only be one of "px" (pixel), "sh" (screen height), and "sw" (screen width).
 
-</dl>
-
-<h3 id=direct-from-seller-signals-section>Direct from seller signals</h3>
-
-A <dfn>direct from seller signals key</dfn> is a [=struct=] with the following [=struct/items=]:
-
-<dl dfn-for="direct from seller signals key">
-  : <dfn>seller</dfn>
-  :: An [=origin=]. Matches the origin that served the captured [:Ad-Auction-Signals:] header.
-  : <dfn>ad slot</dfn>
-  :: A [=string=]. Matches the `adSlot` key of the JSON dictionaries in the top-level array of the
-    [:Ad-Auction-Signals:] value.
-</dl>
-
-A <dfn>direct from seller signals</dfn> is a [=struct=] with the following [=struct/items=]:
-
-<dl dfn-for="direct from seller signals">
-  : <dfn>auction signals</dfn>
-  :: Null or a [=string=].
-    Opaque JSON data passed to both buyers' and the seller's [=script runners=].
-  : <dfn>seller signals</dfn>
-  :: Null or a [=string=].
-    Opaque JSON data passed to the seller's [=script runner=].
-  : <dfn>per buyer signals</dfn>
-  :: A [=map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=strings=].
-    [=map/Keys=] are buyers and must be valid HTTPS origins. [=map/Values=] are opaque JSON data
-    passed to corresponding buyer's [=script runner=].
 </dl>
 
 <h3 dfn-type=dfn>Score ad output</h3>


### PR DESCRIPTION
This support is provided by a new `adAuctionHeaders` attribute on the
iframe element that will have the same functional behavior as the
`adAuctionHeaders` fetch flag, in that it will trigger the user agent to
send the `Sec-Ad-Auction-Fetch` request header, and to remove
`Ad-Auction-Signals` and `Ad-Auction-Additional-Bid` response headers,
providing their values to the Protected Audience auction.
    
This is a continuation of https://github.com/WICG/turtledove/pull/883,
which needed to be closed due to an merge conflict on rebase.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/orrb1/turtledove/pull/912.html" title="Last updated on Nov 16, 2023, 8:13 PM UTC (9de90d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/912/692ad88...orrb1:9de90d7.html" title="Last updated on Nov 16, 2023, 8:13 PM UTC (9de90d7)">Diff</a>