### PR TITLE
Fix an error in prevWin's ad json.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1288,9 +1288,9 @@ To <dfn>parse an https origin</dfn> given a [=string=] |input|:
     [=interest group/name=] is |ig|'s [=interest group/name=], return if none found.
   1. Let |win| be a new [=previous win=].
   1. Set |win|'s [=previous win/time=] to the [=current wall time=].
-  1. Let |ad| be the [=interest group ad=] from |ig|'s [=interest group/ads=] whose
-    [=ad descriptor/url=] is |bid|'s [=generated bid/ad descriptor=]
-    [=ad descriptor/url=], return if none found.
+  1. Let |ad| be an [=interest group ad=] whose [=interest group ad/render url=] is |bid|'s
+    [=generated bid/bid ad=]'s [=interest group ad/render url=], and [=interest group ad/metadata=]
+    is |bid|'s [=generated bid/bid ad=]'s [=interest group ad/metadata=].
   1. Set |win|'s [=previous win/ad json=] to the result of
     [=serializing an Infra value to a JSON string=] given |ad|.
   1. [=list/Append=] |win| to |loadedIg|'s [=interest group/previous wins=].

--- a/spec.bs
+++ b/spec.bs
@@ -1289,8 +1289,9 @@ To <dfn>parse an https origin</dfn> given a [=string=] |input|:
   1. Let |win| be a new [=previous win=].
   1. Set |win|'s [=previous win/time=] to the [=current wall time=].
   1. Let |ad| be an [=interest group ad=] whose [=interest group ad/render url=] is |bid|'s
-    [=generated bid/bid ad=]'s [=interest group ad/render url=], and [=interest group ad/metadata=]
-    is |bid|'s [=generated bid/bid ad=]'s [=interest group ad/metadata=].
+    [=generated bid/bid ad=]'s [=interest group ad/render url=], and whose
+    [=interest group ad/metadata=] is |bid|'s [=generated bid/bid ad=]'s
+    [=interest group ad/metadata=].
   1. Set |win|'s [=previous win/ad json=] to the result of
     [=serializing an Infra value to a JSON string=] given |ad|.
   1. [=list/Append=] |win| to |loadedIg|'s [=interest group/previous wins=].


### PR DESCRIPTION
#919 fixed a problem with preWin's ads field, but it still has some errors.
PreviousWin's ad_json only includes render_url and metadata
([code](https://crsrc.org/c/content/services/auction_worklet/public/mojom/bidder_worklet.mojom;drc=bdcb3b55d9837670a0bc8d541e326fb271678217;l=36) for reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/921.html" title="Last updated on Nov 21, 2023, 4:55 PM UTC (0302d6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/921/9c9973c...qingxinwu:0302d6c.html" title="Last updated on Nov 21, 2023, 4:55 PM UTC (0302d6c)">Diff</a>