### PR TITLE
Explicitly spec out how non-k-anon auction works.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1700,7 +1700,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
                  |generatedBidsForDebuggingReports|.
           1. [=list/For each=] |bidToScore| of |bidsToScore|:
             1. If |bidToScore|'s [=generated bid/for k-anon auction=] is true,
-                [=list/insert=] |bidToScore|'s [=generated bid/interest group=] in |bidIgs|.
+                [=list/append=] |bidToScore|'s [=generated bid/interest group=] in |bidIgs|.
             1. [=Score and rank a bid=] with |auctionConfig|, |bidToScore|, |leadingBidInfo|,
               |decisionLogicScript|, |directFromSellerSignalsForSeller|, |dataVersion|, |auctionLevel|,
               |componentAuctionExpectedCurrency|, and |topLevelOrigin|.
@@ -1914,8 +1914,17 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     |scoreAdOutput|["{{ScoreAdOutput/incomingBidInSellerCurrency}}"].
 1. Let |score| be |scoreAdOutput|["{{ScoreAdOutput/desirability}}"].
 1. If |generatedBid|'s [=generated bid/for k-anon auction=] is false:
+  1. Let |updateLeadingNonKAnonEnforcedBid| be false.
   1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]
      is null, or |score| &gt; |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced score=]:
+    1. Set |updateLeadingNonKAnonEnforcedBid| to true.
+    1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced bids count=] to 1.
+  1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=] is not null and
+      |score| = |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced score=]:
+      1. Increment |leadingBidInfo|'s by [=leading bid info/top non-k-anon-enforced bids count=] 1.
+      1. Set |updateLeadingNonKAnonEnforcedBid| to true with 1 in |leadingBidInfo|'s
+        [=leading bid info/top non-k-anon-enforced bids count=] chance.
+  1. If |updateLeadingNonKAnonEnforcedBid| is true:
      1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced score=]
         to |score|.
      1. Set |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=] to |generatedBid|.
@@ -5430,6 +5439,8 @@ scored bids. It's a [=struct=] with the following [=struct/items=]:
   :: A {{double}}, initially 0.0. The highest score so far when disregarding k-anonymity.
   : <dfn>top bids count</dfn>
   :: An integer, initially 0. The number of bids with the same `top score`.
+  : <dfn>top non-k-anon-enforced bids count</dfn>
+  :: Number of bids that are tied for leadership when disregarding k-anonymity thus far.
   : <dfn>at most one top bid owner</dfn>
   :: A [=boolean=], initially true. Whether all bids of `top score` are from the same interest
     group owner.

--- a/spec.bs
+++ b/spec.bs
@@ -1700,7 +1700,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
                  |generatedBidsForDebuggingReports|.
           1. [=list/For each=] |bidToScore| of |bidsToScore|:
             1. If |bidToScore|'s [=generated bid/for k-anon auction=] is true,
-                [=list/append=] |bidToScore|'s [=generated bid/interest group=] in |bidIgs|.
+                [=list/append=] |bidToScore|'s [=generated bid/interest group=] to |bidIgs|.
             1. [=Score and rank a bid=] with |auctionConfig|, |bidToScore|, |leadingBidInfo|,
               |decisionLogicScript|, |directFromSellerSignalsForSeller|, |dataVersion|, |auctionLevel|,
               |componentAuctionExpectedCurrency|, and |topLevelOrigin|.

--- a/spec.bs
+++ b/spec.bs
@@ -853,8 +853,9 @@ To <dfn>asynchronously finish reporting</dfn> given a
 [=fencedframetype/fenced frame reporting map=] |reportingMap|, [=leading bid info=] |leadingBidInfo|,
 and [=auction report info=] |auctionReportInfo|.
 1. [=Increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading bid=].
-1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is not null,
-   [=increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=].
+1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=] is
+   not null, [=increment a winning bid's k-anonymity count=] given
+   |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=].
 1. Let |buyerDone|, |sellerDone|, and |componentSellerDone| be [=booleans=], initially false.
 1. If |leadingBidInfo|'s [=leading bid info/component seller=] is null, set |componentSellerDone|
    to true.
@@ -1439,12 +1440,13 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
       1. Set |topLevelDirectFromSellerSignalsRetrieved| to true.
     1. If |compWinnerInfo|'s [=leading bid info/leading bid=] is not null, then run
       [=score and rank a bid=] with |auctionConfig|, |compWinnerInfo|'s
-      [=leading bid info/leading bid=], |leadingBidInfo|, |decisionLogicScript|, null,
-      "top-level-auction", null, and |topLevelOrigin|.
-    1. If |compWinnerInfo|'s [=leading bid info/leading non-k-anon bid=] is not null, then run
-      [=score and rank a bid=] with |auctionConfig|, |compWinnerInfo|'s
-      [=leading bid info/leading non-k-anon bid=], |leadingBidInfo|, |decisionLogicScript|, null,
-      "top-level-auction", null, and |topLevelOrigin|.
+      [=leading bid info/leading bid=], |leadingBidInfo|, |decisionLogicScript|,
+      null, "top-level-auction", null, and |topLevelOrigin|.
+    1. If |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]
+      is not null, then run [=score and rank a bid=] with |auctionConfig|,
+      |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=],
+      |leadingBidInfo|, |decisionLogicScript|, null, "top-level-auction", null,
+      and |topLevelOrigin|.
     1. Decrement |pendingComponentAuctions| by 1.
   1. Wait until |pendingComponentAuctions| is 0.
   1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, return null.
@@ -1604,8 +1606,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             1. [=list/Append=] |bidCopy| to |bidsToScore|.
             1. [=list/Append=] |generatedBid| to |bidsToScore|.
 
-            Note: Conceptually, a bid that's already k-anonymous is considered for both
-            the k-anonymous and non-k-anonymous leadership.
+            Note: Conceptually, a bid that's already k-anonymous is considered
+            for both the k-anonymous and non-enforcing-k-anonymity leadership.
 
             1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
                |generatedBidsForDebuggingReports|.
@@ -1858,10 +1860,11 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     |scoreAdOutput|["{{ScoreAdOutput/incomingBidInSellerCurrency}}"].
 1. Let |score| be |scoreAdOutput|["{{ScoreAdOutput/desirability}}"].
 1. If |generatedBid|'s [=generated bid/for k-anon auction=] is false:
-  1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is null, or
-     |score| &gt; |leadingBidInfo|'s [=leading bid info/top non-k-anon score=]:
-     1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon score=] to |score|.
-     1. Set |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] to |generatedBid|.
+  1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]
+     is null, or |score| &gt; |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced score=]:
+     1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced score=]
+        to |score|.
+     1. Set |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=] to |generatedBid|.
   1. Return.
 1. Let |updateLeadingBid| be false.
 1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, or |score| &gt;
@@ -5352,7 +5355,7 @@ scored bids. It's a [=struct=] with the following [=struct/items=]:
 <dl dfn-for="leading bid info">
   : <dfn>top score</dfn>
   :: A {{double}}, initially 0.0. The highest score so far.
-  : <dfn>top non-k-anon score</dfn>
+  : <dfn>top non-k-anon-enforced score</dfn>
   :: A {{double}}, initially 0.0. The highest score so far when disregarding k-anonymity.
   : <dfn>top bids count</dfn>
   :: An integer, initially 0. The number of bids with the same `top score`.
@@ -5361,7 +5364,7 @@ scored bids. It's a [=struct=] with the following [=struct/items=]:
     group owner.
   : <dfn>leading bid</dfn>
   :: Null or a [=generated bid=], initially null. The leading bid of the auction so far.
-  : <dfn>leading non-k-anon bid</dfn>
+  : <dfn>leading non-k-anon-enforced bid</dfn>
   :: Null or a [=generated bid=], initially null. The leading bid of the auction disregarding k-anonymity so far.
   : <dfn>auction config</dfn>
   :: An [=auction config=]. The auction config of the auction which generated this

--- a/spec.bs
+++ b/spec.bs
@@ -1921,7 +1921,7 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced bids count=] to 1.
   1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=] is not null and
       |score| = |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced score=]:
-      1. Increment |leadingBidInfo|'s by [=leading bid info/top non-k-anon-enforced bids count=] 1.
+      1. Increment |leadingBidInfo|'s [=leading bid info/top non-k-anon-enforced bids count=] by 1.
       1. Set |updateLeadingNonKAnonEnforcedBid| to true with 1 in |leadingBidInfo|'s
         [=leading bid info/top non-k-anon-enforced bids count=] chance.
   1. If |updateLeadingNonKAnonEnforcedBid| is true:

--- a/spec.bs
+++ b/spec.bs
@@ -861,7 +861,9 @@ To <dfn>asynchronously finish reporting</dfn> given a
 and [=auction report info=] |auctionReportInfo|.
 1. [=Increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading bid=].
 1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=] is
-   not null, [=increment a winning bid's k-anonymity count=] given
+   not null, and |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]'s [=generated bid/id=]
+   &ne; |leadingBidInfo|'s [=leading bid info/leading bid=]'s  [=generated bid/id=],
+   [=increment a winning bid's k-anonymity count=] given
    |leadingBidInfo|'s [=leading bid info/leading non-k-anon-enforced bid=].
 1. Let |buyerDone|, |sellerDone|, and |componentSellerDone| be [=booleans=], initially false.
 1. If |leadingBidInfo|'s [=leading bid info/component seller=] is null, set |componentSellerDone|

--- a/spec.bs
+++ b/spec.bs
@@ -3137,7 +3137,7 @@ threshold when responding to [=query k-anonymity count=].
 </div>
 
 <div algorithm>
-  To <dfn>increment a winning bid's k-anonymity count</dfn> given a [=generated bid=] |winner|:
+  To <dfn local-lt="update k-anonymity counts">increment a winning bid's k-anonymity count</dfn> given a [=generated bid=] |winner|:
   1. [=Increment ad k-anonymity count=] given |winner|'s [=generated bid/interest group=] and
     |winner|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
   1. If |winner|'s [=generated bid/ad component descriptors=] is not null:
@@ -5133,7 +5133,7 @@ result of [=evaluating a bidding script=], or an [=additional bid=] provided by 
     chose not to bid. When true, [=generated bid/bidder debug loss report url=] is still considered.
   : <dfn>for k-anon auction</dfn>
   :: A [=boolean=], initially true. If this is false, the bid is only used to determine the hypothetical
-    winner with no k-anonymity constraints, which would be used to update k-anonymity counts only.
+    winner with no k-anonymity constraints, which would be used to [=update k-anonymity counts=] only.
   : <dfn>bid</dfn>
   :: A [=bid with currency=]. If the [=bid with currency/value=] is zero or negative, then this
     [=interest group=] will not participate in the auction.

--- a/spec.bs
+++ b/spec.bs
@@ -1604,18 +1604,20 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             1. [=list/Append=] |bidCopy| to |bidsToScore|.
             1. [=list/Append=] |generatedBid| to |bidsToScore|.
 
-            Note: conceptually, a bid that's already k-anonymous is considered for both
-            the k-anonymous and non-k-anonymous leadership
+            Note: Conceptually, a bid that's already k-anonymous is considered for both
+            the k-anonymous and non-k-anonymous leadership.
 
             1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
                |generatedBidsForDebuggingReports|.
           1. Otherwise:
+
             Note: [=Generate a bid=] is now rerun with only k-anonymous [=interest group/ads=] to give
             the buyer a chance to [=generate a bid=] for k-anonymous [=interest group/ads=]. Allowing
             the buyer to first [=generate a bid=] for non-k-anonymous [=interest group/ads=] provides a
             mechanism to bootstrap the k-anonymity count, otherwise no [=interest group/ads=] would
             ever trigger [=increment k-anonymity count=] and all ads would fail
             [=query k-anonymity count=].
+
             1. Set |generatedBid|'s [=generated bid/for k-anon auction=] to false.
             1. [=list/Append=] |generatedBid| to |bidsToScore|.
             1. Let |originalAds| be |ig|'s [=interest group/ads=].
@@ -1651,9 +1653,9 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
               1. [=list/Append=] |generatedBid| to |bidsToScore|.
               1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
                  |generatedBidsForDebuggingReports|.
-          1. [=list/For each=| |bidToScore| of |bidsToScore|:
+          1. [=list/For each=] |bidToScore| of |bidsToScore|:
             1. If |bidToScore|'s [=generated bid/for k-anon auction=] is true,
-                [=list/Insert=] |bidToScore|'s [=generated bid/interest group=] in |bidIgs|.
+                [=list/insert=] |bidToScore|'s [=generated bid/interest group=] in |bidIgs|.
             1. [=Score and rank a bid=] with |auctionConfig|, |bidToScore|, |leadingBidInfo|,
               |decisionLogicScript|, |directFromSellerSignalsForSeller|, |dataVersion|, |auctionLevel|,
               |componentAuctionExpectedCurrency|, and |topLevelOrigin|.

--- a/spec.bs
+++ b/spec.bs
@@ -666,12 +666,12 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
       [=auction config/interest group buyers=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-  1. Let |generatedBids| be a new [=list=] of [=generated bids=].
+  1. Let |generatedBidsForDebuggingReports| be a new [=list=] of [=generated bids=].
   1. Let |winnerInfo| be the result of running [=generate and score bids=] with |auctionConfig|,
-    null, |global|, |settings|'s [=environment/top-level origin=], |bidIgs|, and |generatedBids|.
+    null, |global|, |settings|'s [=environment/top-level origin=], |bidIgs|, and |generatedBidsForDebuggingReports|.
   1. Let |auctionReportInfo| be a new [=auction report info=].
   1. If |winnerInfo| is not failure, then set |auctionReportInfo| to the result of running
-    [=collect forDebuggingOnly reports=] with |generatedBids| and |winnerInfo|.
+    [=collect forDebuggingOnly reports=] with |generatedBidsForDebuggingReports| and |winnerInfo|.
   1. If |winnerInfo| is failure, then [=queue a global task=] on [=DOM manipulation task source=],
     given |global|, to [=reject=] |p| with a "{{TypeError}}".
   1. Otherwise if |winnerInfo| is null or |winnerInfo|'s [=leading bid info/leading bid=] is null:
@@ -852,17 +852,9 @@ To <dfn>fill in a pending fenced frame config</dfn> given a [=fenced frame confi
 To <dfn>asynchronously finish reporting</dfn> given a
 [=fencedframetype/fenced frame reporting map=] |reportingMap|, [=leading bid info=] |leadingBidInfo|,
 and [=auction report info=] |auctionReportInfo|.
-1. Let |winner| be |leadingBidInfo|'s [=leading bid info/leading bid=].
-1. [=Increment ad k-anonymity count=] given |winner|'s [=generated bid/interest group=] and
-  |winner|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
-1. If |winner|'s [=generated bid/ad component descriptors=] is not null:
-  1. [=set/For each=] |adComponentDescriptor| in |winner|'s
-    [=generated bid/ad component descriptors=]:
-    1. [=Increment component ad k-anonymity count=] given |adComponentDescriptor|'s
-      [=ad descriptor/url=].
-1. [=Increment reporting ID k-anonymity count=] given |winner|'s
-  [=generated bid/interest group=] and |winner|'s [=generated bid/ad descriptor=]'s
-  [=ad descriptor/url=].
+1. [=Increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading bid=].
+1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is not null:
+  1. [=Increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=].
 1. Let |buyerDone|, |sellerDone|, and |componentSellerDone| be [=booleans=], initially false.
 1. If |leadingBidInfo|'s [=leading bid info/component seller=] is null, set |componentSellerDone|
    to true.
@@ -1412,7 +1404,7 @@ and a [=moment=] |auctionStartTime|:
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, an
 [=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|, an [=origin=]
 |topLevelOrigin|, a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=generated bids=]
-|generatedBids|:
+|generatedBidsForDebuggingReports|:
 1. [=Assert=] that these steps are running [=in parallel=].
 1. Let |auctionStartTime| be the [=current wall time=].
 1. Let |decisionLogicScript| be the result of [=fetching script=] with |auctionConfig|'s
@@ -1434,7 +1426,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=],
     [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
     1. Let |compWinnerInfo| be the result of running [=generate and score bids=] with |component|,
-      |auctionConfig|, |global|, |topLevelOrigin|, |bidIgs|, and |generatedBids|.
+      |auctionConfig|, |global|, |topLevelOrigin|, |bidIgs|, and |generatedBidsForDebuggingReports|.
     1. If |compWinnerInfo| is failure, return failure.
     1. If [=recursively wait until configuration input promises resolve=] given |auctionConfig| returns
       failure, return failure.
@@ -1448,6 +1440,10 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     1. If |compWinnerInfo|'s [=leading bid info/leading bid=] is not null, then run
       [=score and rank a bid=] with |auctionConfig|, |compWinnerInfo|'s
       [=leading bid info/leading bid=], |leadingBidInfo|, |decisionLogicScript|, null,
+      "top-level-auction", null, and |topLevelOrigin|.
+    1. If |compWinnerInfo|'s [=leading bid info/leading non-k-anon bid=] is not null, then run
+      [=score and rank a bid=] with |auctionConfig|, |compWinnerInfo|'s
+      [=leading bid info/leading non-k-anon bid=], |leadingBidInfo|, |decisionLogicScript|, null,
       "top-level-auction", null, and |topLevelOrigin|.
     1. Decrement |pendingComponentAuctions| by 1.
   1. Wait until |pendingComponentAuctions| is 0.
@@ -1593,29 +1589,35 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             |auctionSignals|, a [=map/clone=] of |browserSignals|, |perBuyerSignals|,
             |directFromSellerSignalsForBuyer|, |perBuyerTimeout|, |expectedCurrency|, |ig|, and
             |auctionStartTime|.
-          1. Set |generatedBid|'s [=generated bid/id=] to |generatedBids|'s [=list/size=].
-          1. [=list/Append=] |generatedBid| to |generatedBids|.
-
-            Issue: Instead of inserting to |generatedBids| in each component auction that runs in
-            parallel, create a strucure InterestGroupAuction that holds data for each auction
-            separately (<a href="https://github.com/WICG/turtledove/issues/1021">WICG/turtledove#1021</a>).
           1. Let |generateBidDuration| be the [=duration from=] |generateBidStartTime| to |settings|'s
             [=environment settings object/current monotonic time=], in milliseconds.
           1. If |perBuyerCumulativeTimeout| is not null, decrement |perBuyerCumulativeTimeout| by
             |generateBidDuration|.
-          1. If |generatedBid|'s [=generated bid/no bid=] is true, [=iteration/continue=].
-          1. If [=query generated bid k-anonymity count=] given |generatedBid| returns false:
+          1. If |generatedBid|'s [=generated bid/no bid=] is true:
+            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
+               |generatedBidsForDebuggingReports|.
+            1. [=iteration/continue=].
+          1. Let |bidsToScore| be a new [=list=] of [=generated bids=]
+          1. If [=query generated bid k-anonymity count=] given |generatedBid| returns true:
+            1. Let |bidCopy| be a copy of |generatedBid|.
+            1. Set |bidCopy|'s [=generated bid/for k-anon auction=] to false.
+            1. [=list/Append=] |bidCopy| to |bidsToScore|.
+            1. [=list/Append=] |generatedBid| to |bidsToScore|.
 
+            Note: conceptually, a bid that's already k-anonymous is considered for both
+            the k-anonymous and non-k-anonymous leadership
+
+            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
+               |generatedBidsForDebuggingReports|.
+          1. Otherwise:
             Note: [=Generate a bid=] is now rerun with only k-anonymous [=interest group/ads=] to give
             the buyer a chance to [=generate a bid=] for k-anonymous [=interest group/ads=]. Allowing
             the buyer to first [=generate a bid=] for non-k-anonymous [=interest group/ads=] provides a
             mechanism to bootstrap the k-anonymity count, otherwise no [=interest group/ads=] would
             ever trigger [=increment k-anonymity count=] and all ads would fail
             [=query k-anonymity count=].
-            1. TODO: Run [=score and rank a bid=] on |generatedBid| to find the highest scoring bid
-              that isn't k-anonymous. After the auction, if the highest scoring bid that isn't
-              k-anonymous has a higher score than the highest scoring k-anonymous bid, then call
-              [=increment ad k-anonymity count=] on it.
+            1. Set |generatedBid|'s [=generated bid/for k-anon auction=] to false.
+            1. [=list/Append=] |generatedBid| to |bidsToScore|.
             1. Let |originalAds| be |ig|'s [=interest group/ads=].
             1. If |originalAds| is not null:
               1. Set |ig|'s [=interest group/ads=] to a new [=list=] of [=interest group ad=].
@@ -1644,11 +1646,17 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
               |settings|'s [=environment settings object/current monotonic time=], in milliseconds.
             1. If |perBuyerCumulativeTimeout| is not null, then decrement |perBuyerCumulativeTimeout|
               by |generateBidDuration|.
-            1. If |generatedBid| is failure, [=iteration/continue=].
-          1. [=list/Insert=] |generatedBid|'s [=generated bid/interest group=] in |bidIgs|.
-          1. [=Score and rank a bid=] with |auctionConfig|, |generatedBid|, |leadingBidInfo|,
-            |decisionLogicScript|, |directFromSellerSignalsForSeller|, |dataVersion|, |auctionLevel|,
-            |componentAuctionExpectedCurrency|, and |topLevelOrigin|.
+            1. If |generatedBid| is not a failure:
+              1. [=Assert=] that [=query generated bid k-anonymity count=] given |generatedBid| returns true.
+              1. [=list/Append=] |generatedBid| to |bidsToScore|.
+              1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
+                 |generatedBidsForDebuggingReports|.
+          1. [=list/For each=| |bidToScore| of |bidsToScore|:
+            1. If |bidToScore|'s [=generated bid/for k-anon auction=] is true,
+                [=list/Insert=] |bidToScore|'s [=generated bid/interest group=] in |bidIgs|.
+            1. [=Score and rank a bid=] with |auctionConfig|, |bidToScore|, |leadingBidInfo|,
+              |decisionLogicScript|, |directFromSellerSignalsForSeller|, |dataVersion|, |auctionLevel|,
+              |componentAuctionExpectedCurrency|, and |topLevelOrigin|.
   1. Decrement |pendingBuyers| by 1.
 1. Wait until both |pendingBuyers| and |pendingAdditionalBids| are 0.
 1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, return null.
@@ -1847,8 +1855,14 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     then set |generatedBid|'s [=generated bid/bid in seller currency=] to
     |scoreAdOutput|["{{ScoreAdOutput/incomingBidInSellerCurrency}}"].
 1. Let |score| be |scoreAdOutput|["{{ScoreAdOutput/desirability}}"].
+1. If |generatedBid|'s [=generated bid/for k-anon auction=] is false:
+  1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is null, or
+     |score| > |leadingBidInfo|'s [=leading bid info/top non-k-anon score=]:
+     1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon score=] to |score|
+     1. Set |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] to |generatedBid|
+  1. Return.
 1. Let |updateLeadingBid| be false.
-1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, or |score| is greater than
+1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, or |score| >
   |leadingBidInfo|'s [=leading bid info/top score=]:
   1. Set |updateLeadingBid| to true.
   1. Set |leadingBidInfo|'s [=leading bid info/top bids count=] to 1.
@@ -2499,6 +2513,17 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
   1. Return |auctionReportInfo|.
 </div>
 
+<div>
+  To <dfn>register a bid for forDebuggingOnly reports</dfn> given a [=generated bid=]
+  |generatedBid| and a [=list=] of [=generated bids=] |generatedBidsForDebuggingReports|:
+  1. Set |generatedBid|'s [=generated bid/id=] to |generatedBidsForDebuggingReports|'s [=list/size=].
+  1. [=list/Append=] |generatedBid| to |generatedBidsForDebuggingReports|.
+
+  Issue: Instead of inserting to |generatedBidsForDebuggingReports| in each component auction that runs in
+  parallel, create a structure InterestGroupAuction that holds data for each auction
+  separately (<a href="https://github.com/WICG/turtledove/issues/1021">WICG/turtledove#1021</a>).
+</div>
+
 ### Downsampling ### {#downsampling-header}
 
 *This first introductory paragraph is non-normative.*
@@ -3104,6 +3129,19 @@ threshold when responding to [=query k-anonymity count=].
       [=interest group ad/render url=] is |ad|.
     1. Let |keyHash| be the result of [=computing the key hash of reporting ID=] given |ig| and |igAd|.
     1. [=Increment k-anonymity count=] given |keyHash|.
+</div>
+
+<div algorithm>
+  To <dfn>increment a winning bid's k-anonymity count</dfn> given a [=generated bid=] |winner|:
+  1. [=Increment ad k-anonymity count=] given |winner|'s [=generated bid/interest group=] and
+    |winner|'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=].
+  1. If |winner|'s [=generated bid/ad component descriptors=] is not null:
+    1. [=list/For each=] |adComponentDescriptor| in |winner|'s [=generated bid/ad component descriptors=]:
+      1. [=Increment component ad k-anonymity count=] given |adComponentDescriptor|'s
+        [=ad descriptor/url=].
+  1. [=Increment reporting ID k-anonymity count=] given |winner|'s
+    [=generated bid/interest group=] and |winner|'s [=generated bid/ad descriptor=]'s
+    [=ad descriptor/url=].
 </div>
 
 # Script Runners # {#script-runners}
@@ -5088,6 +5126,9 @@ result of [=evaluating a bidding script=], or an [=additional bid=] provided by 
   : <dfn>no bid</dfn>
   :: A [=boolean=], initially false. True if there was a failure generating a bid, or the bidder
     chose not to bid. When true, [=generated bid/bidder debug loss report url=] is still considered.
+  : <dfn>for k-anon auction</dfn>
+  :: A [=boolean=], initially true. If this is false, the bid is only used to determine the hypothetical
+    winner with no k-anonymity constraints, which would be used to update k-anonymity counts only.
   : <dfn>bid</dfn>
   :: A [=bid with currency=]. If the [=bid with currency/value=] is zero or negative, then this
     [=interest group=] will not participate in the auction.
@@ -5309,13 +5350,17 @@ scored bids. It's a [=struct=] with the following [=struct/items=]:
 <dl dfn-for="leading bid info">
   : <dfn>top score</dfn>
   :: A {{double}}, initially 0.0. The highest score so far.
+  : <dfn>top non-k-anon score</dfn>
+  :: A {{double}}, initially 0.0. The highest score so far when disregarding k-anonymity.
   : <dfn>top bids count</dfn>
   :: An integer, initially 0. The number of bids with the same `top score`.
   : <dfn>at most one top bid owner</dfn>
   :: A [=boolean=], initially true. Whether all bids of `top score` are from the same interest
     group owner.
   : <dfn>leading bid</dfn>
-  :: Null or a [=generate bid=], initially null. The leading bid of the auction so far.
+  :: Null or a [=generated bid=], initially null. The leading bid of the auction so far.
+  : <dfn>leading non-k-anon bid</dfn>
+  :: Null or a [=generated bid=], initially null. The leading bid of the auction disregarding k-anonymity so far.
   : <dfn>auction config</dfn>
   :: An [=auction config=]. The auction config of the auction which generated this
     [=leading bid info/leading bid=].

--- a/spec.bs
+++ b/spec.bs
@@ -853,8 +853,8 @@ To <dfn>asynchronously finish reporting</dfn> given a
 [=fencedframetype/fenced frame reporting map=] |reportingMap|, [=leading bid info=] |leadingBidInfo|,
 and [=auction report info=] |auctionReportInfo|.
 1. [=Increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading bid=].
-1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is not null:
-  1. [=Increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=].
+1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is not null,
+   [=increment a winning bid's k-anonymity count=] given |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=].
 1. Let |buyerDone|, |sellerDone|, and |componentSellerDone| be [=booleans=], initially false.
 1. If |leadingBidInfo|'s [=leading bid info/component seller=] is null, set |componentSellerDone|
    to true.
@@ -1599,7 +1599,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             1. [=iteration/continue=].
           1. Let |bidsToScore| be a new [=list=] of [=generated bids=]
           1. If [=query generated bid k-anonymity count=] given |generatedBid| returns true:
-            1. Let |bidCopy| be a copy of |generatedBid|.
+            1. Let |bidCopy| be a clone of |generatedBid|.
             1. Set |bidCopy|'s [=generated bid/for k-anon auction=] to false.
             1. [=list/Append=] |bidCopy| to |bidsToScore|.
             1. [=list/Append=] |generatedBid| to |bidsToScore|.
@@ -1859,12 +1859,12 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
 1. Let |score| be |scoreAdOutput|["{{ScoreAdOutput/desirability}}"].
 1. If |generatedBid|'s [=generated bid/for k-anon auction=] is false:
   1. If |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] is null, or
-     |score| > |leadingBidInfo|'s [=leading bid info/top non-k-anon score=]:
-     1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon score=] to |score|
-     1. Set |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] to |generatedBid|
+     |score| &gt; |leadingBidInfo|'s [=leading bid info/top non-k-anon score=]:
+     1. Set |leadingBidInfo|'s [=leading bid info/top non-k-anon score=] to |score|.
+     1. Set |leadingBidInfo|'s [=leading bid info/leading non-k-anon bid=] to |generatedBid|.
   1. Return.
 1. Let |updateLeadingBid| be false.
-1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, or |score| >
+1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, or |score| &gt;
   |leadingBidInfo|'s [=leading bid info/top score=]:
   1. Set |updateLeadingBid| to true.
   1. Set |leadingBidInfo|'s [=leading bid info/top bids count=] to 1.


### PR DESCRIPTION
... This is a prerequisite to specing how it works with targetNumAdComponents, which has rather subtler 
effects on what bids are made in each auction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1080.html" title="Last updated on Mar 18, 2024, 7:45 PM UTC (c021fb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1080/57e1852...morlovich:c021fb7.html" title="Last updated on Mar 18, 2024, 7:45 PM UTC (c021fb7)">Diff</a>