### PR TITLE
Spec: split out forDebuggingOnly fields from generated bid

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -696,12 +696,12 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
       [=auction config/interest group buyers=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
-  1. Let |generatedBidsForDebuggingReports| be a new [=list=] of [=generated bids=].
+  1. Let |bidDebugReportInfoList| be a new [=list=] of [=bid debug reporting info=].
   1. Let |winnerInfo| be the result of running [=generate and score bids=] with |auctionConfig|,
-    null, |global|, |settings|'s [=environment/top-level origin=], |bidIgs|, and |generatedBidsForDebuggingReports|.
+    null, |global|, |settings|'s [=environment/top-level origin=], |bidIgs|, and |bidDebugReportInfoList|.
   1. Let |auctionReportInfo| be a new [=auction report info=].
   1. If |winnerInfo| is not failure, then set |auctionReportInfo| to the result of running
-    [=collect forDebuggingOnly reports=] with |generatedBidsForDebuggingReports| and |winnerInfo|.
+    [=collect forDebuggingOnly reports=] with |bidDebugReportInfoList| and |winnerInfo|.
   1. If |winnerInfo| is failure, then [=queue a global task=] on [=DOM manipulation task source=],
     given |global|, to [=reject=] |p| with a "{{TypeError}}".
   1. Otherwise if |winnerInfo| is null or |winnerInfo|'s [=leading bid info/leading bid=] is null:
@@ -1468,8 +1468,8 @@ and a [=moment=] |auctionStartTime|:
 
 To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig|, an
 [=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|, an [=origin=]
-|topLevelOrigin|, a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=generated bids=]
-|generatedBidsForDebuggingReports|:
+|topLevelOrigin|, a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug reporting info=]
+|bidDebugReportInfoList|:
 1. [=Assert=] that these steps are running [=in parallel=].
 1. Let |auctionStartTime| be the [=current wall time=].
 1. Let |decisionLogicScript| be the result of [=fetching script=] with |auctionConfig|'s
@@ -1491,7 +1491,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   1. [=list/For each=] |component| in |auctionConfig|'s [=auction config/component auctions=],
     [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
     1. Let |compWinnerInfo| be the result of running [=generate and score bids=] with |component|,
-      |auctionConfig|, |global|, |topLevelOrigin|, |bidIgs|, and |generatedBidsForDebuggingReports|.
+      |auctionConfig|, |global|, |topLevelOrigin|, |bidIgs|, and |bidDebugReportInfoList|.
     1. If |compWinnerInfo| is failure, return failure.
     1. If [=recursively wait until configuration input promises resolve=] given |auctionConfig| returns
       failure, return failure.
@@ -1680,7 +1680,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. Let |directFromSellerSignalsForBuyer| be the result of running
             [=get direct from seller signals for a buyer=] with |directFromSellerSignals|, and |ig|'s
             [=interest group/owner=].
-          1. Let |generatedBid| be the result of [=generate a bid=] given |allTrustedBiddingSignals|,
+          1. Let « |generatedBid|, |bidDebugReportInfo| » be the result of [=generate a bid=] given |allTrustedBiddingSignals|,
             |auctionSignals|, a [=map/clone=] of |browserSignals|, |perBuyerSignals|,
             |directFromSellerSignalsForBuyer|, |perBuyerTimeout|, |expectedCurrency|, |ig|, and
             |auctionStartTime|.
@@ -1688,9 +1688,9 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             [=environment settings object/current monotonic time=], in milliseconds.
           1. If |perBuyerCumulativeTimeout| is not null, decrement |perBuyerCumulativeTimeout| by
             |generateBidDuration|.
-          1. If |generatedBid|'s [=generated bid/no bid=] is true:
-            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
-               |generatedBidsForDebuggingReports|.
+          1. If |generatedBid| is null:
+            1. [=Register a bid for forDebuggingOnly reports=] given null, |bidDebugReportInfo|, and
+               |bidDebugReportInfoList|.
             1. [=iteration/continue=].
           1. Let |bidsToScore| be a new [=list=] of [=generated bids=]
           1. If [=query generated bid k-anonymity count=] given |generatedBid| returns true:
@@ -1702,8 +1702,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             Note: Conceptually, a bid that's already k-anonymous is considered
             for both the k-anonymous and non-enforcing-k-anonymity leadership.
 
-            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
-               |generatedBidsForDebuggingReports|.
+            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid|, |bidDebugReportInfo|, and
+               |bidDebugReportInfoList|.
           1. Otherwise:
 
             Note: [=Generate a bid=] is now rerun with only k-anonymous [=interest group/ads=] to give
@@ -1733,7 +1733,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
               |perBuyerTimeout| to |perBuyerCumulativeTimeout|.
             1. Let |generateBidStartTime| be |settings|'s
               [=environment settings object/current monotonic time=].
-            1. Set |generatedBid| to the result of [=generate a bid=] given
+            1. Set « |generatedBid|, |bidDebugReportInfo| » to the result of [=generate a bid=] given
               |allTrustedBiddingSignals|, |auctionSignals|, a [=map/clone=] of |browserSignals|,
               |perBuyerSignals|, |directFromSellerSignalsForBuyer|, |perBuyerTimeout|,
               |expectedCurrency|, |ig|, and |auctionStartTime|.
@@ -1743,11 +1743,14 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
               |settings|'s [=environment settings object/current monotonic time=], in milliseconds.
             1. If |perBuyerCumulativeTimeout| is not null, then decrement |perBuyerCumulativeTimeout|
               by |generateBidDuration|.
-            1. If |generatedBid| is not a failure:
+            1. If |generatedBid| is a [=generated bid=]:
               1. [=Assert=] that [=query generated bid k-anonymity count=] given |generatedBid| returns true.
               1. [=list/Append=] |generatedBid| to |bidsToScore|.
-              1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid| and
-                 |generatedBidsForDebuggingReports|.
+              1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid|, |bidDebugReportInfo| and
+                 |bidDebugReportInfoList|.
+            1. If |generatedBid| is null:
+              1. [=Register a bid for forDebuggingOnly reports=] given null, |bidDebugReportInfo| and
+                 |bidDebugReportInfoList|.
           1. [=list/For each=] |bidToScore| of |bidsToScore|:
             1. If |bidToScore|'s [=generated bid/for k-anon auction=] is true,
                 [=list/append=] |bidToScore|'s [=generated bid/interest group=] to |bidIgs|.
@@ -1838,7 +1841,7 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
 
 <div algorithm>
 To <dfn>score and rank a bid</dfn> given an [=auction config=] |auctionConfig|, a [=generated bid=]
-|generatedBid|, a [=leading bid info=] |leadingBidInfo|, a [=string=] |decisionLogicScript|, a
+|generatedBid|, a [=bid debug reporting info=] |bidDebugReportInfo|, a [=leading bid info=] |leadingBidInfo|, a [=string=] |decisionLogicScript|, a
 {{DirectFromSellerSignalsForSeller}} |directFromSellerSignalsForSeller|, an {{unsigned long}}-or-null
 |biddingDataVersion|, an enum |auctionLevel|, which is "single-level-auction", "top-level-auction",
 or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, and an [=origin=]
@@ -1920,16 +1923,16 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
   |trustedScoringSignals|, |browserSignals|, |directFromSellerSignalsForSeller|, and
   |auctionConfig|'s [=auction config/seller timeout=].
 1. If |auctionLevel| is "top-level-auction":
-  1. Set |generatedBid|'s [=generated bid/top level seller debug loss report url=] to
+  1. Set |bidDebugReportInfo|'s [=bid debug reporting info/top level seller debug loss report url=] to
     |debugLossReportUrl|.
-  1. Set |generatedBid|'s [=generated bid/top level seller debug win report url=] to
+  1. Set |bidDebugReportInfo|'s [=bid debug reporting info/top level seller debug win report url=] to
     |debugWinReportUrl|.
 1. Otherwise:
-  1. Set |generatedBid|'s [=generated bid/seller debug loss report url=] to |debugLossReportUrl|.
-  1. Set |generatedBid|'s [=generated bid/seller debug win report url=] to |debugWinReportUrl|.
+  1. Set |bidDebugReportInfo|'s [=bid debug reporting info/seller debug loss report url=] to |debugLossReportUrl|.
+  1. Set |bidDebugReportInfo|'s [=bid debug reporting info/seller debug win report url=] to |debugWinReportUrl|.
 1. Let |scoreAdOutput| be result of [=processing scoreAd output=] with |scoreAdResult|.
 1. If |auctionLevel| is "component-auction", then set |generatedBid|'s
-  [=generated bid/component seller=] to |seller|.
+  [=generated bid/component seller=] and |bidDebugReportInfo|'s [=bid debug reporting info/component seller=] to |seller|.
 1. Return if any of the following conditions hold:
   * |scoreAdOutput| is failure;
   * auctionLevel| is not "single-level-auction", and |scoreAdOutput|
@@ -2586,58 +2589,61 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
 </div>
 
 <div algorithm>
-  To <dfn>collect forDebuggingOnly reports</dfn> given a [=list=] of [=generated bids=]
-  |generatedBids|, [=origin=] |seller|, and [=leading bid info=]-or-null |winnerInfo|:
+  To <dfn>collect forDebuggingOnly reports</dfn> given a [=list=] of [=bid debug reporting info=]
+  |bidDebugReportInfoList|, [=origin=] |seller|, and [=leading bid info=]-or-null |winnerInfo|:
 
   1. Let |auctionReportInfo| be a new [=auction report info=].
   1. Let |winningBid| be |winnerInfo|'s [=leading bid info/leading bid=] if |winnerInfo| is
     not null, null otherwise.
-  1. [=list/For each=] |generatedBid| of |generatedBids|:
-    1. If |winningBid| is not null and |generatedBid|'s [=generated bid/id=] is |winningBid|'s
+  1. [=list/For each=] |bidDebugReportInfo| of |bidDebugReportInfoList|:
+    1. If |winningBid| is not null and |bidDebugReportInfo|'s [=bid debug reporting info/id=] is |winningBid|'s
       [=generated bid/id=]:
-      1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-        [=generated bid/bidder debug win report url=], |generatedBid|'s
-        [=generated bid/interest group=]'s [=interest group/owner=], and |auctionReportInfo|'s
+      1. [=Assert=] that |winningBid|'s [=generated bid/id=] is not null.
+      1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+        [=bid debug reporting info/bidder debug win report url=], |bidDebugReportInfo|'s
+        [=bid debug reporting info/interest group owner=], and |auctionReportInfo|'s
         [=auction report info/debug win report urls=].
-      1. If |generatedBid|'s [=generated bid/component seller=] is null:
-        1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-          [=generated bid/seller debug win report url=], |seller|, and
+      1. If |bidDebugReportInfo|'s [=bid debug reporting info/component seller=] is null:
+        1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+          [=bid debug reporting info/seller debug win report url=], |seller|, and
           |auctionReportInfo|'s [=auction report info/debug win report urls=].
       1. Otherwise:
-        1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-          [=generated bid/seller debug win report url=], |generatedBid|'s
-          [=generated bid/component seller=], |auctionReportInfo|'s
+        1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+          [=bid debug reporting info/seller debug win report url=], |bidDebugReportInfo|'s
+          [=bid debug reporting info/component seller=], |auctionReportInfo|'s
           [=auction report info/debug win report urls=].
-        1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-          [=generated bid/top level seller debug win report url=], |seller|, and
+        1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+          [=bid debug reporting info/top level seller debug win report url=], |seller|, and
           |auctionReportInfo|'s [=auction report info/debug win report urls=].
     1. Otherwise:
-      1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-        [=generated bid/bidder debug loss report url=], |generatedBid|'s
-        [=generated bid/interest group=]'s [=interest group/owner=], and |auctionReportInfo|'s
+      1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+        [=bid debug reporting info/bidder debug loss report url=], |bidDebugReportInfo|'s
+        [=bid debug reporting info/interest group owner=], and |auctionReportInfo|'s
         [=auction report info/debug loss report urls=].
-      1. If |generatedBid|'s [=generated bid/component seller=] is null:
-        1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-          [=generated bid/seller debug loss report url=], |seller|, and
+      1. If |bidDebugReportInfo|'s [=bid debug reporting info/component seller=] is null:
+        1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+          [=bid debug reporting info/seller debug loss report url=], |seller|, and
           |auctionReportInfo|'s [=auction report info/debug loss report urls=].
       1. Otherwise:
-        1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-          [=generated bid/seller debug loss report url=], |generatedBid|'s
-          [=generated bid/component seller=], |auctionReportInfo|'s
+        1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+          [=bid debug reporting info/seller debug loss report url=], |bidDebugReportInfo|'s
+          [=bid debug reporting info/component seller=], |auctionReportInfo|'s
           [=auction report info/debug loss report urls=].
-        1. [=Collect a single forDebuggingOnly report=] with |generatedBid|'s
-          [=generated bid/top level seller debug loss report url=], |seller|, and
+        1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
+          [=bid debug reporting info/top level seller debug loss report url=], |seller|, and
           |auctionReportInfo|'s [=auction report info/debug loss report urls=].
   1. Return |auctionReportInfo|.
 </div>
 
 <div>
-  To <dfn>register a bid for forDebuggingOnly reports</dfn> given a [=generated bid=]
-  |generatedBid| and a [=list=] of [=generated bids=] |generatedBidsForDebuggingReports|:
-  1. Set |generatedBid|'s [=generated bid/id=] to |generatedBidsForDebuggingReports|'s [=list/size=].
-  1. [=list/Append=] |generatedBid| to |generatedBidsForDebuggingReports|.
+  To <dfn>register a bid for forDebuggingOnly reports</dfn> given a [=generated bid=]-or-null
+  |generatedBid|, [=bid debug reporting info=] |bidDebugReportInfo|, a [=list=] of [=bid debug reporting info=] |bidDebugReportInfoList|:
+  1. If |generatedBid| is not null:
+    1. Set |generatedBid|'s [=generated bid/id=] to |bidDebugReportInfoList|'s [=list/size=].
+    1. Set |bidDebugReportInfo|'s [=bid debug reporting info/id=] to |bidDebugReportInfoList|'s [=list/size=]
+  1. [=list/Append=] |bidDebugReportInfo| to |bidDebugReportInfoList|.
 
-  Issue: Instead of inserting to |generatedBidsForDebuggingReports| in each component auction that runs in
+  Issue: Instead of inserting to |bidDebugReportInfoList| in each component auction that runs in
   parallel, create a structure InterestGroupAuction that holds data for each auction
   separately (<a href="https://github.com/WICG/turtledove/issues/1021">WICG/turtledove#1021</a>).
 </div>
@@ -3426,9 +3432,13 @@ of the following global objects:
           |generatedBidIDL|, |ig|, |expectedCurrency|, |isComponentAuction|, and |global|'s
           [=InterestGroupBiddingScriptRunnerGlobalScope/group has ad components=].
         1. If |bidOutput| is not failure, then set |generatedBid| to |bidOutput|.
+    1. Let |bidDebugReportInfo| be a new [=bid debug reporting info=].
+    1. Set |bidDebugReportInfo|'s [=bid debug reporting info/interest group owner=] to
+       |ig|'s [=interest group/owner=]
     1. Let |debugLossReportUrl| be |global|'s
       [=InterestGroupBiddingAndScoringScriptRunnerGlobalScope/debug loss report url=] if it's not
       failure, null otherwise.
+    1. Set |bidDebugReportInfo|'s [=bid debug reporting info/bidder debug loss report url=] to |debugLossReportUrl|.
     1. If |generatedBid| is a [=generated bid=] and |generatedBid|'s [=generated bid/bid=]'s
       [=bid with currency/value=] &le; 0, then set |generatedBid| to null.
     1. If |generatedBid| is a [=generated bid=]:
@@ -3436,17 +3446,9 @@ of the following global objects:
         [=InterestGroupBiddingAndScoringScriptRunnerGlobalScope/debug win report url=] if it's not
         failure, null otherwise.
       1. Set |generatedBid|'s [=generated bid/bid duration=] to |duration|,
-        [=generated bid/interest group=] to |ig|, [=generated bid/bidder debug loss report url=] to
-        |debugLossReportUrl|, [=generated bid/bidder debug win report url=] to |debugWinReportUrl|.
-    1. Otherwise:
-      1. Set |generatedBid| to a new [=generated bid=] with the following [=struct/items=]:
-        : [=generated bid/no bid=]
-        :: true
-        : [generated bid/interest group=]
-        :: |ig|
-        : [=generated bid/bidder debug loss report url=]
-        :: |debugLossReportUrl|
-    1. Return |generatedBid|.
+        [=generated bid/interest group=] to |ig|,
+      1. Set |bidDebugReportInfo|'s [=bid debug reporting info/bidder debug win report url=] to |debugWinReportUrl|.
+    1. Return « |generatedBid|, |bidDebugReportInfo| ».
 </div>
 
 <div algorithm>
@@ -5309,9 +5311,6 @@ result of [=evaluating a bidding script=], or an [=additional bid=] provided by 
 <dl dfn-for="generated bid">
   : <dfn>id</dfn>
   :: An {{unsigned long}}. Used to identify a [=generated bid=].
-  : <dfn>no bid</dfn>
-  :: A [=boolean=], initially false. True if there was a failure generating a bid, or the bidder
-    chose not to bid. When true, [=generated bid/bidder debug loss report url=] is still considered.
   : <dfn>for k-anon auction</dfn>
   :: A [=boolean=], initially true. If this is false, the bid is only used to determine the hypothetical
     winner with no k-anonymity constraints, which would be used to [=update k-anonymity counts=] only.
@@ -5354,6 +5353,21 @@ result of [=evaluating a bidding script=], or an [=additional bid=] provided by 
   : <dfn>component seller</dfn>
   :: Null or an [=origin=]. Seller in component auction which the [=generated bid/interest group=]
     is participating. Only set for component auctions, null otherwise.
+</dl>
+
+A <dfn>bid debug reporting info</dfn> is a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="bid debug reporting info">
+  : <dfn>id</dfn>
+  :: An {{unsigned long}}-or-null. Matches a [=generated bid/id=] of the [=generated bid=] corresponding to
+     this reporting information, or null if no bid was produced, in which case the debug loss URLs are
+     still relevant.
+  : <dfn>component seller</dfn>
+  ::  Null or an [=origin=]. Seller in component auction which was running to produce
+    this debug information. Only set for component auctions, null otherwise.
+  : <dfn>interest group owner</dfn>
+  :: An [=origin=]. Matches [=interest group/owner=] of the interest group that was
+     used to call `generateBid()` to produce this reporting information.
   : <dfn>bidder debug win report url</dfn>
   :: Null or a [=URL=], initially null. Set by `generateBid()`'s
     {{InterestGroupBiddingAndScoringScriptRunnerGlobalScope/forDebuggingOnly}}'s

--- a/spec.bs
+++ b/spec.bs
@@ -1699,11 +1699,11 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             1. [=list/Append=] |bidCopy| to |bidsToScore|.
             1. [=list/Append=] |generatedBid| to |bidsToScore|.
 
-            Note: Conceptually, a bid that's already k-anonymous is considered
-            for both the k-anonymous and non-enforcing-k-anonymity leadership.
+              Note: Conceptually, a bid that's already k-anonymous is considered
+              for both the k-anonymous and non-enforcing-k-anonymity leadership.
 
-            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid|, |bidDebugReportInfo|, and
-               |bidDebugReportInfoList|.
+            1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid|,
+               |bidDebugReportInfo|, and |bidDebugReportInfoList|.
           1. Otherwise:
 
             Note: [=Generate a bid=] is now rerun with only k-anonymous [=interest group/ads=] to give
@@ -1748,9 +1748,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
               1. [=list/Append=] |generatedBid| to |bidsToScore|.
               1. [=Register a bid for forDebuggingOnly reports=] given |generatedBid|, |bidDebugReportInfo| and
                  |bidDebugReportInfoList|.
-            1. If |generatedBid| is null:
-              1. [=Register a bid for forDebuggingOnly reports=] given null, |bidDebugReportInfo| and
-                 |bidDebugReportInfoList|.
+            1. If |generatedBid| is null, [=register a bid for forDebuggingOnly reports=] given null,
+                 |bidDebugReportInfo| and |bidDebugReportInfoList|.
           1. [=list/For each=] |bidToScore| of |bidsToScore|:
             1. If |bidToScore|'s [=generated bid/for k-anon auction=] is true,
                 [=list/append=] |bidToScore|'s [=generated bid/interest group=] to |bidIgs|.
@@ -3445,9 +3444,9 @@ of the following global objects:
       1. Let |debugWinReportUrl| be |global|'s
         [=InterestGroupBiddingAndScoringScriptRunnerGlobalScope/debug win report url=] if it's not
         failure, null otherwise.
-      1. Set |generatedBid|'s [=generated bid/bid duration=] to |duration|,
-        [=generated bid/interest group=] to |ig|,
       1. Set |bidDebugReportInfo|'s [=bid debug reporting info/bidder debug win report url=] to |debugWinReportUrl|.
+      1. Set |generatedBid|'s [=generated bid/bid duration=] to |duration|,
+        [=generated bid/interest group=] to |ig|.
     1. Return « |generatedBid|, |bidDebugReportInfo| ».
 </div>
 
@@ -5359,12 +5358,12 @@ A <dfn>bid debug reporting info</dfn> is a [=struct=] with the following [=struc
 
 <dl dfn-for="bid debug reporting info">
   : <dfn>id</dfn>
-  :: An {{unsigned long}}-or-null. Matches a [=generated bid/id=] of the [=generated bid=] corresponding to
-     this reporting information, or null if no bid was produced, in which case the debug loss URLs are
-     still relevant.
+  :: An {{unsigned long}}-or-null. Matches a [=generated bid/id=] of the [=generated bid=]
+     corresponding to this reporting information, or null if no bid was produced, in which case the
+     debug loss URLs are still relevant.
   : <dfn>component seller</dfn>
   ::  Null or an [=origin=]. Seller in component auction which was running to produce
-    this debug information. Only set for component auctions, null otherwise.
+    this reporting information. Only set for component auctions, null otherwise.
   : <dfn>interest group owner</dfn>
   :: An [=origin=]. Matches [=interest group/owner=] of the interest group that was
      used to call `generateBid()` to produce this reporting information.


### PR DESCRIPTION
...into new type =bid debug reporting info=. This is in preparation for multibid, since that would have multiple bids corresponding to a single struct of debug reporting URLs [1]. As a bonus, this permits the removal of slightly awkward "no bid" field on generated bid.

[1] So =bid debug reporting info= will ultimately have a /set/ of generated bid ids, rather than id-or-null.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1089.html" title="Last updated on Mar 20, 2024, 4:38 PM UTC (c3a1f11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1089/28abf64...morlovich:c3a1f11.html" title="Last updated on Mar 20, 2024, 4:38 PM UTC (c3a1f11)">Diff</a>