### PR TITLE
Make sendReportTo Doc Apply to All report* functions, Add Beacon Info…

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -845,6 +845,8 @@ Once the winning ad has rendered in its Fenced Frame, the seller and the winning
 
 _As a temporary mechanism,_ these reporting functions will be able to send event-level reports to their servers.  These reports can include contextual information, and can include information about the winning interest group if it is over an anonymity threshold.  This reporting will happen synchronously, while the page with the ad is still open in the browser.
 
+During this period these signals will be sent by calling a `sendReportTo()` API which takes a single string argument representing a URL. The `sendReportTo()` function can be called at most once during a worklet function's execution. The URL is fetched when the frame displaying the ad begins navigating to the ad, and is sent using the [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API). 
+
 In the long term, we need a mechanism to ensure that the after-the-fact reporting cannot be used to learn the advertising interest group of individual visitors to the publisher's site — the same privacy goal that led to Fenced Frame rendering. The [Private Aggregation API](https://github.com/alexmturner/private-aggregation-api) proposal aims to satisfy this use case. Therefore event-level reporting is just a temporary model until an adequate reporting framework is settled and in place.
 
 
@@ -892,8 +894,6 @@ The arguments to this function are:
     *   auctionSignals: Like auctionConfig.auctionSignals, but passed via the [directFromSellerSignals](#25-additional-trusted-signals-directfromsellersignals) mechanism. These are the signals whose subresource URL ends in `?auctionSignals`.
 
 The `browserSignals` argument must be handled carefully to avoid tracking.  It certainly cannot include anything like the full list of interest groups, which would be too identifiable as a tracking signal.  The `renderURL` can be included since it has passed a k-anonymity check. Because `renderSize` will not be included in the k-anonymity check initially, it is not included in the browser signals.  The browser may limit the precision of the bid and desirability values by stochastically rounding them so that they fit into a floating point number with an 8 bit mantissa and 8 bit exponent to avoid these numbers exfiltrating information from the interest group's `userBiddingSignals`. On the upside, this set of signals can be expanded to include useful additional summary data about the wider range of bids that participated in the auction, e.g. the number of bids.  Additionally, the `dataVersion` will only be present if the `Data-Version` header was provided in the response headers from the Trusted Scoring server.
-
-In the short-term, the `reportResult()` function's reporting happens by calling a `sendReportTo()` API which takes a single string argument representing a URL. The `sendReportTo()` function can be called at most once during a worklet function's execution. The URL is fetched when the frame displaying the ad begins navigating to the ad. Eventually reporting will go through the Private Aggregation API once it has been developed.
 
 The output of `reportResult()` is not used for reporting, but rather as an input to the buyer's reporting function.
 


### PR DESCRIPTION
…, Slight Flow Change

Original intention here was to add what I think is a clarification about how the reporting functions send the signal back to the ad tech's servers. As I was digging through I figured a beacon would be used and I thiiink that is supported by slightly-above-cursory-inspection [here](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/interest_group/interest_group_auction_reporter.cc;l=264?q=reportResult&ss=chromium%2Fchromium%2Fsrc:content%2Fbrowser%2Finterest_group%2F).

As I went to write the update I thought it made sense to add it to the paragraph I modified, but wanted it to apply across both reportResult and reportWin, and since that paragraph I think should apply to both as well, I think it makes sense to push it up the "stack" a level. Then, given the move, I changed a few things for flow.

Last thing: as I was writing this PR commit, I realized this might be on the side "not a generic spec piece for any browser implementing Fledge, but still relevant for most readers of this doc"...since I don't think we talked more about that yet, I'm just gonna propose this and we can talk about what makes sense.