### PR TITLE
Spec: Factor out trusted bidding signals batcher...

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1677,7 +1677,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. Let |directFromSellerSignalsForBuyer| be the result of running
             [=get direct from seller signals for a buyer=] with |directFromSellerSignals|, and |ig|'s
             [=interest group/owner=].
-          1. Let |dataVersion| be [=map/get=] |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data versions=]
+          1. Let |dataVersion| be |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data versions=]
              [|ig|'s [=interest group/name=]].
           1. If |dataVersion| is not null, then [=map/set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
           1. Otherwise, [=map/remove=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"].
@@ -5381,8 +5381,8 @@ into smaller number of fetches. It's a [=struct=] with the following [=struct/it
   :: An [=ordered set=] of [=strings=]. Describes the interest group names to be fetched in the
      current batch thus far.
   : <dfn>length limit</dfn>
-  :: A {{long}}, initially the maximum value that it can hold. Describes the URL length limit
-     the current batch is limited to, the smallest of the limits of the interest groups included.
+  :: A {{long}}, initially 2147483647 (the maximum value that it can hold). Describes the URL length
+     limit the current batch is limited to, the smallest of the limits of the interest groups included.
 </dl>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -5300,7 +5300,7 @@ representing [=interest group/joining origins=], and whose [=map/values=] are [=
 <h3 id=trusted-bidder-signals-batcher>Trusted bidding signals batcher</h3>
 
 A <dfn>trusted bidding signals batcher</dfn> helps manage merging multiple trusted bidding signals
-into smaller number of fetches. It's a [=struct=] with the following  [=struct/items=]:
+into smaller number of fetches. It's a [=struct=] with the following [=struct/items=]:
 
 <dl dfn-for="trusted bidding signals batcher">
   : <dfn>all trusted bidding signals</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -1650,12 +1650,7 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. [=Batch or fetch trusted bidding signals=] given |trustedBiddingSignalsBatcher|,
             |ig|, |signalsUrl|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
         1. [=Fetch the current outstanding trusted signals batch=] given |trustedBiddingSignalsBatcher|,
-            |ig|, |signalsUrl|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
-      1. Let |allTrustedBiddingSignals| be |trustedBiddingSignalsBatcher|'s
-        [=trusted bidding signals batcher/all trusted bidding signals=].
-      1. Let |dataVersion| be |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data version=].
-      1. If |dataVersion| is not null, then [=map/set=]
-        |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
+            |signalsUrl|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
       1. Let |fetchSignalDuration| be the [=duration from=] |fetchSignalStartTime| to |settings|'s
         [=environment settings object/current monotonic time=], in milliseconds.
       1. If |perBuyerCumulativeTimeout| is not null, then decrement |perBuyerCumulativeTimeout| by
@@ -1671,7 +1666,12 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
           1. Let |directFromSellerSignalsForBuyer| be the result of running
             [=get direct from seller signals for a buyer=] with |directFromSellerSignals|, and |ig|'s
             [=interest group/owner=].
-          1. Let « |generatedBid|, |bidDebugReportInfo| » be the result of [=generate a bid=] given |allTrustedBiddingSignals|,
+          1. Let |dataVersion| be [=map/get=] |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data versions=]
+             [|ig|'s [=interest group/name=]].
+          1. If |dataVersion| is not null, then [=map/set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
+          1. Otherwise, [=map/remove=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"].
+          1. Let « |generatedBid|, |bidDebugReportInfo| » be the result of [=generate a bid=] given
+            |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/all trusted bidding signals=],
             |auctionSignals|, a [=map/clone=] of |browserSignals|, |perBuyerSignals|,
             |directFromSellerSignalsForBuyer|, |perBuyerTimeout|, |expectedCurrency|, |ig|, and
             |auctionStartTime|.
@@ -1725,7 +1725,8 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
             1. Let |generateBidStartTime| be |settings|'s
               [=environment settings object/current monotonic time=].
             1. Set « |generatedBid|, |bidDebugReportInfo| » to the result of [=generate a bid=] given
-              |allTrustedBiddingSignals|, |auctionSignals|, a [=map/clone=] of |browserSignals|,
+              |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/all trusted bidding signals=],
+              |auctionSignals|, a [=map/clone=] of |browserSignals|,
               |perBuyerSignals|, |directFromSellerSignalsForBuyer|, |perBuyerTimeout|,
               |expectedCurrency|, |ig|, and |auctionStartTime|.
             1. Set |ig|'s [=interest group/ads=] to |originalAds|.
@@ -5306,8 +5307,10 @@ into smaller number of fetches. It's a [=struct=] with the following [=struct/it
   : <dfn>all trusted bidding signals</dfn>
   :: An [=ordered map=] whose [=map/keys=] are [=strings=], and [=map/values=] are [=strings=].
      Contains all trusted bidding signals collected thus far.
-  : <dfn>data version</dfn>
-  :: An {{unsigned long}} or null, initially null. Data version number provided by the last fetch.
+  : <dfn>data versions</dfn>
+  :: An [=ordered map=] who [=map/keys=] are [=strings=] and [=map/values=] are
+    {{unsigned long}} or null. This contains data version returned by a fetch that provided the
+    values for a given interest group name.
   : <dfn>keys</dfn>
   :: An [=ordered set=] of [=strings=]. Describes the keys collected to be fetched in the current
      batch thus far.
@@ -5334,7 +5337,8 @@ and a [=string=] |slotSizeQueryParam|:
   1. [=map/For each=] |key| → |value| in |partialTrustedBiddingSignals|:
     1. Set |trustedBiddingSignalsBatcher|'s
       [=trusted bidding signals batcher/all trusted bidding signals=][|key|] to |value|.
-  1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data version=] to |dataVersion|.
+  1. [=set/For each=] |igName| item of |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=]:
+    1. [=map/Set=] |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data versions=][|igName|] to |dataVersion|.
 </div>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -1643,47 +1643,17 @@ To <dfn>generate and score bids</dfn> given an [=auction config=] |auctionConfig
     to the result of running [=is debugging only in cooldown or lockout=] with |buyer|.
   1. [=map/For each=] |slotSizeQueryParam| → |perSlotSizeQueryParam| of |perBuyerGenerator|:
     1. [=map/For each=] |signalsUrl| → |perSignalsUrlGenerator| of |perSlotSizeQueryParam|:
-      1. Let |allTrustedBiddingSignals| be an [=ordered map=] whose [=map/keys=] are [=strings=],
-        and [=map/values=] are [=strings=].
-      1. Let |keys| be a new [=ordered set=].
-      1. Let |igNames| be a new [=ordered set=].
-      1. Let |lengthLimit| be the maximum value that a {{long}} integer can hold.
+      1. Let |trustedBiddingSignalsBatcher| be a new [=trusted bidding signals batcher=].
       1. Let |fetchSignalStartTime| be |settings|'s [=environment settings object/current monotonic time=].
       1. [=map/For each=] joiningOrigin → |groups| of |perSignalsUrlGenerator|:
         1. [=list/For each=] |ig| of |groups|:
-          1. Let |putativeKeys| be a [=set/clone=] of |keys|.
-          1. Let |putativeIgNames| be a [=set/clone=] of |igNames|.
-          1. Let |putativeLengthLimit| be  |ig|'s [=interest group/max trusted bidding signals url length=].
-          1. If |ig|'s [=interest group/max trusted bidding signals url length=] is 0 or `&gt;`
-            |lengthLimit|, then set |putativeLengthLimit| to |lengthLimit|.
-          1. [=list/Extend=] |putativeKeys| with |ig|'s [=interest group/trusted bidding signals keys=].
-          1. [=list/Append=] |ig|'s [=interest group/name=] to |putativeIgNames|.
-
-          1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
-            |signalsUrl|, |putativeKeys|, |putativeIgNames|, |buyerExperimentGroupId|, |topLevelOrigin|, and
-            |slotSizeQueryParam|.
-          1. If [=URL serializer|serialized=] |biddingSignalsUrl|'s [=string/length=] &le; |putativeLengthLimit|:
-
-              1. Set |keys| to |putativeKeys|.
-              1. Set |igNames| to |putativeIgNames|.
-              1. Set |lengthLimit| to |putativeLengthLimit|.
-          1. Otherwise:
-            1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
-              |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
-            1. Let « |partialTrustedBiddingSignals|, |dataVersion| » be the result of [=fetching trusted signals=]
-              with |biddingSignalsUrl| and true.
-            1. [=map/For each=] |key| → |value| in |partialTrustedBiddingSignals|:
-
-              1. Set |allTrustedBiddingSignals|[|key|] to |value|.
-            1. Set |keys| to a [=list/clone=] of |ig|'s [=interest group/trusted bidding signals keys=].
-            1. Set |igNames| to « |ig|'s [=interest group/name=] ».
-            1. Set |ig|'s [=interest group/max trusted bidding signals url length=] to |lengthLimit|.
-        1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
-          |signalsUrl|, |keys|, |igNames|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
-        1. Let « |partialTrustedBiddingSignals|, |dataVersion| » be the result of [=fetching trusted signals=]
-          with |biddingSignalsUrl| and true.
-        1. [=map/For each=] |key| → |value| in |partialTrustedBiddingSignals|:
-          1. Set |allTrustedBiddingSignals|[|key|] to |value|.
+          1. [=Batch or fetch trusted bidding signals=] given |trustedBiddingSignalsBatcher|,
+            |ig|, |signalsUrl|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
+        1. [=Fetch the current outstanding trusted signals batch=] given |trustedBiddingSignalsBatcher|,
+            |ig|, |signalsUrl|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
+      1. Let |allTrustedBiddingSignals| be |trustedBiddingSignalsBatcher|'s
+        [=trusted bidding signals batcher/all trusted bidding signals=].
+      1. Let |dataVersion| be |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data version=].
       1. If |dataVersion| is not null, then [=map/set=]
         |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to |dataVersion|.
       1. Let |fetchSignalDuration| be the [=duration from=] |fetchSignalStartTime| to |settings|'s
@@ -5326,6 +5296,84 @@ representing [=interest group/trusted bidding signals urls=], and whose [=map/va
 A <dfn>per signals url bid generator</dfn> is an [=ordered map=] whose [=map/keys=] are [=origins=]
 representing [=interest group/joining origins=], and whose [=map/values=] are [=lists=] of
 [=interest groups=].
+
+<h3 id=trusted-bidder-signals-batcher>Trusted bidding signals batcher</h3>
+
+A <dfn>trusted bidding signals batcher</dfn> helps manage merging multiple trusted bidding signals
+into smaller number of fetches. It's a [=struct=] with the following  [=struct/items=]:
+
+<dl dfn-for="trusted bidding signals batcher">
+  : <dfn>all trusted bidding signals</dfn>
+  :: An [=ordered map=] whose [=map/keys=] are [=strings=], and [=map/values=] are [=strings=].
+     Contains all trusted bidding signals collected thus far.
+  : <dfn>data version</dfn>
+  :: An {{unsigned long}} or null, initially null. Data version number provided by the last fetch.
+  : <dfn>keys</dfn>
+  :: An [=ordered set=] of [=strings=]. Describes the keys collected to be fetched in the current
+     batch thus far.
+  : <dfn>ig names</dfn>
+  :: An [=ordered set=] of [=strings=]. Describes the interest group names to be fetched in the
+     current batch thus far.
+  : <dfn>length limit</dfn>
+  :: A {{long}}, initially the maximum value that it can hold. Describes the URL length limit
+     the current batch is limited to, the smallest of the limits of the interest groups included.
+</dl>
+
+<div algorithm>
+To <dfn>fetch the current outstanding trusted signals batch</dfn> given a
+[=trusted bidding signals batcher=] |trustedBiddingSignalsBatcher|, a [=URL=] |signalsUrl|, an
+{{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|,
+and a [=string=] |slotSizeQueryParam|:
+
+  1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
+     |signalsUrl|, |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=],
+     |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=],
+     |experimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
+  1. Let « |partialTrustedBiddingSignals|, |dataVersion| » be the result of [=fetching trusted signals=]
+     with |biddingSignalsUrl| and true.
+  1. [=map/For each=] |key| → |value| in |partialTrustedBiddingSignals|:
+    1. Set |trustedBiddingSignalsBatcher|'s
+      [=trusted bidding signals batcher/all trusted bidding signals=][|key|] to |value|.
+  1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/data version=] to |dataVersion|.
+</div>
+
+<div algorithm>
+To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding signals batcher=]
+|trustedBiddingSignalsBatcher|, [=interest group=] |ig|, a [=URL=] |signalsUrl|, an
+{{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|,
+and a [=string=] |slotSizeQueryParam|:
+
+  1. Let |putativeKeys| be a [=set/clone=] of |trustedBiddingSignalsBatcher|'s
+     [=trusted bidding signals batcher/keys=].
+  1. Let |putativeIgNames| be a [=set/clone=] of |trustedBiddingSignalsBatcher|'s
+     [=trusted bidding signals batcher/ig names=].
+  1. Let |putativeLengthLimit| be  |ig|'s [=interest group/max trusted bidding signals url length=].
+  1. If |ig|'s [=interest group/max trusted bidding signals url length=] is 0 or &gt;
+    |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=],
+    then set |putativeLengthLimit| to |trustedBiddingSignalsBatcher|'s
+    [=trusted bidding signals batcher/length limit=].
+  1. [=list/Extend=] |putativeKeys| with |ig|'s [=interest group/trusted bidding signals keys=].
+  1. [=list/Append=] |ig|'s [=interest group/name=] to |putativeIgNames|.
+  1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
+    |signalsUrl|, |putativeKeys|, |putativeIgNames|, |experimentGroupId|, |topLevelOrigin|, and
+    |slotSizeQueryParam|.
+  1. If [=URL serializer|serialized=] |biddingSignalsUrl|'s [=string/length=] &le; |putativeLengthLimit|:
+      1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to |putativeKeys|.
+      1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=] to
+        |putativeIgNames|.
+      1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=] to
+        |putativeLengthLimit|.
+  1. Otherwise:
+    1. [=Fetch the current outstanding trusted signals batch=] given |trustedBiddingSignalsBatcher|,
+      |signalsUrl|, |experimentGroupId|, |topLevelOrigin|, |slotSizeQueryParam|.
+    1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to a
+      [=list/clone=] of |ig|'s [=interest group/trusted bidding signals keys=].
+    1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=] to
+        « |ig|'s [=interest group/name=] ».
+    1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=] to
+      |ig|'s [=interest group/max trusted bidding signals url length=].
+
+</div>
 
 <h3 id=generated-bid-header>Generated bid</h3>
 


### PR DESCRIPTION
...to separate struct + routines, since it's a non-trivial piece of code in the middle of a complicated algorithm, and I am about to make it a bit more complicated still.

Also fix a bug in data-version handling: If different data versions are returned during the various fetches, route them to the appropriate IG rather than using the last version for everything.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1163.html" title="Last updated on May 13, 2024, 6:43 PM UTC (e37f0e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1163/42a65c5...morlovich:e37f0e7.html" title="Last updated on May 13, 2024, 6:43 PM UTC (e37f0e7)">Diff</a>