### PR TITLE
Spec: increase limit on ad components to 40 and add a feature detection mechanism

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1289,6 +1289,7 @@ and a [=moment=] |auctionStartTime|:
     minus |ig|'s [=interest group/join time=], in milliseconds.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/bidCount}}"] to the sum of |ig|'s
      [=interest group/bid counts=] for all days within the last 30 days.
+  1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/adComponentsLimit}}"] to 40.
   1. Let |prevWins| be a new <code>[=sequence=]<{{PreviousWin}}></code>.
   1. [=list/For each=] |prevWin| of |ig|'s [=interest group/previous wins=] for all days within the
     the last 30 days:
@@ -3166,7 +3167,7 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
     1. Let |adComponents| be |generateBidOutput|["{{GenerateBidOutput/adComponents}}"].
     1. Return failure if any of the following conditions hold:
       * |groupHasAdComponents| is false;
-      * |adComponents|'s size is greater than 20.
+      * |adComponents|'s size is greater than 40.
     1. Let |adComponentDescriptors| be a new [=list=] of [=ad descriptors=].
     1. For |component| in |adComponents|:
       1. Let |componentDescriptor| be a new [=ad descriptor=].
@@ -3608,6 +3609,28 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
 
 </div>
 
+# Feature Detection # {#feature-detection}
+
+The {{ProtectedAudience/queryFeatureSupport()}} method permits checking what functionality is available in the current implementation, in order to help deploy new features.  The return values specified in this specifications are for an implementation that fully implements it.
+
+<xmp class="idl">
+[SecureContext]
+partial interface Navigator {
+  [SameObject] readonly attribute ProtectedAudience protectedAudience;
+};
+
+interface ProtectedAudience {
+  any queryFeatureSupport(DOMString feature);
+};
+</xmp>
+
+<div algorithm>
+
+The <dfn for=ProtectedAudience method>queryFeatureSupport(feature)</dfn> method steps are:
+1. If feature is "adComponentsLimit", return 40.
+2. Return `undefined`.
+
+</div>
 
 # Common Algorithms # {#common-algorithms}
 
@@ -4056,6 +4079,7 @@ dictionary BiddingBrowserSignals {
   required long joinCount;
   required long bidCount;
   required long recency;
+  required long adComponentsLimit;
 
   USVString topLevelSeller;
   sequence<PreviousWin> prevWinsMs;
@@ -4619,7 +4643,7 @@ result of [=evaluating a bidding script=], or an [=additional bid=] provided by 
   :: An [=ad descriptor=]. Render URL and size of the bid's ad.
   : <dfn>ad component descriptors</dfn>
   :: Null or a [=list=] of [=ad descriptors=]. Ad components associated with bid, if any. May have at
-    most 20 [=list/items=]. Must be null if the interest group making this bid has a null
+    most 40 [=list/items=]. Must be null if the interest group making this bid has a null
     [=interest group/ad components=] field.
   : <dfn>ad cost</dfn>
   :: Null or a {{double}}. Advertiser click or conversion cost passed from `generateBid()` to

--- a/spec.bs
+++ b/spec.bs
@@ -3611,7 +3611,7 @@ The <dfn for=Navigator method>updateAdInterestGroups()</dfn> method steps are:
 
 # Feature Detection # {#feature-detection}
 
-The {{ProtectedAudience/queryFeatureSupport()}} method permits checking what functionality is available in the current implementation, in order to help deploy new features.  The return values specified in this specifications are for an implementation that fully implements it.
+The {{ProtectedAudience/queryFeatureSupport()}} method permits checking what functionality is available in the current implementation, in order to help deploy new features.  The return values specified in this specification are for an implementation that fully implements it.
 
 <xmp class="idl">
 [SecureContext]
@@ -3619,6 +3619,7 @@ partial interface Navigator {
   [SameObject] readonly attribute ProtectedAudience protectedAudience;
 };
 
+[SecureContext, Exposed=Window]
 interface ProtectedAudience {
   any queryFeatureSupport(DOMString feature);
 };


### PR DESCRIPTION
Addresses https://github.com/WICG/turtledove/issues/810


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1004.html" title="Last updated on Jan 25, 2024, 6:26 PM UTC (45ba305)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1004/6de2828...morlovich:45ba305.html" title="Last updated on Jan 25, 2024, 6:26 PM UTC (45ba305)">Diff</a>