### PR TITLE
State the ability to use named ad size as size group is a possible future support.

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -124,13 +124,10 @@ const myGroup = {
   'trustedBiddingSignalsSlotSizeMode' : 'slot-size',
   'userBiddingSignals': {...},
   'ads': [{renderUrl: shoesAd1, sizeGroup: 'group1', ...},
-          {renderUrl: shoesAd2, sizeGroup: 'group2', ...},
-          {renderUrl: shoesAd3, sizeGroup: 'size3', ...}],
+          {renderUrl: shoesAd2, sizeGroup: 'group2', ...}],
   'adComponents': [{renderUrl: runningShoes1, sizeGroup: 'group2', ...},
                    {renderUrl: runningShoes2, sizeGroup: 'group2', ...},
-                   {renderUrl: gymShoes, sizeGroup; 'group2', ...},
-                   {renderUrl: gymTrainers1, sizeGroup: 'size4', ...},
-                   {renderUrl: gymTrainers2, sizeGroup: 'size4', ...}],
+                   {renderUrl: gymShoes, sizeGroup; 'group2', ...}],
   'adSizes': {'size1': {width: '100', height: '100'},
               'size2': {width: '100', height: '200'},
               'size3': {width: '75', height: '25'},
@@ -228,7 +225,7 @@ The `adComponents` field contains the various ad components (or "products") that
 
 The `adSizes` field (optionally) contains a dictionary of named ad sizes. Each size has the format `{width: widthVal, height: heightVal}`, where the values can have either pixel units (e.g. `100` or `'100px'`) or screen dimension coordinates (e.g. `100sw` or `100sh`). For example, the size `{width: '100sw', height: 50}` describes an ad that is the width of the screen and 50 pixels tall. The size `{width: '100sw', height: '200sw'}` describes an ad that is the width of the screen and has a 1:2 aspect ratio. Sizes with screen dimension coordinates are primarily intended for screen-width ads on mobile devices, and may be restricted in certain contexts (to be determined) for privacy reasons.
 
-The `sizeGroups` field (optionally) contains a dictionary of named lists of ad sizes. Each ad declared above must specify a size group, saying which sizes it might be loaded at. Each named ad size is also considered a size group, so you don't need to manually define singleton size groups; for example see the `sizeGroup: 'size3'` code above.
+The `sizeGroups` field (optionally) contains a dictionary of named lists of ad sizes. Each ad declared above must specify a size group, saying which sizes it might be loaded at. Each named ad size could in the future also be considered a size group, so you don't need to manually define singleton size groups.
 
 At some point in the future -  no earlier than Q1 2025 -  when the sizes are declared, the URL-size pairings will be used to prefetch k-anonymity checks to limit the configurations that can win an auction, please see [this doc](https://developer.chrome.com/docs/privacy-sandbox/protected-audience-api/feature-status/#k-anonymity). In the present implementation, only the URL is used for k-anonymity checks, not the size. When an ad with a particular size wins the auction (including in the current implementation), the size will be substituted into any macros in the URL (through `{%AD_WIDTH%}` and `{%AD_HEIGHT%}`, or `${AD_WIDTH}` and `${AD_HEIGHT}`), and once loaded into a fenced frame, the size will be used by the browser to freeze the fenced frame's inner dimensions. We therefore recommend using ad size declarations, but they are not required at this time.
 


### PR DESCRIPTION
The explainer does not match the current implementation's behavior. For compatibility consideration, we are changing the ability to use named ad size as size group as a possible future support.