### PR TITLE
[Spec] Fix build

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2028,27 +2028,28 @@ To <dfn>build trusted bidding signals url</dfn> given a [=URL=] |signalsUrl|, an
 |experimentGroupId|, and an [=origin=] |topLevelOrigin|:
 1. Let |queryParamsList| be a new empty [=list=].
 
-  Note: These steps create a [=url/query=] of the form "`&<name>=<values in comma-delimited list>`". E.g.,
-    "`hostname=publisher1.com&keys=key1,key2&interestGroupNames=ad+platform,name2&experimentGroupId=1234`".
-    <br><br>These steps don't use the [=urlencoded serializer|application/x-www-form-urlencoded serializer=]
-    to construct the query string because it repeats a key if it has multiple values instead of a
-    comma-demilited list (e.g., "keys=key1&keys=key2", instead of "keys=key1,key2"), and it also
-    uses a different percent encode set from the Chrome implementation.
+  Note: These steps create a [=url/query=] of the form "`&<name>=<values in comma-delimited list>`".
+  E.g., "`hostname=publisher1.com&keys=key1,key2&interestGroupNames=ad+platform,name2&experimentGroupId=1234`".
+    <br><br>These steps don't use the [=urlencoded serializer|application/x-www-form-urlencoded
+    serializer=] to construct the query string because it repeats a key if it has multiple values
+    instead of a comma-demilited list (e.g., "`keys=key1&keys=key2`", instead of
+    "`keys=key1,key2`"), and it also uses a different percent encode set from the Chrome
+    implementation.
 
 1. [=list/Append=] "hostname=" to |queryParamsList|.
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |topLevelOrigin| using [=component percent-encode set=]
   to |queryParamsList|.
 1. If |keys| is not [=set/is empty|empty=]:
-  1. [=list/Append=] "&keys=" to |queryParamsList|.
+  1. [=list/Append=] "`&keys=`" to |queryParamsList|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
     |keys|.
 1. If |igNames| is not [=set/is empty|empty=]:
-  1. [=list/Append=] "&interestGroupNames=" to |queryParamsList|.
+  1. [=list/Append=] "`&interestGroupNames=`" to |queryParamsList|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
     |igNames|.
 1. If |experimentGroupId| is not null:
-  1. [=list/Append=] "&experimentGroupId=" to |queryParamsList|.
+  1. [=list/Append=] "`&experimentGroupId=`" to |queryParamsList|.
   1. [=list/Append=] [=serialize an integer|serialized=] |experimentGroupId| to |queryParamsList|.
 1. Let |fullSignalsUrl| be |signalsUrl|.
 1. Set |fullSignalsUrl|'s [=url/query=] to the result of [=string/concatenating=] |queryParamsList|.
@@ -2069,15 +2070,15 @@ Note: When trusted scoring signals fetches are not batched, |renderURLs|'s [=lis
 1. [=list/Append=] the result of [=string/UTF-8 percent-encoding=] |topLevelOrigin| using
   [=component percent-encode set=] to |queryParamsList|.
 1. If |renderURLs| is not [=set/is empty|empty=]:
-  1. [=list/Append=] "&renderURLs=" to |queryParamsList|.
+  1. [=list/Append=] "`&renderURLs=`" to |queryParamsList|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
     |renderURLs|.
 1. If |adComponentRenderURLs| is not [=set/is empty|empty=]:
-  1. [=list/Append=] "&adComponentRenderURLs=" to |queryParamsList|.
+  1. [=list/Append=] "`&adComponentRenderURLs=`" to |queryParamsList|.
   1. [=list/Extend=] |queryParamsList| with the result of [=encode trusted signals keys=] with
     |adComponentRenderURLs|.
 1. If |experimentGroupId| is not null:
-  1. [=list/Append=] "&experimentGroupId=" to |queryParamsList|.
+  1. [=list/Append=] "`&experimentGroupId=`" to |queryParamsList|.
   1. [=list/Append=] [=serialize an integer|serialized=] |experimentGroupId| to |queryParamsList|.
 1. Set |signalsUrl|'s [=url/query=] to the result of [=string/concatenating=] |queryParamsList|.
 1. return |signalsUrl|.


### PR DESCRIPTION
Bikeshed was updated recently to add new warnings around HTML & escape sequences -- use backtick blocks to put the problematic strings in `<code>` tags so that no escaping is necessary.

Also, fix wrapping of touched lines (should be 100 columns).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/949.html" title="Last updated on Dec 11, 2023, 9:36 PM UTC (5da8ced)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/949/b821120...caraitto:5da8ced.html" title="Last updated on Dec 11, 2023, 9:36 PM UTC (5da8ced)">Diff</a>