### PR TITLE
[WPM] add Wirtualna Polska Media to to tester list

### DIFF
--- a/fledge-tester-list.md
+++ b/fledge-tester-list.md
@@ -71,6 +71,7 @@ The usefulness of this page depends on testers sharing information and updates.
 | Globo | DSP & SSP | Testing | | adtech-delivery@g.globo |
 | Mediavine | DSP & SSP | 2023-2024 | | privacysandbox@mediavine.com |
 | Jivox | Ad Server (DCO) | Testing in progress | | jvx-google-privacy-sandbox-team@jivox.com |
+| Wirtualna Polska Media | Publisher & SSP | Running Protected Audience API tests since July 2023 | https://github.com/grupawp/PAapi | privacysandbox@grupawp.pl |
 
 ## Table - Publishers and Advertisers Interested in Testing or Early Adoption
 Companies who may be interested in participating in tests and early adoption opportunities provided by ad tech companies.


### PR DESCRIPTION
Updating Fledge tester list with Wirtualna Polska Media - we've been running PAA tests since 07/2023 (executing auctions directly, or using Prebid / Google Ad Manager integration).