### PR TITLE
Spec: split up response validation into two stages, and fix a bug in it

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2104,7 +2104,7 @@ failure, or a [=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
       "`application/wasm`".
 
       Note: This was intended to match the behavior of [=compiling a potential WebAssembly
-      response=], but ended up more restrictive of whitespace.
+      response=], but diverges by failing to remove leading and trailing HTTP whitespace.
 
   1. If |mimeType| is not "`application/wasm`":
     1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].

--- a/spec.bs
+++ b/spec.bs
@@ -2078,23 +2078,44 @@ The <dfn http-header><code>Ad-Auction-Allowed</code></dfn> HTTP response header 
 [=structured header=] whose value must be a [=structured header/boolean=].
 
 <div algorithm>
-To <dfn>validate fetching response</dfn> given a [=response=] |response|, null, failure, or a
-[=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
+To <dfn>validate fetching response headers</dfn> given a [=response=] |response|:
+
+  1. If [=header list/getting a structured field value|getting=] [:Ad-Auction-Allowed:] and
+     "`item`" from |response|'s [=response/header list=] does not return a true value, return false.
+  1. If |response|'s [=response/status=] is not an [=ok status=], return false.
+  1. Return true.
+</div>
+
+<div algorithm>
+To <dfn>validate fetching response mime and body</dfn> given a [=response=] |response|, null,
+failure, or a [=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
 
   1. If |responseBody| is null or failure, return false.
-  1. If [=header list/getting a structured field value|getting=] [:Ad-Auction-Allowed:] and
-    "`item`" from |response|'s [=response/header list=] does not return a true value, return false.
   1. Let |headerMimeType| be the result of [=header list/extracting a MIME type=] from |response|'s
     [=response/header list=].
   1. Return false if any of the following conditions hold:
     * |headerMimeType| is failure;
     * |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=];
     * |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
-  1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-  1. Return false if any of the following conditions hold:
-    * |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and |responseBody|
-      is not [=UTF-8=] encoded;
-    * |mimeTypeCharset| is "us-ascii", and not all bytes in |responseBody| are [=ASCII bytes=].
+    * |mimeType| is "`application/wasm`" and |headerMimeType|'s [=MIME type/essence=] is not
+      "`application/wasm`".
+  1. If |mimeType| is not "`application/wasm`":
+    1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
+    1. Return false if any of the following conditions hold:
+      * |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and |responseBody|
+        is not [=UTF-8=] encoded;
+      * |mimeTypeCharset| is "us-ascii", and not all bytes in |responseBody| are [=ASCII bytes=].
+  1. Return true.
+</div>
+
+<div algorithm>
+To <dfn>validate fetching response</dfn> given a [=response=] |response|, null, failure, or a
+[=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
+
+  1. If the result of [=validating fetching response headers=] given |response| is false, then
+     return false.
+  1. If the result of [=validating fetching response mime and body=] given |response|,
+     |responseBody|, |mimeType| is false, the return false.
   1. Return true.
 </div>
 
@@ -2159,10 +2180,8 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url|:
   1. Let |moduleObject| be null.
   1. [=Fetch=] |request| with [=fetch/processResponseConsumeBody=] set to the following steps given
     a [=response=] |response| and null, failure, or a [=byte sequence=] |responseBody|:
-    1. Set |moduleObject| to failure and return, if any of the following conditions hold:
-      * |responseBody| is null or failure;
-      * [=header list/getting a structured field value|Getting=] [:Ad-Auction-Allowed:] and "`item`"
-        from |response|'s [=response/header list=] does not return a true value.
+    1. If [=validate fetching response=] with |response|, |responseBody| and "`application/wasm`"
+        returns false, set |moduleObject| to failure and return.
     1. Let |module| be the result of [=compiling a WebAssembly module=] |response|.
     1. If |module| is [=error=], set |moduleObject| to failure.
     1. Otherwise, set |moduleObject| to |module|.

--- a/spec.bs
+++ b/spec.bs
@@ -66,6 +66,7 @@ spec: WebAssembly; urlPrefix: https://webassembly.github.io/spec/core/
 spec: WebAssembly-js-api; urlPrefix: https://webassembly.github.io/spec/js-api/
   type: dfn
     text: compiling a WebAssembly module; url: #compile-a-webassembly-module
+spec: WebAssembly-web-api; urlPrefix: https://webassembly.github.io/spec/web-api/
   type: dfn
     text: compiling a potential WebAssembly response; url: #compile-a-potential-webassembly-response
 spec: WebIDL; urlPrefix: https://webidl.spec.whatwg.org/
@@ -2104,7 +2105,8 @@ failure, or a [=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
       "`application/wasm`".
 
       Note: This was intended to match the behavior of [=compiling a potential WebAssembly
-      response=], but diverges by failing to remove leading and trailing HTTP whitespace.
+      response=], but diverges by failing to remove leading and trailing [=HTTP tab or space
+      bytes=].
 
   1. If |mimeType| is not "`application/wasm`":
     1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].

--- a/spec.bs
+++ b/spec.bs
@@ -66,6 +66,8 @@ spec: WebAssembly; urlPrefix: https://webassembly.github.io/spec/core/
 spec: WebAssembly-js-api; urlPrefix: https://webassembly.github.io/spec/js-api/
   type: dfn
     text: compiling a WebAssembly module; url: #compile-a-webassembly-module
+  type: dfn
+    text: compiling a potential WebAssembly response; url: #compile-a-potential-webassembly-response
 spec: WebIDL; urlPrefix: https://webidl.spec.whatwg.org/
   type: dfn
     text: convert a Web IDL arguments list to an ECMAScript arguments list; url: #web-idl-arguments-list-converting
@@ -2097,8 +2099,13 @@ failure, or a [=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
     * |headerMimeType| is failure;
     * |mimeType| is "`text/javascript`" and |headerMimeType| is not a [=JavaScript MIME type=];
     * |mimeType| is "`application/json`" and |headerMimeType| is not a [=JSON MIME type=].
-    * |mimeType| is "`application/wasm`" and |headerMimeType|'s [=MIME type/essence=] is not
+    * |mimeType| is "`application/wasm`" and the result of [=header list/getting=] "`Content-Type`"
+      from |response|'s [=response/header list=] is null or not [=byte-case-insensitive=] equal to
       "`application/wasm`".
+
+      Note: This was intended to match the behavior of [=compiling a potential WebAssembly
+      response=], but ended up more restrictive of whitespace.
+
   1. If |mimeType| is not "`application/wasm`":
     1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
     1. Return false if any of the following conditions hold:
@@ -2115,7 +2122,7 @@ To <dfn>validate fetching response</dfn> given a [=response=] |response|, null, 
   1. If the result of [=validating fetching response headers=] given |response| is false, then
      return false.
   1. If the result of [=validating fetching response mime and body=] given |response|,
-     |responseBody|, |mimeType| is false, the return false.
+     |responseBody|, |mimeType| is false, then return false.
   1. Return true.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2109,11 +2109,13 @@ failure, or a [=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
       bytes=].
 
   1. If |mimeType| is not "`application/wasm`":
-    1. Let |mimeTypeCharset| be |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
-    1. Return false if any of the following conditions hold:
-      * |mimeTypeCharset| does not [=map/exist=], or |mimeTypeCharset| is "utf-8", and |responseBody|
-        is not [=UTF-8=] encoded;
-      * |mimeTypeCharset| is "us-ascii", and not all bytes in |responseBody| are [=ASCII bytes=].
+    1. Let |mimeTypeCharset| be "utf-8".
+    1. If |headerMimeType|'s [=MIME type/parameters=]["`charset`"] exists, set |mimeTypeCharset|
+      to |headerMimeType|'s [=MIME type/parameters=]["`charset`"].
+    1. Return true if any of the following conditions hold:
+      * |mimeTypeCharset| is "utf-8", and |responseBody| is [=UTF-8=] encoded;
+      * |mimeTypeCharset| is "us-ascii", and all bytes in |responseBody| are [=ASCII bytes=].
+    1. Return false.
   1. Return true.
 </div>
 


### PR DESCRIPTION
We will need to do checking in two stages for script bodies to get the proper cross-site seller signals behavior.

While at it, make sure we actually check that the response is a 2xx; we are not supposed to be trying to use error pages. 
Also fix the charset check, we accept very few.

Make the WASM path go through this, too, so it actually checks its mimetype, and gets the status check as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1175.html" title="Last updated on Jun 5, 2024, 3:55 PM UTC (4bedf6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1175/42a65c5...morlovich:4bedf6b.html" title="Last updated on Jun 5, 2024, 3:55 PM UTC (4bedf6b)">Diff</a>