### PR TITLE
Spec navigator.canLoadAdAuctionFencedFrame().

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2646,27 +2646,26 @@ The <dfn for=Navigator method>canLoadAdAuctionFencedFrame()</dfn> method steps a
 
 1. If |global|'s [=Window/browsing context=]'s [=required CSP=] is not null, then return false.
 
-1. Let |CSP list| be [=this=]'s [=relevant settings object=]'s [=environment settings object/policy
+1. Let |CSPList| be [=this=]'s [=relevant settings object=]'s [=environment settings object/policy
    container=]'s [=policy container/CSP list=].
 
-1. [=list/For each=] |policy| of |CSP list|:
+1. [=list/For each=] |policy| of |CSPList|:
 
-  1. [=list/For each=] |directive| of |policy|'s [=policy/directive set=]:
+  1. [=set/For each=] |directive| of |policy|'s [=policy/directive set=]:
 
     1. If |directive|'s [=directive name|name=] is either "`fenced-frame-src`", "`frame-src`",
-       "`child-src`", or "`default-src`", and if |directive|'s [=directive name|value=] does not
-       contain either "`https:`", "`https://*:*`", or "`*`", then return false.
+       "`child-src`", or "`default-src`", and if |directive|'s [=directive value|value=] does not
+       [=set/contain=] any of "`https:`", "`https://*:*`", or "`*`", then return false.
 
-1. Let |sandbox flags| be |global|'s [=associated Document=]'s [=Document/active sandboxing flag
+1. Let |sandboxFlags| be |global|'s [=associated Document=]'s [=Document/active sandboxing flag
    set=].
 
-1. [=list/For each=] |mandatory unsandboxed flag| of TODO: Get the mandatory unsandboxed
-   flags list from the fenced frames spec:
+1. [=list/For each=] |mandatoryUnsandboxedFlags| of TBD:
 
    Issue: TODO: Get the mandatory unsandboxed flags list once it exists in the fenced frame spec.
+   (<a href="https://github.com/WICG/turtledove/issues/1206">WICG/turtledove#1206</a>)
 
-  1. If |sandbox flags| does not [=set/contains|contain=] |mandatory unsandboxed flag|, then return
-     false.
+  1. If |sandboxFlags| [=set/contains=] |mandatoryUnsandboxedFlags|, then return false.
 
 1. Return true.
 

--- a/spec.bs
+++ b/spec.bs
@@ -83,6 +83,13 @@ spec: Shared Storage API; urlPrefix: https://wicg.github.io/shared-storage
   type: dfn
     text: shared-storage; url: #permissionspolicy-shared-storage
     text: shared-storage-select-url; url: #permissionspolicy-shared-storage-select-url
+spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
+  type: dfn
+    text: directive name; url: directive-name
+    text: directive value; url: directive-value
+spec: CSPEE; urlPrefix: https://w3c.github.io/webappsec-cspee/
+  type: dfn
+    text: required csp; url: browsing-context-required-csp
 </pre>
 
 <pre class=link-defaults>
@@ -2614,6 +2621,54 @@ a {{ReportingBrowserSignals}} |browserSignals|, and a [=direct from seller signa
      : [=reporting result/reporting macro map=]
      :: |reportingMacroMap|
 </div>
+
+<h3 id="canloadadauctionfencedframe">canLoadAdAuctionFencedFrame()</h3>
+
+*This first introductory paragraph is non-normative.*
+
+The process of running an ad auction through {{Window/navigator}}.{{Navigator/runAdAuction()}} is an
+expensive operation. To prevent wasted cycles if the resulting ad cannot be loaded in the current
+context, {{Window/navigator}}.{{Navigator/canLoadAdAuctionFencedFrame()}} is provided as a method to
+determine, before the ad auction begins, whether an ad auction-created <{fencedframe}> is allowed to
+be loaded in the current context. A <{fencedframe}> has restrictions on where and how it can be
+loaded that do not exist with <{iframe}>s.
+
+<xmp class="idl">
+[SecureContext]
+partial interface Navigator {
+  boolean canLoadAdAuctionFencedFrame();
+};
+</xmp>
+
+The <dfn for=Navigator method>canLoadAdAuctionFencedFrame()</dfn> method steps are:
+
+1. Let |global| be [=this=]'s [=relevant global object=].
+
+1. If |global|'s [=Window/browsing context=]'s [=required CSP=] is not null, then return false.
+
+1. Let |CSP list| be [=this=]'s [=relevant settings object=]'s [=environment settings object/policy
+   container=]'s [=policy container/CSP list=].
+
+1. [=list/For each=] |policy| of |CSP list|:
+
+  1. [=list/For each=] |directive| of |policy|'s [=policy/directive set=]:
+
+    1. If |directive|'s [=directive name|name=] is either "`fenced-frame-src`", "`frame-src`",
+       "`child-src`", or "`default-src`", and if |directive|'s [=directive name|value=] does not
+       contain either "`https:`", "`https://*:*`", or "`*`", then return false.
+
+1. Let |sandbox flags| be |global|'s [=associated Document=]'s [=Document/active sandboxing flag
+   set=].
+
+1. [=list/For each=] |mandatory unsandboxed flag| of TODO: Get the mandatory unsandboxed
+   flags list from the fenced frames spec:
+
+   Issue: TODO: Get the mandatory unsandboxed flags list once it exists in the fenced frame spec.
+
+  1. If |sandbox flags| does not [=set/contains|contain=] |mandatory unsandboxed flag|, then return
+     false.
+
+1. Return true.
 
 # Reporting # {#reporting}
 

--- a/spec.bs
+++ b/spec.bs
@@ -2664,7 +2664,7 @@ The <dfn for=Navigator method>canLoadAdAuctionFencedFrame()</dfn> method steps a
 1. Let |sandboxFlags| be |global|'s [=associated Document=]'s [=Document/active sandboxing flag
    set=].
 
-1. If the intersection of |sandboxFlags| and TBD [=set/is not empty=], then return false.
+1. If the [=set/intersection=] of |sandboxFlags| and TBD [=set/is not empty=], then return false.
 
    Issue: TODO: Get the mandatory unsandboxed [=sandboxing flag set=] once it exists in the fenced
    frame spec. This will then determine the intersection between that and the |sandboxFlags|.

--- a/spec.bs
+++ b/spec.bs
@@ -2646,6 +2646,10 @@ The <dfn for=Navigator method>canLoadAdAuctionFencedFrame()</dfn> method steps a
 
 1. If |global|'s [=Window/browsing context=]'s [=required CSP=] is not null, then return false.
 
+   Note: CSPEE lets arbitrary data flow from an embedder into a <{fencedframe}> via the policies it
+   sets. Since this goes against the privacy guarantees of a Protected Audience-created
+   <{fencedframe}>, this is disallowed.
+
 1. Let |CSPList| be [=this=]'s [=relevant settings object=]'s [=environment settings object/policy
    container=]'s [=policy container/CSP list=].
 
@@ -2660,12 +2664,11 @@ The <dfn for=Navigator method>canLoadAdAuctionFencedFrame()</dfn> method steps a
 1. Let |sandboxFlags| be |global|'s [=associated Document=]'s [=Document/active sandboxing flag
    set=].
 
-1. [=list/For each=] |mandatoryUnsandboxedFlags| of TBD:
+1. If the intersection of |sandboxFlags| and TBD [=set/is not empty=], then return false.
 
-   Issue: TODO: Get the mandatory unsandboxed flags list once it exists in the fenced frame spec.
+   Issue: TODO: Get the mandatory unsandboxed [=sandboxing flag set=] once it exists in the fenced
+   frame spec. This will then determine the intersection between that and the |sandboxFlags|.
    (<a href="https://github.com/WICG/turtledove/issues/1206">WICG/turtledove#1206</a>)
-
-  1. If |sandboxFlags| [=set/contains=] |mandatoryUnsandboxedFlags|, then return false.
 
 1. Return true.
 


### PR DESCRIPTION
The `navigator.canLoadAdAuctionFencedFrame()` is an API that can be used to determine, before an ad auction begins, whether a fenced frame can load on a page. This helps prevent unnecessary work being done in the ad auction if the resulting ad can't even be shown on the page. The API looks at CSPEE, CSP policies, and sandbox flags to determine whether a hypothetical fenced frame would be able to load, and the checks mirror the checks that fenced frames perform before loading.

See: https://github.com/WICG/fenced-frame/issues/46

Note that sandbox flags haven't been spec'd in fenced frames yet. There will be a follow up to get the value from the fenced frame spec, once it exists. See: https://github.com/WICG/fenced-frame/issues/155


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/blu25/turtledove/pull/1205.html" title="Last updated on Jun 13, 2024, 9:03 PM UTC (1cff8f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1205/e615700...blu25:1cff8f4.html" title="Last updated on Jun 13, 2024, 9:03 PM UTC (1cff8f4)">Diff</a>