### PR TITLE
[Spec] Disallow calling registerAdBeacon for undefined reserved.* types

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3480,10 +3480,10 @@ Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
   1. If [=this=]'s [=relevant global object=]'s [=InterestGroupReportingScriptRunnerGlobalScope/
      reporting beacon map=] is not null, then [=exception/Throw=] a {{TypeError}}.
 
-  1. [=map/For each=] |type| → |url| of |map|'s [=map/values=]:
+  1. [=map/For each=] |type| → |url| of |map|:
 
      1. If |type| [=string/starts with=] "`reserved.`" and |type| does not match one of the
-        [=fencedframetype/automatic beacon event type=] values, [=exception/Throw=] a {{TypeError}}.
+        [=fencedframetype/automatic beacon event type=] values, [=exception/throw=] a {{TypeError}}.
 
      1. Let |parsedURL| be the result of running [=URL parser=] on |url|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -66,8 +66,6 @@ spec: Fenced Frame; urlPrefix: https://wicg.github.io/fenced-frame/
   type: dfn
     for: browsing context
       text: fenced frame config instance; url: #browsing-context-fenced-frame-config-instance
-    for: fencedframetype
-      text: automatic beacon event type; url: #fencedframetype-automatic-beacon-event-type
 spec: Private Aggregation API; urlPrefix: https://patcg-individual-drafts.github.io/private-aggregation-api
   type: dfn
     text: private-aggregation; url: #private-aggregation

--- a/spec.bs
+++ b/spec.bs
@@ -66,6 +66,8 @@ spec: Fenced Frame; urlPrefix: https://wicg.github.io/fenced-frame/
   type: dfn
     for: browsing context
       text: fenced frame config instance; url: #browsing-context-fenced-frame-config-instance
+    for: fencedframetype
+      text: automatic beacon event type; url: #fencedframetype-automatic-beacon-event-type
 spec: Private Aggregation API; urlPrefix: https://patcg-individual-drafts.github.io/private-aggregation-api
   type: dfn
     text: private-aggregation; url: #private-aggregation
@@ -3480,7 +3482,10 @@ Each {{InterestGroupReportingScriptRunnerGlobalScope}} has a
   1. If [=this=]'s [=relevant global object=]'s [=InterestGroupReportingScriptRunnerGlobalScope/
      reporting beacon map=] is not null, then [=exception/Throw=] a {{TypeError}}.
 
-  1. [=map/For each=] |url| of |map|'s [=map/values=]:
+  1. [=map/For each=] |type| → |url| of |map|'s [=map/values=]:
+
+     1. If |type| [=string/starts with=] "`reserved.`" and |type| does not match one of the
+        [=fencedframetype/automatic beacon event type=] values, [=exception/Throw=] a {{TypeError}}.
 
      1. Let |parsedURL| be the result of running [=URL parser=] on |url|.
 


### PR DESCRIPTION
This is similar to https://github.com/WICG/fenced-frame/pull/134 on the fenced frame side. This ensures that only valid defined `reserved.*` event types can be registered.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/blu25/turtledove/pull/968.html" title="Last updated on Jan 3, 2024, 9:26 PM UTC (c428eea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/968/b7336d0...blu25:c428eea.html" title="Last updated on Jan 3, 2024, 9:26 PM UTC (c428eea)">Diff</a>