### PR TITLE
spec.bs:  Change how updating IGs to an unknown executionMode behaves.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3587,7 +3587,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
         <dd>
         1. If |value| is "`compatibility`" or "`group-by-origin`",
           set |ig|'s [=interest group/execution mode=] to |value|.
-        1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
+        1. Otherwise, set |ig|'s [=interest group/execution mode=] to "`compatibility`".
 
         <dt>"`biddingLogicURL`"
         <dt>"`biddingWasmHelperURL`"


### PR DESCRIPTION
When joining IGs with unrecognized modes, we use "compatibility" for forward compatibility.  Seems like we should do the same for IG updates.

Note that neither the behavior this CL describes nor the originally described behavior are what currently happens - we currently ignore unrecognized modes.  I want to get approval for this before changing behavior.