### PR TITLE
[Spec] Add deprecatedRenderURLReplacements

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1221,7 +1221,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. If |config|["{{AuctionAdConfig/interestGroupBuyers}}"] [=map/exists=] and is not [=list/empty=],
     then return failure.
   1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=] and is not [=list/empty=],
-    then return failure.
+    then [=exception/throw=] a {{TypeError}}.
 1. [=list/For each=] |component| in |config|["{{AuctionAdConfig/componentAuctions}}"]:
   1. If |isTopLevel| is false, then return failure.
   1. Let |componentAuction| be the result of running [=validate and convert auction ad config=] with

--- a/spec.bs
+++ b/spec.bs
@@ -1102,17 +1102,17 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"].
   1. [=Handle an input promise in configuration=] given |auctionConfig| and |auctionConfig|'s
       [=auction config/deprecated render url replacements=]:
-      * To parse the value |result|:
-        1. Let |renderUrlReplacements| be a new empty [=list=].
-        1. [=list/For each=] |replacement| in |result|:
-          1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
-          1. If [=validate a url macro=] with |match| returns false, then [=exception/throw=] a
-            {{TypeError}}.
-          1. Otherwise, [=list/append=] |replacement| to |renderUrlReplacements|.
-        1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
-          |renderUrlReplacements|.
-      * To handle an error, set |auctionConfig|'s 
-        [=auction config/deprecated render url replacements=] to failure.
+    * To parse the value |result|:
+      1. Let |renderUrlReplacements| be a new empty [=list=].
+      1. [=list/For each=] |replacement| in |result|:
+        1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
+        1. If [=validate a url macro=] with |match| returns false, then [=exception/throw=] a
+          {{TypeError}}.
+        1. Otherwise, [=list/append=] |replacement| to |renderUrlReplacements|.
+      1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
+        |renderUrlReplacements|.
+    * To handle an error, set |auctionConfig|'s 
+      [=auction config/deprecated render url replacements=] to failure.
       
 
 1. If |config|["{{AuctionAdConfig/sellerTimeout}}"] [=map/exists=], set |auctionConfig|'s

--- a/spec.bs
+++ b/spec.bs
@@ -607,6 +607,7 @@ dictionary AuctionAdConfig {
   sequence<record<DOMString, DOMString>> allSlotsRequestedSizes;
   Promise<any> sellerSignals;
   Promise<DOMString> directFromSellerSignalsHeaderAdSlot;
+  Promise<record<USVString, USVString>> deprecatedRenderURLReplacements;
   unsigned long long sellerTimeout;
   unsigned short sellerExperimentGroupId;
   USVString sellerCurrency;
@@ -1096,6 +1097,14 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     * To handle an error:
       1. Set |auctionConfig|'s [=auction config/direct from seller signals header ad slot=] to
         failure.
+1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=]:
+  1. Let |renderUrlReplacements| be a new empty [=list=].
+  1. [=list/For each=] |localReplacement| in |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"]:
+    1. Let |match| be the [=ad keyword replacement/match=] within |localReplacement|.
+    1. If [=validate a url macro=] with |match| returns false, then throw a {{TypeError}}.
+    1. Otherwise, [=list/Append=] |localReplacement| to |renderUrlReplacements|.
+  1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to |renderUrlReplacements|.
+
 1. If |config|["{{AuctionAdConfig/sellerTimeout}}"] [=map/exists=], set |auctionConfig|'s
   [=auction config/seller timeout=] to |config|["{{AuctionAdConfig/sellerTimeout}}"] in milliseconds
   or 500 milliseconds, whichever is smaller.
@@ -1216,6 +1225,22 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
      |resolveToConfig|, set |auctionConfig|'s [=auction config/resolve to config=] to
      |resolveToConfig|.
 1. Return |auctionConfig|.
+
+</div>
+
+<div algorithm>
+
+  To <dfn>validate a url macro</dfn> given a [=string=] |macro|:
+  1. If |macro| [=string/starts with=] "'${'":
+    1. If |macro| [=string/ends with=] "'}'":
+      1. Return true
+    1. Otherwise:
+      1. Return false
+  1. If |macro| [=string/starts with=] "'%%'":
+    1. If |macro| [=string/ends with=] "'%%'":
+      1. Return true
+    1. Otherwise:
+      1. Return false
 
 </div>
 
@@ -4862,6 +4887,13 @@ An <dfn>auction config</dfn> is a [=struct=] with the following items:
   :: A [=list=] of [=auction config=]s.
     Nested auctions whose results will also participate in a top level auction. Only the top level
     [=auction config=] can have component auctions.
+
+  : <dfn>deprecated render url replacements</dfn>
+  :: Null, a {{Promise}}, failure, or a [=list=] of [=ad keyword replacement=]s, each containing a 
+    single [=ad keyword replacement/match=] and [=ad keyword replacement/replacement=]. Render url 
+    replacements can only happen within the top level [=auction config=] or
+    within the component [=auction config=]s, but not both simultaneously. 
+    
   : <dfn>seller experiment group id</dfn>
   :: Null or an {{unsigned short}}, initially null.
     Optional identifier for an experiment group to support coordinated experiments with the seller's
@@ -4922,12 +4954,12 @@ To <dfn>wait until configuration input promises resolve</dfn> given an [=auction
   1. Wait until |auctionConfig|'s [=auction config/pending promise count=] is 0.
   1. [=Assert=] |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
     [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
-    [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], and
+    [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], [=auction config/deprecated render url replacements=], and
     [=auction config/direct from seller signals header ad slot=] are not {{Promise}}s, and
     [=auction config/expects additional bids=] is false.
   1. If |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
     [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
-    [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], or
+    [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], [=auction config/deprecated render url replacements=], or
     [=auction config/direct from seller signals header ad slot=] is failure, return failure.
   1. Return.
 </div>
@@ -5107,6 +5139,15 @@ An <dfn>ad size</dfn> is the width and height of an ad.
     [=ad size/height=] to |height|, [=ad size/height units=] to |heightUnit|.
   1. Return |adSize|.
 </div>
+
+An <dfn>ad keyword replacement</dfn> is a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="ad keyword replacement">
+  : <dfn>match</dfn>
+  :: A [=string=], meant to match part of a {{AuctionAd/renderURL}}. must be in the format `${<match>}` or `%%<match>%%`
+  : <dfn>replacement</dfn>
+  :: A [=string=], meant to replace [=ad keyword replacement/match=] within a {{AuctionAd/renderURL}}.
+</dl>
 
 <h3 id=direct-from-seller-signals-section>Direct from seller signals</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1098,12 +1098,22 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       1. Set |auctionConfig|'s [=auction config/direct from seller signals header ad slot=] to
         failure.
 1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=]:
-  1. Let |renderUrlReplacements| be a new empty [=list=].
-  1. [=list/For each=] |replacement| in |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"]:
-    1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
-    1. If [=validate a url macro=] with |match| returns false, then throw a {{TypeError}}.
-    1. Otherwise, [=list/Append=] |replacement| to |renderUrlReplacements|.
-  1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to |renderUrlReplacements|.
+  1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
+    |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"].
+  1. [=Handle an input promise in configuration=] given |auctionConfig| and |auctionConfig|'s
+      [=auction config/deprecated render url replacements=]:
+      * To parse the value |result|:
+        1. Let |renderUrlReplacements| be a new empty [=list=].
+        1. [=list/For each=] |replacement| in |result|:
+          1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
+          1. If [=validate a url macro=] with |match| returns false, then [=exception/throw=] a
+            {{TypeError}}.
+          1. Otherwise, [=list/append=] |replacement| to |renderUrlReplacements|.
+        1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
+          |renderUrlReplacements|.
+      * To handle an error, set |auctionConfig|'s 
+        [=auction config/deprecated render url replacements=] to failure.
+      
 
 1. If |config|["{{AuctionAdConfig/sellerTimeout}}"] [=map/exists=], set |auctionConfig|'s
   [=auction config/seller timeout=] to |config|["{{AuctionAdConfig/sellerTimeout}}"] in milliseconds
@@ -1210,6 +1220,8 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 1. If |config|["{{AuctionAdConfig/componentAuctions}}"] is not [=list/empty=]:
   1. If |config|["{{AuctionAdConfig/interestGroupBuyers}}"] [=map/exists=] and is not [=list/empty=],
     then return failure.
+  1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=] and is not [=list/empty=],
+    then return failure.
 1. [=list/For each=] |component| in |config|["{{AuctionAdConfig/componentAuctions}}"]:
   1. If |isTopLevel| is false, then return failure.
   1. Let |componentAuction| be the result of running [=validate and convert auction ad config=] with
@@ -1232,15 +1244,9 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 
   To <dfn>validate a url macro</dfn> given a [=string=] |macro|:
   1. If |macro| [=string/starts with=] "'${'":
-    1. If |macro| [=string/ends with=] "'}'":
-      1. Return true
-    1. Otherwise:
-      1. Return false
+    1. If |macro| [=string/ends with=] "'}'", then return true, otherwise return false.
   1. If |macro| [=string/starts with=] "'%%'":
-    1. If |macro| [=string/ends with=] "'%%'":
-      1. Return true
-    1. Otherwise:
-      1. Return false
+    1. If |macro| [=string/ends with=] "'%%'", then return true, otherwise return false.
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1103,7 +1103,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
   1. [=Handle an input promise in configuration=] given |auctionConfig| and |auctionConfig|'s
       [=auction config/deprecated render url replacements=]:
     * To parse the value |result|:
-      1. Let |renderUrlReplacements| be a new empty [=list=].
+      1. Let |renderUrlReplacements| be a new empty [=list=] of [=ad keyword replacement=]s.
       1. [=list/For each=] |replacement| in |result|:
         1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
         1. If [=validate a url macro=] with |match| returns false, then [=exception/throw=] a
@@ -1220,8 +1220,8 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 1. If |config|["{{AuctionAdConfig/componentAuctions}}"] is not [=list/empty=]:
   1. If |config|["{{AuctionAdConfig/interestGroupBuyers}}"] [=map/exists=] and is not [=list/empty=],
     then return failure.
-  1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=] and is not [=list/empty=],
-    then [=exception/throw=] a {{TypeError}}.
+  1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=], then
+    [=exception/throw=] a {{TypeError}}.
 1. [=list/For each=] |component| in |config|["{{AuctionAdConfig/componentAuctions}}"]:
   1. If |isTopLevel| is false, then return failure.
   1. Let |componentAuction| be the result of running [=validate and convert auction ad config=] with
@@ -1631,6 +1631,16 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       [=interest group/owner=].
   1. Run [=report win=] with |leadingBidInfo|, |sellerSignals|, |reportResultBrowserSignals|, and
     |directFromSellerSignalsForWinner|.
+1. Let |replacements| be an [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=]
+    are [=strings=].
+  1. [=list/For each=] [=ad keyword replacement=], |replacement|, within [=auction config/deprecated render url replacements=]:
+    1. Let |k| be |replacement|'s [=ad keyword replacement/match=].
+    1. Let |v| be |replacement|'s [=ad keyword replacement/replacement=].
+    1. [=map/Set=] |replacements|[|k|] to |v|.
+1. Set |leadingBidInfo|'s [=leading bid info/leading bid=]'s [=generated bid/ad descriptor=] to the result of [=fencedframeutil/substitute macros=] with |replacements| and [=leading bid info/leading bid=]'s [=generated bid/ad descriptor=].
+1. If |leadingBidInfo|'s [=leading bid info/leading bid=]'s [=generated bid/ad descriptors=] is not null:
+  1. [=list/For each=] [=generated bid/ad descriptor=], |adDescriptor|, within [=leading bid info/leading bid=]'s [=generated bid/ad descriptors=]:
+    1. Set |adDescriptor| to the result of [=fencedframeutil/substitute macros=] with |replacements| and |adDescriptor|.
 1. Return |leadingBidInfo|.
 
 </div>
@@ -4960,8 +4970,9 @@ To <dfn>wait until configuration input promises resolve</dfn> given an [=auction
   1. Wait until |auctionConfig|'s [=auction config/pending promise count=] is 0.
   1. [=Assert=] |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
     [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
-    [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], [=auction config/deprecated render url replacements=], and
-    [=auction config/direct from seller signals header ad slot=] are not {{Promise}}s, and
+    [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=], 
+    [=auction config/deprecated render url replacements=], and
+    [=auction config/direct from seller signals header ad slot=] are not {{Promise}}s, and 
     [=auction config/expects additional bids=] is false.
   1. If |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
     [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
@@ -5150,7 +5161,8 @@ An <dfn>ad keyword replacement</dfn> is a [=struct=] with the following [=struct
 
 <dl dfn-for="ad keyword replacement">
   : <dfn>match</dfn>
-  :: A [=string=], that is a [=code unit substring=] of {{AuctionAd/renderURL}}. Must be in the format `${<match>}` or `%%<match>%%`
+  :: A [=string=], represents the match within a {{AuctionAd/renderURL}}, that we are looking to
+    replace. Must be in the format `${...}` or `%%...%%`.
   : <dfn>replacement</dfn>
   :: A [=string=], meant to replace [=ad keyword replacement/match=] within a {{AuctionAd/renderURL}}.
 </dl>

--- a/spec.bs
+++ b/spec.bs
@@ -789,16 +789,11 @@ To <dfn>fill in a pending fenced frame config</dfn> given a [=fenced frame confi
   1. Let |k| be |replacement|'s [=ad keyword replacement/match=].
   1. Let |v| be |replacement|'s [=ad keyword replacement/replacement=].
   1. [=map/Set=] |replacements|[|k|] to |v|.
-1. Set |winningBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=] to the result of
+1. Let |replacedAdURL| be the result of
   running [=fencedframeutil/substitute macros=] with |replacements| and |winningBid|'s 
   [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
-1. If |winningBid|'s [=generated bid/ad component descriptors=] is not null:
-  1. [=list/For each=] |adDescriptor| of |winningBid|'s 
-    [=generated bid/ad component descriptors=]:
-    1. Set |adDescriptor|'s [=ad descriptor/url=] to the result of running [=fencedframeutil/substitute macros=] with
-      |replacements| and |adDescriptor|'s [=ad descriptor/url=].
 1. Set |pendingConfig|'s [=fenced frame config/mapped url=]'s [=mapped url/value=] to
-   |winningBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
+   |replacedAdURL|.
 1. Let |adSize| be |winningBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=].
 1. If |adSize| is not null:
    1. Set |pendingConfig|'s [=fenced frame config/content size=] to a [=struct=] with the following
@@ -841,9 +836,19 @@ To <dfn>fill in a pending fenced frame config</dfn> given a [=fenced frame confi
       [=fenced frame reporting metadata/value=]'s
       [=fenced frame reporting metadata/fenced frame reporting map=], |winningBidInfo| and
       |auctionReportInfo|.
+1. Let |adComponentDescriptorsWithReplacements| be a new [=list=] of [=ad descriptors=].
+1. If |winningBid|'s [=generated bid/ad component descriptors=] is not null: 
+  1. [=list/For each=] |adComponentDescriptor| of |winningBid|'s 
+    [=generated bid/ad component descriptors=]:
+    1. Let |descriptorWithReplacement| be a new [=ad descriptor=].
+    1. Set |descriptorWithReplacement|'s [=ad descriptor/size=] to 
+      |adComponentDescriptor|'s [=ad descriptor/size=].
+    1. Set |descriptorWithReplacement|'s [=ad descriptor/url=] to the result of running
+      [=fencedframeutil/substitute macros=] with |replacements| and |adComponentDescriptor|'s
+      [=ad descriptor/url=].
+    1. [=list/Append=] |descriptorWithReplacement| to |adComponentDescriptorsWithReplacements|.
 1. Set |pendingConfig|'s [=fenced frame config/nested configs=]'s [=nested configs/value=] to
-   the result of running [=create nested configs=] with |winningBid|'s
-   [=generated bid/ad component descriptors=].
+   the result of running [=create nested configs=] with |adComponentDescriptorsWithReplacements|.
 1. Return |pendingConfig|.
 
 </div>
@@ -1122,6 +1127,8 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       1. [=list/For each=] |replacement| in |result|:
         1. If [=validate a url macro=] with |replacement|'s [=ad keyword replacement/match=] 
           returns false, then [=exception/throw=] a {{TypeError}}.
+        1. If [=validate a url macro=] with |replacement|'s [=ad keyword replacement/match=] 
+          returns false, then [=exception/throw=] a {{TypeError}}.
         1. Otherwise, [=list/append=] |replacement| to |renderUrlReplacements|.
       1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
         |renderUrlReplacements|.
@@ -1257,6 +1264,10 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 <div algorithm>
 
   To <dfn>validate a url macro</dfn> given a [=string=] |macro|:
+  1. Return true if any of the following conditions hold:
+    * |macro| [=string/starts with=] "'${'" and [=string/ends with=] "'}'";
+    * |macro| [=string/starts with=] "'%%'" and [=string/ends with=] "'%%'".
+  1. Otherwise, return false.
   1. Return true if any of the following conditions hold:
     * |macro| [=string/starts with=] "'${'" and [=string/ends with=] "'}'";
     * |macro| [=string/starts with=] "'%%'" and [=string/ends with=] "'%%'".

--- a/spec.bs
+++ b/spec.bs
@@ -1099,10 +1099,10 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
         failure.
 1. If |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"] [=map/exists=]:
   1. Let |renderUrlReplacements| be a new empty [=list=].
-  1. [=list/For each=] |localReplacement| in |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"]:
-    1. Let |match| be the [=ad keyword replacement/match=] within |localReplacement|.
+  1. [=list/For each=] |replacement| in |config|["{{AuctionAdConfig/deprecatedRenderURLReplacements}}"]:
+    1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
     1. If [=validate a url macro=] with |match| returns false, then throw a {{TypeError}}.
-    1. Otherwise, [=list/Append=] |localReplacement| to |renderUrlReplacements|.
+    1. Otherwise, [=list/Append=] |replacement| to |renderUrlReplacements|.
   1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to |renderUrlReplacements|.
 
 1. If |config|["{{AuctionAdConfig/sellerTimeout}}"] [=map/exists=], set |auctionConfig|'s

--- a/spec.bs
+++ b/spec.bs
@@ -1127,8 +1127,6 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
       1. [=list/For each=] |replacement| in |result|:
         1. If [=validate a url macro=] with |replacement|'s [=ad keyword replacement/match=] 
           returns false, then [=exception/throw=] a {{TypeError}}.
-        1. If [=validate a url macro=] with |replacement|'s [=ad keyword replacement/match=] 
-          returns false, then [=exception/throw=] a {{TypeError}}.
         1. Otherwise, [=list/append=] |replacement| to |renderUrlReplacements|.
       1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
         |renderUrlReplacements|.
@@ -1264,10 +1262,6 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 <div algorithm>
 
   To <dfn>validate a url macro</dfn> given a [=string=] |macro|:
-  1. Return true if any of the following conditions hold:
-    * |macro| [=string/starts with=] "'${'" and [=string/ends with=] "'}'";
-    * |macro| [=string/starts with=] "'%%'" and [=string/ends with=] "'%%'".
-  1. Otherwise, return false.
   1. Return true if any of the following conditions hold:
     * |macro| [=string/starts with=] "'${'" and [=string/ends with=] "'}'";
     * |macro| [=string/starts with=] "'%%'" and [=string/ends with=] "'%%'".

--- a/spec.bs
+++ b/spec.bs
@@ -5144,7 +5144,7 @@ An <dfn>ad keyword replacement</dfn> is a [=struct=] with the following [=struct
 
 <dl dfn-for="ad keyword replacement">
   : <dfn>match</dfn>
-  :: A [=string=], meant to match part of a {{AuctionAd/renderURL}}. must be in the format `${<match>}` or `%%<match>%%`
+  :: A [=string=], meant to Match part of a {{AuctionAd/renderURL}}. must be in the format `${<match>}` or `%%<match>%%`
   : <dfn>replacement</dfn>
   :: A [=string=], meant to replace [=ad keyword replacement/match=] within a {{AuctionAd/renderURL}}.
 </dl>

--- a/spec.bs
+++ b/spec.bs
@@ -5144,7 +5144,7 @@ An <dfn>ad keyword replacement</dfn> is a [=struct=] with the following [=struct
 
 <dl dfn-for="ad keyword replacement">
   : <dfn>match</dfn>
-  :: A [=string=], meant to Match part of a {{AuctionAd/renderURL}}. must be in the format `${<match>}` or `%%<match>%%`
+  :: A [=string=], that is a [=code unit substring=] of {{AuctionAd/renderURL}}. Must be in the format `${<match>}` or `%%<match>%%`
   : <dfn>replacement</dfn>
   :: A [=string=], meant to replace [=ad keyword replacement/match=] within a {{AuctionAd/renderURL}}.
 </dl>

--- a/spec.bs
+++ b/spec.bs
@@ -5180,10 +5180,12 @@ An <dfn>ad keyword replacement</dfn> is a [=struct=] with the following [=struct
 
 <dl dfn-for="ad keyword replacement">
   : <dfn>match</dfn>
-  :: A [=string=], represents the match within a {{AuctionAd/renderURL}}, that we are looking to
-    replace. Must be in the format `${...}` or `%%...%%`.
+  :: A [=string=], represents the match within a {{AuctionAd/renderURL}}, that is going to be
+    replaced by [=ad keyword replacement/replacement=]. Must be in the format `${...}` or 
+    `%%...%%`.
   : <dfn>replacement</dfn>
-  :: A [=string=], meant to replace [=ad keyword replacement/match=] within a {{AuctionAd/renderURL}}.
+  :: A [=string=], meant to replace [=ad keyword replacement/match=] within a 
+    {{AuctionAd/renderURL}}.
 </dl>
 
 <h3 id=direct-from-seller-signals-section>Direct from seller signals</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -782,6 +782,21 @@ To <dfn>fill in a pending fenced frame config</dfn> given a [=fenced frame confi
 |pendingConfig|, [=auction config=] |auctionConfig|, [=leading bid info=] |winningBidInfo|, and
 [=auction report info=] |auctionReportInfo|:
 1. Let |winningBid| be |winningBidInfo|'s [=leading bid info/leading bid=].
+1. Let |replacements| be an [=ordered map=] whose [=map/keys=] are [=strings=] and whose 
+  [=map/values=] are [=strings=].
+1. [=list/For each=] |replacement| in |auctionConfig|'s 
+  [=auction config/deprecated render url replacements=]:
+  1. Let |k| be |replacement|'s [=ad keyword replacement/match=].
+  1. Let |v| be |replacement|'s [=ad keyword replacement/replacement=].
+  1. [=map/Set=] |replacements|[|k|] to |v|.
+1. Set |winningBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=] to the result of
+  running [=fencedframeutil/substitute macros=] with |replacements| and |winningBid|'s 
+  [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
+1. If |winningBid|'s [=generated bid/ad component descriptors=] is not null:
+  1. [=list/For each=] |adDescriptor| of |winningBid|'s 
+    [=generated bid/ad component descriptors=]:
+    1. Set |adDescriptor|'s [=ad descriptor/url=] to the result of running [=fencedframeutil/substitute macros=] with
+      |replacements| and |adDescriptor|'s [=ad descriptor/url=].
 1. Set |pendingConfig|'s [=fenced frame config/mapped url=]'s [=mapped url/value=] to
    |winningBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
 1. Let |adSize| be |winningBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=].
@@ -1105,9 +1120,8 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     * To parse the value |result|:
       1. Let |renderUrlReplacements| be a new empty [=list=] of [=ad keyword replacement=]s.
       1. [=list/For each=] |replacement| in |result|:
-        1. Let |match| be the [=ad keyword replacement/match=] within |replacement|.
-        1. If [=validate a url macro=] with |match| returns false, then [=exception/throw=] a
-          {{TypeError}}.
+        1. If [=validate a url macro=] with |replacement|'s [=ad keyword replacement/match=] 
+          returns false, then [=exception/throw=] a {{TypeError}}.
         1. Otherwise, [=list/append=] |replacement| to |renderUrlReplacements|.
       1. Set |auctionConfig|'s [=auction config/deprecated render url replacements=] to 
         |renderUrlReplacements|.
@@ -1243,10 +1257,10 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
 <div algorithm>
 
   To <dfn>validate a url macro</dfn> given a [=string=] |macro|:
-  1. If |macro| [=string/starts with=] "'${'":
-    1. If |macro| [=string/ends with=] "'}'", then return true, otherwise return false.
-  1. If |macro| [=string/starts with=] "'%%'":
-    1. If |macro| [=string/ends with=] "'%%'", then return true, otherwise return false.
+  1. Return true if any of the following conditions hold:
+    * |macro| [=string/starts with=] "'${'" and [=string/ends with=] "'}'";
+    * |macro| [=string/starts with=] "'%%'" and [=string/ends with=] "'%%'".
+  1. Otherwise, return false.
 
 </div>
 
@@ -4907,8 +4921,8 @@ An <dfn>auction config</dfn> is a [=struct=] with the following items:
   : <dfn>deprecated render url replacements</dfn>
   :: Null, a {{Promise}}, failure, or a [=list=] of [=ad keyword replacement=]s, each containing a 
     single [=ad keyword replacement/match=] and [=ad keyword replacement/replacement=]. Render url 
-    replacements can only happen within the top level [=auction config=] or
-    within the component [=auction config=]s, but not both simultaneously. 
+    replacements can only happen within a single seller [=auction config=] or
+    within the component [=auction config=]s. 
     
   : <dfn>seller experiment group id</dfn>
   :: Null or an {{unsigned short}}, initially null.


### PR DESCRIPTION
Adding spec changes for the new auction config parameter, 'deprecatedRenderURLReplacements'.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HabibiYou/turtledove/pull/1051.html" title="Last updated on Mar 5, 2024, 10:47 PM UTC (492845a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1051/d8bb533...HabibiYou:492845a.html" title="Last updated on Mar 5, 2024, 10:47 PM UTC (492845a)">Diff</a>