### PR TITLE
Small clarifications / consistency for arbitrary metadata values.

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -246,7 +246,7 @@ anywhere in the request where a plain `adRenderId` would have been sent (such as
 and `adComponents` fields as well as `prevWins`). Note that `include-full-ads` is not compatible
 with the auction server, so this mode is only for debugging.
 
-All fields that accept arbitrary metadata objects (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable.
+All fields that accept arbitrary metadata (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable.
 All fields that specify URLs for loading scripts or JSON (`biddingLogicURL`,
 `biddingWasmHelperURL`, `trustedBiddingSignalsURL`, and `updateURL`) must be
 same-origin with `owner` and must point to URLs whose responses include the HTTP
@@ -327,8 +327,8 @@ const myAuctionConfig = {
   'sellerSignals': {...},
   'sellerTimeout': 100,
   'sellerExperimentGroupId': 12345,
-  'perBuyerSignals': {'https://www.example-dsp.com': {...},
-                      'https://www.another-buyer.com': {...},
+  'perBuyerSignals': {'https://www.example-dsp.com': ...,
+                      'https://www.another-buyer.com': ...,
                       ...},
   'perBuyerTimeouts': {'https://www.example-dsp.com': 50,
                        'https://www.another-buyer.com': 200,
@@ -409,7 +409,7 @@ Therefore, when requesting a `FencedFrameConfig` for use in a fenced frame eleme
 1. Only pass `resolveToConfig: true` in if you detect that `window.FencedFrameConfig != undefined`, or
 1. Unconditionally pass in `resolveToConfig: true` and check whether the auction result is a config or a URN.
 
-All fields that accept arbitrary metadata objects (`auctionSignals`, `sellerSignals`, and keys of `perBuyerSignals`) must be JSON-serializable.
+All fields that accept arbitrary metadata (`auctionSignals`, `sellerSignals`, and `perBuyerSignals` dictionary values) must be JSON-serializable.
 All fields that specify URLs for loading scripts or JSON (`decisionLogicURL` and
 `trustedScoringSignalsURL`) must be same-origin with `seller` and must point to
 URLs whose responses include the HTTP response header `Ad-Auction-Allowed: true` to
@@ -563,17 +563,17 @@ The value of the `Ad-Auction-Signals` header must be JSON formatted, with the fo
 ```json
 Ad-Auction-Signals=[{
   "adSlot": "adSlot/1",
-  "sellerSignals": /*...*/,
-  "auctionSignals": /*...*/,
-  "perBuyerSignals": {"https://buyer1.example": /*...*/, /*...*/}
+  "sellerSignals": ...,
+  "auctionSignals": ...,
+  "perBuyerSignals": {"https://buyer1.example": ..., ...}
 },
 {
   "adSlot": "adSlot/2",
-  "sellerSignals": /*...*/,
-  "auctionSignals": /*...*/,
-  "perBuyerSignals": {"https://buyer1.example": /*...*/, /*...*/}
+  "sellerSignals": ...,
+  "auctionSignals": ...,
+  "perBuyerSignals": {"https://buyer1.example": ..., ...}
 },
-/*...*/
+...
 ]
 ```
 

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -246,7 +246,7 @@ anywhere in the request where a plain `adRenderId` would have been sent (such as
 and `adComponents` fields as well as `prevWins`). Note that `include-full-ads` is not compatible
 with the auction server, so this mode is only for debugging.
 
-All fields that accept arbitrary metadata (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable.
+All fields that accept arbitrary metadata (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable values (which may include primitive values, arrays, objects of arbitrary structure).
 All fields that specify URLs for loading scripts or JSON (`biddingLogicURL`,
 `biddingWasmHelperURL`, `trustedBiddingSignalsURL`, and `updateURL`) must be
 same-origin with `owner` and must point to URLs whose responses include the HTTP
@@ -409,7 +409,7 @@ Therefore, when requesting a `FencedFrameConfig` for use in a fenced frame eleme
 1. Only pass `resolveToConfig: true` in if you detect that `window.FencedFrameConfig != undefined`, or
 1. Unconditionally pass in `resolveToConfig: true` and check whether the auction result is a config or a URN.
 
-All fields that accept arbitrary metadata (`auctionSignals`, `sellerSignals`, and `perBuyerSignals` dictionary values) must be JSON-serializable.
+All fields that accept arbitrary metadata (`auctionSignals`, `sellerSignals`, and `perBuyerSignals` dictionary values) must be JSON-serializable values (which may include primitive values, arrays, objects of arbitrary structure).
 All fields that specify URLs for loading scripts or JSON (`decisionLogicURL` and
 `trustedScoringSignalsURL`) must be same-origin with `seller` and must point to
 URLs whose responses include the HTTP response header `Ad-Auction-Allowed: true` to

--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -246,7 +246,7 @@ anywhere in the request where a plain `adRenderId` would have been sent (such as
 and `adComponents` fields as well as `prevWins`). Note that `include-full-ads` is not compatible
 with the auction server, so this mode is only for debugging.
 
-All fields that accept arbitrary metadata (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable values (which may include primitive values, arrays, objects of arbitrary structure).
+All fields that accept arbitrary metadata (`userBiddingSignals` and `metadata` field of ads) must be JSON-serializable values (i.e. supported by JSON.stringify()). See [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
 All fields that specify URLs for loading scripts or JSON (`biddingLogicURL`,
 `biddingWasmHelperURL`, `trustedBiddingSignalsURL`, and `updateURL`) must be
 same-origin with `owner` and must point to URLs whose responses include the HTTP
@@ -409,7 +409,7 @@ Therefore, when requesting a `FencedFrameConfig` for use in a fenced frame eleme
 1. Only pass `resolveToConfig: true` in if you detect that `window.FencedFrameConfig != undefined`, or
 1. Unconditionally pass in `resolveToConfig: true` and check whether the auction result is a config or a URN.
 
-All fields that accept arbitrary metadata (`auctionSignals`, `sellerSignals`, and `perBuyerSignals` dictionary values) must be JSON-serializable values (which may include primitive values, arrays, objects of arbitrary structure).
+All fields that accept arbitrary metadata (`auctionSignals`, `sellerSignals`, and `perBuyerSignals` dictionary values) must be JSON-serializable values (i.e. supported by JSON.stringify()). See [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
 All fields that specify URLs for loading scripts or JSON (`decisionLogicURL` and
 `trustedScoringSignalsURL`) must be same-origin with `seller` and must point to
 URLs whose responses include the HTTP response header `Ad-Auction-Allowed: true` to


### PR DESCRIPTION
TechLab standardisation group was discussing serialisation for `perBuyerSignals` from buyers to sellers.  

Suggesting these small cleanups so that it is clear that `perBuyerSignals` is _any_ value (not necessarily a dict or string), and update "arbitrary value" examples to use a uniform `...` placeholder. 


Reference:

Reviewing the spec, `perBuyerSignals` is a map of string keys (buyer origins) to _any _ (arbitrary JSON-serialisable value). Internally, this JS value is serialised to a string: 

```webidl
# Spec:
Promise<record<USVString, any>> perBuyerSignals;

If config["perBuyerSignals"] exists:
1.	Set auctionConfig’s per buyer signals to config["perBuyerSignals"].
2.	Handle an input promise in configuration given auctionConfig and auctionConfig’s per buyer signals:
o	To parse the value result:
1.	Set auctionConfig’s per buyer signals to a new ordered map whose keys are origins and whose values are strings.
2.	For each key → value of result:
1.	Let buyer be the result of parsing an https origin with key. If buyer is failure, throw a TypeError.
2.	Let signalsString be the result of serializing a JavaScript value to a JSON string, given value.
3.	Set auctionConfig’s per buyer signals[buyer] to signalsString.

```