### PR TITLE
Spec: Move k-anon updates to async finish reporting step.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -17,7 +17,7 @@ Indent: 2
 Default Biblio Status: current
 Markup Shorthands: markdown yes
 Assume Explicit For: yes
-</pre>
+</pre> 
 
 <pre class="anchors">
 urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch

--- a/spec.bs
+++ b/spec.bs
@@ -17,7 +17,7 @@ Indent: 2
 Default Biblio Status: current
 Markup Shorthands: markdown yes
 Assume Explicit For: yes
-</pre> 
+</pre>
 
 <pre class="anchors">
 urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch

--- a/spec.bs
+++ b/spec.bs
@@ -678,7 +678,7 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. Otherwise:
     1. Let |winner| be |winnerInfo|'s [=leading bid info/leading bid=].
     1. Let |fencedFrameConfig| be the result of [=filling in a pending fenced frame config=] with
-       |pendingConfig|, |auctionConfig|, |winnerInfo|, and |auctionReportInfo|.
+       |pendingConfig|, |auctionConfig|, |winnerInfo|, |auctionReportInfo|, .
     1. [=fenced frame config mapping/Finalize a pending config=] on |configMapping| with |urn| and
        |fencedFrameConfig|.
     1. Wait until |auctionConfig|'s [=auction config/resolve to config=] is a boolean.
@@ -686,16 +686,6 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
     1. If |auctionConfig|'s [=auction config/resolve to config=] is false, then set |result| to |urn|.
     1. [=Queue a global task=] on the [=DOM manipulation task source=], given |global|, to
        resolve |p| with |result|.
-    1. [=Increment ad k-anonymity count=] given |winner|'s [=generated bid/interest group=] and
-      |winner|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
-    1. If |winner|'s [=generated bid/ad component descriptors=] is not null:
-      1. [=set/For each=] |adComponentDescriptor| in |winner|'s
-        [=generated bid/ad component descriptors=]:
-        1. [=Increment component ad k-anonymity count=] given |adComponentDescriptor|'s
-          [=ad descriptor/url=].
-    1. [=Increment reporting ID k-anonymity count=] given |winner|'s
-      [=generated bid/interest group=] and |winner|'s [=generated bid/ad descriptor=]'s
-      [=ad descriptor/url=].
   1. Run [=interest group update=] with |auctionConfig|'s [=auction config/interest group buyers=].
   1. Run [=update bid counts=] with |bidIgs|.
   1. Run [=update previous wins=] with |winner|.
@@ -837,6 +827,17 @@ To <dfn>fill in a pending fenced frame config</dfn> given a [=fenced frame confi
 To <dfn>asynchronously finish reporting</dfn> given a
 [=fencedframetype/fenced frame reporting map=] |reportingMap|, [=leading bid info=] |leadingBidInfo|,
 and [=auction report info=] |auctionReportInfo|.
+1. Let |winner| be |leadingBidInfo|'s [=leading bid info/leading bid=].
+1. [=Increment ad k-anonymity count=] given |winner|'s [=generated bid/interest group=] and
+  |winner|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
+1. If |winner|'s [=generated bid/ad component descriptors=] is not null:
+  1. [=set/For each=] |adComponentDescriptor| in |winner|'s
+    [=generated bid/ad component descriptors=]:
+    1. [=Increment component ad k-anonymity count=] given |adComponentDescriptor|'s
+      [=ad descriptor/url=].
+1. [=Increment reporting ID k-anonymity count=] given |winner|'s
+  [=generated bid/interest group=] and |winner|'s [=generated bid/ad descriptor=]'s
+  [=ad descriptor/url=].
 1. Let |buyerDone|, |sellerDone|, and |componentSellerDone| be [=booleans=], initially false.
 1. If |leadingBidInfo|'s [=leading bid info/component seller=] is null, set |componentSellerDone|
    to true.

--- a/spec.bs
+++ b/spec.bs
@@ -678,7 +678,7 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. Otherwise:
     1. Let |winner| be |winnerInfo|'s [=leading bid info/leading bid=].
     1. Let |fencedFrameConfig| be the result of [=filling in a pending fenced frame config=] with
-       |pendingConfig|, |auctionConfig|, |winnerInfo|, |auctionReportInfo|, .
+       |pendingConfig|, |auctionConfig|, |winnerInfo|, and |auctionReportInfo|.
     1. [=fenced frame config mapping/Finalize a pending config=] on |configMapping| with |urn| and
        |fencedFrameConfig|.
     1. Wait until |auctionConfig|'s [=auction config/resolve to config=] is a boolean.


### PR DESCRIPTION
Browsers should only update k-anonymity when an ad is actually used, as a mitigation against running bogus auctions to game k-anon logic.

Note that this is also where bid counts are updated (when there's a winner) and when prevWins are updated.  I'll update those after this lands.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MattMenke2/turtledove/pull/1036.html" title="Last updated on Feb 29, 2024, 9:22 PM UTC (c51d311)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1036/eeb0649...MattMenke2:c51d311.html" title="Last updated on Feb 29, 2024, 9:22 PM UTC (c51d311)">Diff</a>