### PR TITLE
Spec: fix missing queryFeatureSupport values, and refactor it

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -4399,7 +4399,6 @@ The <dfn for=ProtectedAudience method>queryFeatureSupport(feature)</dfn> method 
     :: true
     :   "reportingTimeout"
     :: true
-1. If |feature| is "*", then return |featuresTable|.
 1. If |featuresTable|[|feature|] [=map/exists=], then return |featuresTable|[|feature|].
 1. Return `undefined`.
 

--- a/spec.bs
+++ b/spec.bs
@@ -4391,8 +4391,8 @@ interface ProtectedAudience {
 <div algorithm>
 
 The <dfn for=ProtectedAudience method>queryFeatureSupport(feature)</dfn> method steps are:
-1. Let |featuresTable| be an [=ordered map=] whose keys are {{DOMString}} and whose values are
-   {{boolean}} or {{long}}, with the following entries:
+1. Let |featuresTable| be an [=ordered map=] whose keys are {{DOMString}}s and whose values are
+   {{boolean}}s or {{long}}s, with the following entries:
     :   "adComponentsLimit"
     ::  40
     :   "deprecatedRenderURLReplacements"

--- a/spec.bs
+++ b/spec.bs
@@ -4391,8 +4391,17 @@ interface ProtectedAudience {
 <div algorithm>
 
 The <dfn for=ProtectedAudience method>queryFeatureSupport(feature)</dfn> method steps are:
-1. If feature is "adComponentsLimit", return 40.
-2. Return `undefined`.
+1. Let |featuresTable| be an [=ordered map=] whose keys are {{DOMString}} and whose values are
+   {{boolean}} or {{long}}, with the following entries:
+    :   "adComponentsLimit"
+    ::  40
+    :   "deprecatedRenderURLReplacements"
+    :: true
+    :   "reportingTimeout"
+    :: true
+1. If |feature| is "*", then return |featuresTable|.
+1. If |featuresTable|[|feature|] [=map/exists=], then return |featuresTable|[|feature|].
+1. Return `undefined`.
 
 </div>
 


### PR DESCRIPTION
...in prep for supporting queryFeatureSupport('*'), which is just one line under this formalism, 
but which I think we aren't ready for yet process-wise.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1173.html" title="Last updated on May 14, 2024, 5:17 PM UTC (a118460)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1173/42a65c5...morlovich:a118460.html" title="Last updated on May 14, 2024, 5:17 PM UTC (a118460)">Diff</a>