### PR TITLE
Update FLEDGE.md (deprecatedRenderURLReplacements dict typo)

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -383,8 +383,8 @@ const myAuctionConfig = {
   'perBuyerMultiBidLimits': {'https://example.com': 10, '*': 5},
   'sellerCurrency:' : 'CAD',
   'reportingTimeout' : 200,
-  'deprecatedRenderURLReplacements':{{'${SELLER}':'exampleSSP'},
-                                    {'%%SELLER_ALT%%':'exampleSSP'}},
+  'deprecatedRenderURLReplacements':{'${SELLER}':'exampleSSP',
+                                    '%%SELLER_ALT%%':'exampleSSP'},
   'componentAuctions': [
     {'seller': 'https://www.some-other-ssp.com',
       'decisionLogicURL': ...,


### PR DESCRIPTION
Update `deprecatedRenderURLReplacements` example to dict format `runAdAuction()` accepts.