### PR TITLE
Replace inaccurate link for 'request' in iframe navigation patch

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3855,7 +3855,7 @@ partial dictionary RequestInit {
 <div algorithm="fetch new request patch">
 The following step will be added to the <code><a constructor for="Request" lt="Request()">
 new Request (<var ignore>input</var>, <var ignore>init</var>)</a></code> constructor steps, before
-step "Set [=this=]'s [=Request/request=] to |request|":
+step "Set [=this=]'s [=request=] to |request|":
 
 1. If <var ignore>init</var>["{{RequestInit/adAuctionHeaders}}"] [=map/exists=], then set
   |request|'s [=request/capture-ad-auction-headers=] to it.


### PR DESCRIPTION
This is a follow up to https://github.com/WICG/turtledove/pull/918.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/pull/963.html" title="Last updated on Dec 21, 2023, 11:13 PM UTC (9564787)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/963/916fb56...9564787.html" title="Last updated on Dec 21, 2023, 11:13 PM UTC (9564787)">Diff</a>