### PR TITLE
Add TNL Mediagene to tester list

### DIFF
--- a/fledge-tester-list.md
+++ b/fledge-tester-list.md
@@ -87,4 +87,5 @@ Companies who may be interested in participating in tests and early adoption opp
 | OLX Brasil | Publisher | | adtech@olxbr.com |
 | Globo | Publisher | | adtech-delivery@g.globo|
 | A Gazeta | Publisher | | cdutra@redegazeta.com.br |
+| TNL Mediagene | Publisher | | privacysandbox@tnlmediagene.com |
 


### PR DESCRIPTION
TNL Mediagene is a media group based in Taipei & Japan with media brands like Gizmodo Japan, Business Insider Japan, The New Lens and iCook etc. We have enabled Protected Audiences via Prebid.js's fledgeForGpt module.