### PR TITLE
Add default link for utf-8 to fix build error

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -77,6 +77,7 @@ spec: Shared Storage API; urlPrefix: https://wicg.github.io/shared-storage
 </pre>
 
 <pre class=link-defaults>
+spec:encoding; type:dfn; text:utf-8
 spec:infra; type:dfn; text:user agent
 </pre>
 


### PR DESCRIPTION
Seems there are more than one [=utf-8=] defined now in differnet specs. Added a default link for it as the build error suggested.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/996.html" title="Last updated on Jan 19, 2024, 5:55 AM UTC (8bbbd97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/996/59dd727...qingxinwu:8bbbd97.html" title="Last updated on Jan 19, 2024, 5:55 AM UTC (8bbbd97)">Diff</a>