### PR TITLE
Fix spec.bs bug

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1641,8 +1641,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     and |buyer|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/forDebuggingOnlyInCooldownOrLockout}}"]
     to the result of running [=is debugging only in cooldown or lockout=] with |buyer|.
-  1. [=map/For each=] |signalsUrl| → |perSignalsUrlGenerator| of |perSlotSizeQueryParam|:
-    1. [=map/For each=] |slotSizeQueryParam| → |perSlotSizeQueryParam| of |perBuyerGenerator|:
+  1. [=map/For each=] |slotSizeQueryParam| → |perSlotSizeQueryParam| of |perBuyerGenerator|:
+    1. [=map/For each=] |signalsUrl| → |perSignalsUrlGenerator| of |perSlotSizeQueryParam|:
       1. Let |allTrustedBiddingSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=],
         and [=map/values=] are [=strings=].
       1. Let |keys| be a new [=ordered set=].


### PR DESCRIPTION
Two lines appear to be in the wrong order.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/1123.html" title="Last updated on Apr 12, 2024, 6:27 PM UTC (bd0dfdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1123/673e729...caraitto:bd0dfdb.html" title="Last updated on Apr 12, 2024, 6:27 PM UTC (bd0dfdb)">Diff</a>