### PR TITLE
Spec update for ad size entries in ScoringBrowserSignals and BiddingBrowserSignals.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1466,7 +1466,7 @@ and a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
-  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/requested size}}"] to the result of running the [=convert an ad size to a map=] on [=auction config/requested size=].
+  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the [=convert an ad size to a map=] on [=auction config/requested size=].
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.

--- a/spec.bs
+++ b/spec.bs
@@ -1579,7 +1579,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/topWindowHostname}}"] to |topLevelHost|.
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/seller}}"] to the [=serialization of an
   origin|serialization=] of |seller|.
-1. If |auctionConfig|'s [=auction config/requested size=] is not null, [=map/Set=] 
+1. If |auctionConfig|'s [=auction config/requested size=] is not null, [=map/set=] 
    |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the
    [=convert an ad size to a map=] on |auctionConfig|'s [=auction config/requested size=].
 1. Let |auctionLevel| be "single-level-auction".

--- a/spec.bs
+++ b/spec.bs
@@ -4773,12 +4773,12 @@ dictionary ScoringBrowserSignals {
   To <dfn>convert an ad size to a map</dfn> given an [=ad size=] |adSize|:
   
   1. Let |dict| be a new empty [=map=].
-  1. Let |widthStr| be a new empty [=string=].
   1. Let |jsWidth| be |adSize|'s [=ad size/width=], [=converted to an ECMAScript value=].
-  1. [=map/Set=] |dict|["width"] to the result of [=string/concatenating=] « [$ToString$](|jsWidth|), |adSize|'s [=ad size/width units=] ».
-  1. Let |heightStr| be a new empty [=string=].
+  1. [=map/Set=] |dict|["width"] to the result of [=string/concatenating=] « [$ToString$](|jsWidth|),
+     |adSize|'s [=ad size/width units=] ».
   1. Let |jsHeight| be |adSize|'s [=ad size/height=], [=converted to an ECMAScript value=].
-  1. [=map/Set=] |dict|["height"] to the result of [=string/concatenating=] « [$ToString$](|jsHeight|), |adSize|'s [=ad size/height units=] ».
+  1. [=map/Set=] |dict|["height"] to the result of [=string/concatenating=] « [$ToString$](|jsHeight|),
+     |adSize|'s [=ad size/height units=] ».
   1. return |dict|.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -4779,7 +4779,8 @@ dictionary ScoringBrowserSignals {
   1. Let |jsHeight| be |adSize|'s [=ad size/height=], [=converted to an ECMAScript value=].
   1. [=map/Set=] |dict|["height"] to the result of [=string/concatenating=] « [$ToString$](|jsHeight|),
      |adSize|'s [=ad size/height units=] ».
-  1. return |dict|.
+  1. Return |dict|.
+
 </div>
 
 Note: {{ScoringBrowserSignals}}'s {{ScoringBrowserSignals/adComponents}} is {{undefined}} when

--- a/spec.bs
+++ b/spec.bs
@@ -4786,15 +4786,9 @@ dictionary ScoringBrowserSignals {
   1. return |dict|.
 </div>
 
-Note: {{ScoringBrowserSignals}}'s {{BiddingBrowserSignals/requestedSize}} is {{undefined}} when
-[=auction config/requested size=] is null.
-
 Note: {{ScoringBrowserSignals}}'s {{ScoringBrowserSignals/adComponents}} is {{undefined}} when
 [=generated bid/ad component descriptors=] is null or [=list/is empty|an empty list=]. It cannot be
 an [=list/is empty|empty list=].
-
-Note: {{ScoringBrowserSignals}}'s {{ScoringBrowserSignals/renderSize}} is {{undefined}} when
-[=generated bid/ad descriptor=]'s [=ad descriptor/size=] is null.
 
 <xmp class="idl">
 dictionary ReportingBrowserSignals {

--- a/spec.bs
+++ b/spec.bs
@@ -1580,7 +1580,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/seller}}"] to the [=serialization of an
   origin|serialization=] of |seller|.
 1. If |auctionConfig|'s [=auction config/requested size=] is not null, [=map/set=] 
-   |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the
+   |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running
+
    [=convert an ad size to a map=] with |auctionConfig|'s [=auction config/requested size=].
 1. Let |auctionLevel| be "single-level-auction".
 1. Let |componentAuctionExpectedCurrency| be null.

--- a/spec.bs
+++ b/spec.bs
@@ -1466,7 +1466,10 @@ and a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
-  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the [=convert an ad size to a map=] on [=auction config/requested size=].
+  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to
+     {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=]
+     |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the
+     [=convert an ad size to a map=] on [=auction config/requested size=].
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.
@@ -1925,8 +1928,9 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dt>{{ScoringBrowserSignals/renderURL}}
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
-      <dt>{{ScoringBrowserSignals/renderSize}} <dd>The result of running the [=convert an ad size to
-      a map=] on |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
+    <dt>{{ScoringBrowserSignals/renderSize}}
+    <dd>The result of running the [=convert an ad size to a map=] on |generatedBid|'s 
+      [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]
     <dt>{{ScoringBrowserSignals/bidCurrency}}

--- a/spec.bs
+++ b/spec.bs
@@ -1466,7 +1466,11 @@ and a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
-  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/requested size}}"] to the result of running the [=convert an ad size to a map=] on [=auction config/requested size=].
+ 1. If
+  [=auction config/requested size=] of the {{AuctionAdConfig}} passed to
+  {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=]
+  |browserSignals|["{{BiddingBrowserSignals/requested size}}"] to the result of running the
+  [=convert an ad size to a map=] on [=auction config/requested size=].
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.
@@ -1925,8 +1929,8 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dt>{{ScoringBrowserSignals/renderURL}}
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
-    <dt>{{ScoringBrowserSignals/renderSize}}
-    <dd>The result of running the [=convert an ad size to a map=] on |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
+      <dt>{{ScoringBrowserSignals/renderSize}} <dd>The result of running the [=convert an ad size to
+      a map=] on |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]
     <dt>{{ScoringBrowserSignals/bidCurrency}}
@@ -4770,11 +4774,11 @@ dictionary ScoringBrowserSignals {
   To <dfn>convert an ad size to a map</dfn> given an [=ad size=] |adSize|:
   
   1. Let |dict| be a new empty [=map=].
-  1. Let |widthStr| be a new empty [=string=]
+  1. Let |widthStr| be a new empty [=string=].
   1. Let |jsWidth| be |adSize|'s [=ad size/width=], [=converted to an ECMAScript value=].
   1. Append [$ToString$](|jsWidth|) to |widthStr|.
   1. Append |adSize|'s [=ad size/width units=] to |widthStr|.
-  1. Let |heightStr| be a new empty [=string=]
+  1. Let |heightStr| be a new empty [=string=].
   1. Let |jsHeight| be |adSize|'s [=ad size/height=], [=converted to an ECMAScript value=].
   1. Append [$ToString$](|jsHeight|) to |heightStr|.
   1. Append |adSize|'s [=ad size/height units=] to |heightStr|.

--- a/spec.bs
+++ b/spec.bs
@@ -1581,7 +1581,6 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   origin|serialization=] of |seller|.
 1. If |auctionConfig|'s [=auction config/requested size=] is not null, [=map/set=] 
    |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running
-
    [=convert an ad size to a map=] with |auctionConfig|'s [=auction config/requested size=].
 1. Let |auctionLevel| be "single-level-auction".
 1. Let |componentAuctionExpectedCurrency| be null.
@@ -1930,7 +1929,6 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
     <dt>{{ScoringBrowserSignals/renderSize}}
     <dd>The result of running [=convert an ad size to a map=] with |generatedBid|'s
-
         [=generated bid/ad descriptor=]'s [=ad descriptor/size=] if it is not null, {{undefined}} otherwise
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]

--- a/spec.bs
+++ b/spec.bs
@@ -1924,6 +1924,8 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dt>{{ScoringBrowserSignals/renderURL}}
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
+    <dt>{{ScoringBrowserSignals/renderSize}}
+    <dd>The |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]
     <dt>{{ScoringBrowserSignals/bidCurrency}}
@@ -4752,6 +4754,7 @@ dictionary ScoringBrowserSignals {
   required DOMString topWindowHostname;
   required USVString interestGroupOwner;
   required USVString renderURL;
+  record<DOMString, DOMString> renderSize;
   required unsigned long biddingDurationMsec;
   required DOMString bidCurrency;
 
@@ -4764,6 +4767,9 @@ dictionary ScoringBrowserSignals {
 Note: {{ScoringBrowserSignals}}'s {{ScoringBrowserSignals/adComponents}} is {{undefined}} when
 [=generated bid/ad component descriptors=] is null or [=list/is empty|an empty list=]. It cannot be
 an [=list/is empty|empty list=].
+
+Note: {{ScoringBrowserSignals}}'s {{ScoringBrowserSignals/renderSize}} is {{undefined}} when
+[=generated bid/ad descriptor=]'s [=ad descriptor/size=] is null.
 
 <xmp class="idl">
 dictionary ReportingBrowserSignals {

--- a/spec.bs
+++ b/spec.bs
@@ -1928,8 +1928,8 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
     <dt>{{ScoringBrowserSignals/renderSize}}
-    <dd>The result of running the [=convert an ad size to a map=] on |generatedBid|'s 
-      [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
+    <dd>The result of running the [=convert an ad size to a map=] on |generatedBid|'s
+        [=generated bid/ad descriptor=]'s [=ad descriptor/size=] if it is not null, {{undefined}} otherwise
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]
     <dt>{{ScoringBrowserSignals/bidCurrency}}

--- a/spec.bs
+++ b/spec.bs
@@ -1928,7 +1928,8 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
     <dt>{{ScoringBrowserSignals/renderSize}}
-    <dd>The result of running the [=convert an ad size to a map=] with |generatedBid|'s
+    <dd>The result of running [=convert an ad size to a map=] with |generatedBid|'s
+
         [=generated bid/ad descriptor=]'s [=ad descriptor/size=] if it is not null, {{undefined}} otherwise
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]

--- a/spec.bs
+++ b/spec.bs
@@ -1466,11 +1466,7 @@ and a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
- 1. If
-  [=auction config/requested size=] of the {{AuctionAdConfig}} passed to
-  {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=]
-  |browserSignals|["{{BiddingBrowserSignals/requested size}}"] to the result of running the
-  [=convert an ad size to a map=] on [=auction config/requested size=].
+  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/requested size}}"] to the result of running the [=convert an ad size to a map=] on [=auction config/requested size=].
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.

--- a/spec.bs
+++ b/spec.bs
@@ -1581,7 +1581,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
   origin|serialization=] of |seller|.
 1. If |auctionConfig|'s [=auction config/requested size=] is not null, [=map/set=] 
    |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the
-   [=convert an ad size to a map=] on |auctionConfig|'s [=auction config/requested size=].
+   [=convert an ad size to a map=] with |auctionConfig|'s [=auction config/requested size=].
 1. Let |auctionLevel| be "single-level-auction".
 1. Let |componentAuctionExpectedCurrency| be null.
 1. If |topLevelAuctionConfig| is not null:

--- a/spec.bs
+++ b/spec.bs
@@ -1466,6 +1466,7 @@ and a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
+  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/requested size}}"] to the result of running the [=convert an ad size to a map=] on [=auction config/requested size=].
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.
@@ -1925,7 +1926,7 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
     <dt>{{ScoringBrowserSignals/renderSize}}
-    <dd>The |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
+    <dd>The result of running the [=convert an ad size to a map=] on |generatedBid|'s [=generated bid/ad descriptor=]'s [=ad descriptor/size=]
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]
     <dt>{{ScoringBrowserSignals/bidCurrency}}
@@ -4743,6 +4744,7 @@ dictionary BiddingBrowserSignals {
   required long recency;
   required long adComponentsLimit;
 
+  record<DOMString, DOMString> requestedSize;
   USVString topLevelSeller;
   sequence<PreviousWin> prevWinsMs;
   object wasmHelper;
@@ -4754,15 +4756,35 @@ dictionary ScoringBrowserSignals {
   required DOMString topWindowHostname;
   required USVString interestGroupOwner;
   required USVString renderURL;
-  record<DOMString, DOMString> renderSize;
   required unsigned long biddingDurationMsec;
   required DOMString bidCurrency;
 
+  record<DOMString, DOMString> renderSize;
   unsigned long dataVersion;
   sequence<USVString> adComponents;
   boolean forDebuggingOnlyInCooldownOrLockout = false;
 };
 </xmp>
+
+<div algorithm>
+  To <dfn>convert an ad size to a map</dfn> given an [=ad size=] |adSize|:
+  
+  1. Let |dict| be a new empty [=map=].
+  1. Let |widthStr| be a new empty [=string=]
+  1. Let |jsWidth| be |adSize|'s [=ad size/width=], [=converted to an ECMAScript value=].
+  1. Append [$ToString$](|jsWidth|) to |widthStr|.
+  1. Append |adSize|'s [=ad size/width units=] to |widthStr|.
+  1. Let |heightStr| be a new empty [=string=]
+  1. Let |jsHeight| be |adSize|'s [=ad size/height=], [=converted to an ECMAScript value=].
+  1. Append [$ToString$](|jsHeight|) to |heightStr|.
+  1. Append |adSize|'s [=ad size/height units=] to |heightStr|.
+  1. [=map/Set=] |dict|["width"] to |widthStr|.
+  1. [=map/Set=] |dict|["heigth"] to |heightStr|.
+  1. return |dict|.
+</div>
+
+Note: {{ScoringBrowserSignals}}'s {{BiddingBrowserSignals/requestedSize}} is {{undefined}} when
+[=auction config/requested size=] is null.
 
 Note: {{ScoringBrowserSignals}}'s {{ScoringBrowserSignals/adComponents}} is {{undefined}} when
 [=generated bid/ad component descriptors=] is null or [=list/is empty|an empty list=]. It cannot be

--- a/spec.bs
+++ b/spec.bs
@@ -1466,10 +1466,6 @@ and a [=moment=] |auctionStartTime|:
     1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
     1. [=list/Append=] |prevWinIDL| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
-  1. If [=auction config/requested size=] of the {{AuctionAdConfig}} passed to
-     {{Window/navigator}}.{{Navigator/runAdAuction()}} is not null, [=map/Set=]
-     |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the
-     [=convert an ad size to a map=] on [=auction config/requested size=].
   1. Let |biddingScript| be the result of [=fetching script=] with |ig|'s
     [=interest group/bidding url=].
   1. If |biddingScript| is failure, return failure.
@@ -1583,6 +1579,9 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/topWindowHostname}}"] to |topLevelHost|.
 1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/seller}}"] to the [=serialization of an
   origin|serialization=] of |seller|.
+1. If |auctionConfig|'s [=auction config/requested size=] is not null, [=map/Set=] 
+   |browserSignals|["{{BiddingBrowserSignals/requestedSize}}"] to the result of running the
+   [=convert an ad size to a map=] on |auctionConfig|'s [=auction config/requested size=].
 1. Let |auctionLevel| be "single-level-auction".
 1. Let |componentAuctionExpectedCurrency| be null.
 1. If |topLevelAuctionConfig| is not null:
@@ -4778,11 +4777,11 @@ dictionary ScoringBrowserSignals {
   1. Let |jsWidth| be |adSize|'s [=ad size/width=], [=converted to an ECMAScript value=].
   1. Append [$ToString$](|jsWidth|) to |widthStr|.
   1. Append |adSize|'s [=ad size/width units=] to |widthStr|.
+  1. [=map/Set=] |dict|["width"] to |widthStr|.
   1. Let |heightStr| be a new empty [=string=].
   1. Let |jsHeight| be |adSize|'s [=ad size/height=], [=converted to an ECMAScript value=].
   1. Append [$ToString$](|jsHeight|) to |heightStr|.
   1. Append |adSize|'s [=ad size/height units=] to |heightStr|.
-  1. [=map/Set=] |dict|["width"] to |widthStr|.
   1. [=map/Set=] |dict|["heigth"] to |heightStr|.
   1. return |dict|.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -1928,7 +1928,7 @@ or "component-auction", a [=currency tag=] |componentAuctionExpectedCurrency|, a
     <dd>The result of running the [=URL serializer=] on |generatedBid|'s
       [=generated bid/ad descriptor=]'s [=ad descriptor/url=]
     <dt>{{ScoringBrowserSignals/renderSize}}
-    <dd>The result of running the [=convert an ad size to a map=] on |generatedBid|'s
+    <dd>The result of running the [=convert an ad size to a map=] with |generatedBid|'s
         [=generated bid/ad descriptor=]'s [=ad descriptor/size=] if it is not null, {{undefined}} otherwise
     <dt>{{ScoringBrowserSignals/biddingDurationMsec}}
     <dd>|generatedBid|'s [=generated bid/bid duration=]

--- a/spec.bs
+++ b/spec.bs
@@ -4775,14 +4775,10 @@ dictionary ScoringBrowserSignals {
   1. Let |dict| be a new empty [=map=].
   1. Let |widthStr| be a new empty [=string=].
   1. Let |jsWidth| be |adSize|'s [=ad size/width=], [=converted to an ECMAScript value=].
-  1. Append [$ToString$](|jsWidth|) to |widthStr|.
-  1. Append |adSize|'s [=ad size/width units=] to |widthStr|.
-  1. [=map/Set=] |dict|["width"] to |widthStr|.
+  1. [=map/Set=] |dict|["width"] to the result of [=string/concatenating=] « [$ToString$](|jsWidth|), |adSize|'s [=ad size/width units=] ».
   1. Let |heightStr| be a new empty [=string=].
   1. Let |jsHeight| be |adSize|'s [=ad size/height=], [=converted to an ECMAScript value=].
-  1. Append [$ToString$](|jsHeight|) to |heightStr|.
-  1. Append |adSize|'s [=ad size/height units=] to |heightStr|.
-  1. [=map/Set=] |dict|["heigth"] to |heightStr|.
+  1. [=map/Set=] |dict|["height"] to the result of [=string/concatenating=] « [$ToString$](|jsHeight|), |adSize|'s [=ad size/height units=] ».
   1. return |dict|.
 </div>
 


### PR DESCRIPTION
1. The [explainer](https://github.com/WICG/turtledove/blob/main/FLEDGE.md#23-scoring-bids) states the browserSignals argument of scoreAd function contains an optional member `renderSize`. However, this has not been spec'd.  This PR adds `renderSize` to the spec. See #1088.

2. Similarly, the [requestedSize](https://github.com/WICG/turtledove/blob/main/FLEDGE.md?plain=1#L777) for [biddingBrowserSignals](https://wicg.github.io/turtledove/#dictdef-biddingbrowsersignals) is also missing from the spec. 

Both `renderSize` and `requestedSize` code examples in explainer are missing size units. See explainer update PR: #1145


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xiaochen-z/turtledove/pull/1141.html" title="Last updated on Apr 25, 2024, 1:47 PM UTC (959538a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1141/5f869e1...xiaochen-z:959538a.html" title="Last updated on Apr 25, 2024, 1:47 PM UTC (959538a)">Diff</a>