### PR TITLE
[Spec] Add size API surface to joinAdInterestGroup

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -4582,7 +4582,7 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   1. The [=string/length=] of |ad|'s [=interest group ad/size group=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
 1. If |ig|'s [=interest group/ad sizes=] is not null, [=map/For each=] |sizeName| → |size| of it:
-  1. The sum of the [=string/length=] of |sizeName| and 18.
+  1. The sum of the [=string/length=] of |sizeName| and 18 (representing the fixed length of |size|).
 
   Note: 10 represents the size of 2 doubles for [=ad size/width=] and [=ad size/height=] (each 8
   bytes),and 2 bytes for enums for [=ad size/width units=] and [=ad size/height units=] (each 1 byte).

--- a/spec.bs
+++ b/spec.bs
@@ -392,11 +392,11 @@ This is detectable because it can change the set of fields that are read from th
               a {{TypeError}}.
           1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
-  1. If |group|["{{AuctionAdInterestGroup/adSizes}}"] [=map/exists=]:
-    1. [=map/For each=] |key| → |value| of |group|["{{AuctionAdInterestGroup/adSizes}}"]:
+  1. If |group|["{{GenerateBidInterestGroup/adSizes}}"] [=map/exists=]:
+    1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
       1. TODO
-  1. If |group|["{{AuctionAdInterestGroup/sizeGroups}}"] [=map/exists=]:
-    1. [=map/For each=] |key| → |value| of |group|["{{AuctionAdInterestGroup/sizeGroups}}"]:
+  1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
+    1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
       1. TODO
   1. If |group|["{{AuctionAdInterestGroup/additionalBidKey}}"] [=map/exists=]:
     1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with
@@ -4388,9 +4388,11 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
         <dt>"`adSizes`"
         <dd>
         1. TODO
+
         <dt>"`sizeGroups`"
         <dd>
         1. TODO
+
         <dt>"`additionalBidKey`"
         <dd>
         1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with |value|.

--- a/spec.bs
+++ b/spec.bs
@@ -360,7 +360,7 @@ This is detectable because it can change the set of fields that are read from th
       1. [=map/Set=] |adSizes|[|sizeName|] to |parsedSize|.
     1. Set |interestGroup|'s [=interest group/ad sizes=] to |adSizes|.
   1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
-     are [=strings=].
+     are [=lists=] of [=strings=]
   1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
     1. [=map/For each=] |groupName| → |sizeList| of
        |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:

--- a/spec.bs
+++ b/spec.bs
@@ -4581,12 +4581,12 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
     [=interest group ad/render url=].
   1. The [=string/length=] of |ad|'s [=interest group ad/size group=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
-1. If |ig|'s [=interest group/ad sizes=] is not null, [=map/For each=] |sizeName| → |size| of it:
+1. If |ig|'s [=interest group/ad sizes=] is not null, [=map/for each=] |sizeName| → |size| of it:
   1. The sum of the [=string/length=] of |sizeName| and 18 (representing the fixed length of |size|).
 
   Note: 10 represents the size of 2 doubles for [=ad size/width=] and [=ad size/height=] (each 8
-  bytes),and 2 bytes for enums for [=ad size/width units=] and [=ad size/height units=] (each 1 byte).
-1. If |ig|'s [=interest group/size groups=] is not null, [=map/For each=] |sizeGroupName| → |sizeList|
+  bytes), and 2 bytes for enums for [=ad size/width units=] and [=ad size/height units=] (each 1 byte).
+1. If |ig|'s [=interest group/size groups=] is not null, [=map/for each=] |sizeGroupName| → |sizeList|
    of it:
   1. The sum of the [=string/length=] of |sizeGroupName| and the following:
   1. [=list/For each=] |sizeName| of |sizeList|:

--- a/spec.bs
+++ b/spec.bs
@@ -179,7 +179,7 @@ advertisement relevant to this interest to this user in the future. The [=user a
 <h3 id="join-ad-interest-groups">joinAdInterestGroup()</h3>
 
 Issue: TODO: Currently, several of the IDL fields in {{AuctionAdInterestGroup}} are specified to use
-USVString rather than DOMString, only because the Chromium implementation currently does. This may
+USVString rather than DOMString, only because the initial implementation currently does. This may
 contradict <a href="https://webidl.spec.whatwg.org/#idl-USVString">the recommended use of
 DOMString</a>.
 (<a href="https://github.com/WICG/turtledove/issues/1250">WICG/turtledove#1250</a>)

--- a/spec.bs
+++ b/spec.bs
@@ -192,6 +192,11 @@ dictionary AuctionAd {
   sequence<USVString> allowedReportingOrigins;
 };
 
+dictionary AuctionAdInterestGroupSize {
+  required USVString width;
+  required USVString height;
+};
+
 dictionary GenerateBidInterestGroup {
   required USVString owner;
   required USVString name;
@@ -212,6 +217,8 @@ dictionary GenerateBidInterestGroup {
   any userBiddingSignals;
   sequence<AuctionAd> ads;
   sequence<AuctionAd> adComponents;
+  record<DOMString, AuctionAdInterestGroupSize> adSizes;
+  record<DOMString, sequence<DOMString>> sizeGroups;
 };
 
 dictionary AuctionAdInterestGroup : GenerateBidInterestGroup {

--- a/spec.bs
+++ b/spec.bs
@@ -198,11 +198,6 @@ dictionary AuctionAdInterestGroupSize {
   required USVString height;
 };
 
-dictionary AuctionAdInterestGroupSize {
-  required USVString width;
-  required USVString height;
-};
-
 dictionary GenerateBidInterestGroup {
   required USVString owner;
   required USVString name;

--- a/spec.bs
+++ b/spec.bs
@@ -5107,8 +5107,6 @@ dictionary DirectFromSellerSignalsForSeller {
 An <dfn>interest group</dfn> is a [=struct=] with the following [=struct/items=]:
 
 <dl dfn-for="interest group">
-<<<<<<< HEAD
-<<<<<<< HEAD
   : <dfn>expiry</dfn>
   :: A [=moment=] at which the browser will forget about this interest group.
   : <dfn>owner</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -392,6 +392,10 @@ This is detectable because it can change the set of fields that are read from th
               a {{TypeError}}.
           1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
+  1. If |group|["{{AuctionAdInterestGroup/adSizes}}"] [=map/exists=]:
+    1. TODO
+  1. If |group|["{{AuctionAdInterestGroup/sizeGroups}}"] [=map/exists=]:
+    1. TODO
   1. If |group|["{{AuctionAdInterestGroup/additionalBidKey}}"] [=map/exists=]:
     1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with
       |group|["{{AuctionAdInterestGroup/additionalBidKey}}"].

--- a/spec.bs
+++ b/spec.bs
@@ -3971,6 +3971,8 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. Let |dimension| be the result of parsing |dimensionString| using the
     [=rules for parsing floating-point number values=].
   1. If |dimension| is an error, then return null as the dimension and the empty string as the dimension unit.
+  1. If |dimension| is less than 0, then return null as the dimension and the empty string as the
+     dimension unit.
   1. [=Collect a sequence of code points=] that are [=ASCII lower alpha=], given |position|. Let
     that be |dimensionUnit|.
   1. If |position| is not past the end of |input|, then return null as the dimension and the empty
@@ -4009,11 +4011,16 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
 
   1. Let |adUrl| be |adDescriptor|'s [=ad descriptor/url=].
   1. If |adUrl|'s [=url/scheme=] is not "`https`", return null.
-  1. TODO: Need to check [=ad descriptor/size=] as well.
-  1. If |isComponent|, [=list/for each=] |ad| in |ig|'s [=interest group/ad components=]:
-    1. If |ad|'s [=interest group ad/render url=] equals |adUrl|, return |ad|.
-  1. Otherwise, [=list/for each=] |ad| in |ig|'s [=interest group/ads=]:
-    1. If |ad|'s [=interest group ad/render url=] equals |adUrl|, return |ad|.
+  1. Let |adSize| be |adDescriptor|'s [=ad descriptor/size=].
+  1. Let |adList| be |ig|'s [=interest group/ad components=] if |isComponent|, otherwise |ig|'s
+     [=interest group/ads=].
+  1. [=list/For each=] |ad| in |adList|:
+    1. If |ad|'s [=interest group ad/render url=] does not equal |adUrl|, [=iteration/continue=].
+    1. If |ad|'s [=interest group ad/size group=] is null, return |ad|.
+    1. If |adSize| is null, return |ad|.
+    1. [=list/For each=] |igSize| in (|ig|'s [=interest group/size groups=])[|ad|'s
+       [=interest group ad/size group=]]:
+      1. If |igSize| equals |adSize|, return |ad|.
   1. Return null.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -362,13 +362,13 @@ This is detectable because it can change the set of fields that are read from th
   1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
      are [=lists=] of [=strings=]
   1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
-    1. [=map/For each=] |groupName| → |sizeList| of
+    1. [=map/For each=] |sizeGroupName| → |sizeList| of
        |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
-      1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
+      1. If |sizeGroupName| is "", [=exception/throw=] a {{TypeError}}.
       1. [=list/For each=] |sizeName| of |sizeList|:
         1. If |sizeName| is "" or |adSizes|[|sizeName|] does not [=map/exist=],
            [=exception/throw=] a {{TypeError}}.
-      1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
+      1. [=map/Set=] |sizeGroups|[|sizeGroupName|] to |sizeList|.
     1. Set |interestGroup|'s [=interest group/size groups=] to |sizeGroups|.
   1. For each |groupMember| and |interestGroupField| in the following table
     <table class="data">
@@ -4384,12 +4384,12 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
         1. Let |adSizes| be |ig|'s [=interest group/ad sizes=].
         1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
            are [=strings=].
-        1. [=map/For each=] |groupName| → |sizeList| of |value|:
-          1. If |groupName| is "", jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
+        1. [=map/For each=] |sizeGroupName| → |sizeList| of |value|:
+          1. If |sizeGroupName| is "", jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
           1. [=list/For each=] |sizeName| of |sizeList|:
             1. If |sizeName| is "" or |adSizes|[|sizeName|] does not [=map/exist=],
                jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
-          1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
+          1. [=map/Set=] |sizeGroups|[|sizeGroupName|] to |sizeList|.
         1. Set |ig|'s [=interest group/size groups=] to |sizeGroups|.
 
         <dt>"`ads`"

--- a/spec.bs
+++ b/spec.bs
@@ -395,20 +395,24 @@ This is detectable because it can change the set of fields that are read from th
   1. If |group|["{{GenerateBidInterestGroup/adSizes}}"] [=map/exists=]:
     1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
        [=ad sizes=].
-    1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
-      1. If |key| is "", [=exception/throw=] a {{TypeError}}.
-      1. Let |adSize| be the result from running [=parse an AdRender ad size=] with |value|.
-      1. If |adSize| is null, [=exception/throw=] a {{TypeError}}.
-      1. [=map/Set=] |adSizes|[|key|] to |adSize|.
+    1. [=map/For each=] |sizeName| → |size| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
+      1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+      1. Let |parsedSize| be the result from running [=parse an AdRender ad size=] with |size|.
+      1. If |parsedSize| is null, [=exception/throw=] a {{TypeError}}.
+      1. [=map/Set=] |adSizes|[|sizeName|] to |parsedSize|.
     1. Set |interestGroup|'s [=interest group/ad sizes=] to |adSizes|.
   1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
     1. Let |adSizes| be |interestGroup|'s [=interest group/ad sizes=].
     1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
        are [=strings=].
-    1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
-      1. If |key| is "", [=exception/throw=] a {{TypeError}}.
-      1. If |adSizes||key| does not [=map/exist=], then [=exception/throw=] a {{TypeError}}.
-      1. [=map/Set=] |sizeGroups|[|key|] to |value|.
+    1. [=map/For each=] |groupName| → |sizeList| of
+       |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
+      1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
+      1. [=list/For each |sizeName| of |sizeList|:
+        1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+        1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
+               {{TypeError}}.
+      1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
     1. Set |interestGroup|'s [=interest group/size groups=] to |sizeGroups|.
   1. If |group|["{{AuctionAdInterestGroup/additionalBidKey}}"] [=map/exists=]:
     1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with
@@ -4399,11 +4403,28 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
 
         <dt>"`adSizes`"
         <dd>
-        1. TODO
+        1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
+           [=ad sizes=].
+        1. [=map/For each=] |sizeName| → |size| of |value|:
+          1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+          1. Let |adSize| be the result from running [=parse an AdRender ad size=] with |size|.
+          1. If |adSize| is null, [=exception/throw=] a {{TypeError}}.
+          1. [=map/Set=] |adSizes|[|sizeName|] to |adSize|.
+        1. Set |ig|'s [=interest group/ad sizes=] to |adSizes|.
 
         <dt>"`sizeGroups`"
         <dd>
-        1. TODO
+        1. Let |adSizes| be |ig|'s [=interest group/ad sizes=].
+        1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
+           are [=strings=].
+        1. [=map/For each=] |groupName| → |sizeList| of |value|:
+          1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
+          1. [=list/For each |sizeName| of |sizeList|:
+            1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+            1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
+               {{TypeError}}.
+          1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
+        1. Set |ig|'s [=interest group/size groups=] to |sizeGroups|.
 
         <dt>"`additionalBidKey`"
         <dd>

--- a/spec.bs
+++ b/spec.bs
@@ -5103,6 +5103,7 @@ An <dfn>interest group</dfn> is a [=struct=] with the following [=struct/items=]
 
 <dl dfn-for="interest group">
 <<<<<<< HEAD
+<<<<<<< HEAD
   : <dfn>expiry</dfn>
   :: A [=moment=] at which the browser will forget about this interest group.
   : <dfn>owner</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -5102,6 +5102,7 @@ dictionary DirectFromSellerSignalsForSeller {
 An <dfn>interest group</dfn> is a [=struct=] with the following [=struct/items=]:
 
 <dl dfn-for="interest group">
+<<<<<<< HEAD
   : <dfn>expiry</dfn>
   :: A [=moment=] at which the browser will forget about this interest group.
   : <dfn>owner</dfn>
@@ -5183,6 +5184,13 @@ An <dfn>interest group</dfn> is a [=struct=] with the following [=struct/items=]
   :: Null or a [=list=] of [=interest group ad=]. Contains various ad components (or "products") that
     can be used to construct ads composed of multiple pieces — a top-level ad template "container"
     which includes some slots that can be filled in with specific "products".
+  : <dfn>ad sizes</dfn>
+  :: Null or a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are TODO ad sizes.
+     Contains named sizes (width and height) that can be bound to ads to specify their render size.
+  : <dfn>size groups</dfn>
+  :: Null or a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=lists=] of
+     [=strings=]. Contains named collections of ad sizes that can be used to declare a bundle of
+     possible sizes which all apply to one ad url.
   : <dfn>additional bid key</dfn>
   :: Null or a [=byte sequence=] of length 32. Must be null if [=interest group/ads=] or
     [=interest group/update url=] is not null. The Ed25519 public key (a 256-bit EdDSA public key)

--- a/spec.bs
+++ b/spec.bs
@@ -366,9 +366,8 @@ This is detectable because it can change the set of fields that are read from th
        |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
       1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
       1. [=list/For each=] |sizeName| of |sizeList|:
-        1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
-        1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
-               {{TypeError}}.
+        1. If |sizeName| is "" or |adSizes|[|sizeName|] does not [=map/exist=],
+           [=exception/throw=] a {{TypeError}}.
       1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
     1. Set |interestGroup|'s [=interest group/size groups=] to |sizeGroups|.
   1. For each |groupMember| and |interestGroupField| in the following table

--- a/spec.bs
+++ b/spec.bs
@@ -4373,9 +4373,9 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
         1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
            [=ad sizes=].
         1. [=map/For each=] |sizeName| → |size| of |value|:
-          1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+          1. If |sizeName| is "", jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
           1. Let |adSize| be the result from running [=parse an AdRender ad size=] with |size|.
-          1. If |adSize| is null, [=exception/throw=] a {{TypeError}}.
+          1. If |adSize| is null, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
           1. [=map/Set=] |adSizes|[|sizeName|] to |adSize|.
         1. Set |ig|'s [=interest group/ad sizes=] to |adSizes|.
 
@@ -4385,10 +4385,10 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
         1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
            are [=strings=].
         1. [=map/For each=] |groupName| → |sizeList| of |value|:
-          1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
+          1. If |groupName| is "", jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
           1. [=list/For each=] |sizeName| of |sizeList|:
             1. If |sizeName| is "" or |adSizes|[|sizeName|] does not [=map/exist=],
-               [=exception/throw=] a {{TypeError}}.
+               jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
           1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
         1. Set |ig|'s [=interest group/size groups=] to |sizeGroups|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -393,11 +393,22 @@ This is detectable because it can change the set of fields that are read from th
           1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
   1. If |group|["{{GenerateBidInterestGroup/adSizes}}"] [=map/exists=]:
+    1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
+       [=ad sizes=].
     1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
-      1. TODO
+      1. If |key| is "", [=exception/throw=] a {{TypeError}}.
+      1. TODO: Convert |value| to an [=ad size=] |adSize|.
+      1. [=map/Set=] |adSizes|[|key|] to |adSize|.
+    1. Set |interestGroup|'s [=interest group/ad sizes=] to |adSizes|.
   1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
+    1. Let |adSizes| be |interestGroup|'s [=interest group/ad sizes=].
+    1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
+       are [=strings=].
     1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
-      1. TODO
+      1. If |key| is "", [=exception/throw=] a {{TypeError}}.
+      1. If |adSizes||key| does not [=map/exist=], then [=exception/throw=] a {{TypeError}}.
+      1. [=map/Set=] |sizeGroups|[|key|] to |value|.
+    1. Set |interestGroup|'s [=interest group/size groups=] to |sizeGroups|.
   1. If |group|["{{AuctionAdInterestGroup/additionalBidKey}}"] [=map/exists=]:
     1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with
       |group|["{{AuctionAdInterestGroup/additionalBidKey}}"].

--- a/spec.bs
+++ b/spec.bs
@@ -185,6 +185,7 @@ partial interface Navigator {
 
 dictionary AuctionAd {
   required USVString renderURL;
+  USVString sizeGroup;
   any metadata;
 
   USVString buyerReportingId;
@@ -375,6 +376,8 @@ This is detectable because it can change the set of fields that are read from th
         * |renderURL| [=url/scheme=] is not "`https`";
         * |renderURL| [=includes credentials=].
       1. Set |igAd|'s [=interest group ad/render url=] to |renderURL|.
+      1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists]], then set |igAd|'s
+         [=interest group ad/size group=] to |ad|["{{AuctionAd/sizeGroup}}"].
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
         |igAd|'s [=interest group ad/metadata=] be the result of
         [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].
@@ -4363,6 +4366,8 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
               * |renderURL| [=url/scheme=] is not "`https`";
               * |renderURL| [=includes credentials=].
             1. Set |igAd|'s [=interest group ad/render url=] to |renderURL|.
+            1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists]], then set |igAd|'s
+               [=interest group ad/size group=] to |ad|["{{AuctionAd/sizeGroup}}"].
             1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
               |igAd|'s [=interest group ad/metadata=] be the result of
               [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].

--- a/spec.bs
+++ b/spec.bs
@@ -365,7 +365,7 @@ This is detectable because it can change the set of fields that are read from th
     1. [=map/For each=] |groupName| → |sizeList| of
        |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
       1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
-      1. [=list/For each |sizeName| of |sizeList|:
+      1. [=list/For each=] |sizeName| of |sizeList|:
         1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
         1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
                {{TypeError}}.
@@ -1894,7 +1894,7 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
     1. If |ad|'s [=interest group ad/size group=] is not null, then [=map/set=]
-       |adIDL|["{{AuctionAd/sizeGroup}}"] to the |ad|'s [=interest group ad/size group=].
+       |adIDL|["{{AuctionAd/sizeGroup}}"] to |ad|'s [=interest group ad/size group=].
     1. If |ad|'s [=interest group ad/metadata=] is not null, then [=map/set=]
       |adIDL|["{{AuctionAd/metadata}}"] to the result of
       [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
@@ -4380,7 +4380,7 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
            are [=strings=].
         1. [=map/For each=] |groupName| → |sizeList| of |value|:
           1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
-          1. [=list/For each |sizeName| of |sizeList|:
+          1. [=list/For each=] |sizeName| of |sizeList|:
             1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
             1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
                {{TypeError}}.

--- a/spec.bs
+++ b/spec.bs
@@ -178,6 +178,12 @@ advertisement relevant to this interest to this user in the future. The [=user a
 
 <h3 id="join-ad-interest-groups">joinAdInterestGroup()</h3>
 
+Issue: TODO: Currently, several of the IDL fields in {{AuctionAdInterestGroup}} are specified to use
+USVString rather than DOMString, only because the Chromium implementation currently does. This may
+contradict <a href="https://webidl.spec.whatwg.org/#idl-USVString">the recommended use of
+DOMString</a>.
+(<a href="https://github.com/WICG/turtledove/issues/1254">WICG/turtledove#1250</a>)
+
 <xmp class="idl">
 [SecureContext]
 partial interface Navigator {

--- a/spec.bs
+++ b/spec.bs
@@ -197,6 +197,11 @@ dictionary AuctionAdInterestGroupSize {
   required USVString height;
 };
 
+dictionary AuctionAdInterestGroupSize {
+  required USVString width;
+  required USVString height;
+};
+
 dictionary GenerateBidInterestGroup {
   required USVString owner;
   required USVString name;

--- a/spec.bs
+++ b/spec.bs
@@ -4568,6 +4568,7 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 1. If |ig|'s [=interest group/ads=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
+  1. The [=string/length=] of |ad|'s [=interest group ad/size group=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer reporting ID=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer and seller reporting ID=] if the
@@ -4578,7 +4579,18 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 1. If |ig|'s [=interest group/ad components=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
     [=interest group ad/render url=].
+  1. The [=string/length=] of |ad|'s [=interest group ad/size group=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/metadata=] if the field is not null.
+1. If |ig|'s [=interest group/ad sizes=] is not null, [=map/For each=] |sizeName| → |size| of it:
+  1. The sum of the [=string/length=] of |sizeName| and 18.
+
+  Note: 10 represents the size of 2 doubles for [=ad size/width=] and [=ad size/height=] (each 8
+  bytes),and 2 bytes for enums for [=ad size/width units=] and [=ad size/height units=] (each 1 byte).
+1. If |ig|'s [=interest group/size groups=] is not null, [=map/For each=] |sizeGroupName| → |sizeList|
+   of it:
+  1. The sum of the [=string/length=] of |sizeGroupName| and the following:
+  1. [=list/For each=] |sizeName| of |sizeList|:
+    1. The [=string/length=] of |sizeName|.
 1. If |ig|'s [=interest group/additional bid key=] is not null:
   1. 32, which is its size (number of bytes).
 

--- a/spec.bs
+++ b/spec.bs
@@ -185,7 +185,7 @@ partial interface Navigator {
 
 dictionary AuctionAd {
   required USVString renderURL;
-  DOMString sizeGroup;
+  USVString sizeGroup;
   any metadata;
 
   USVString buyerReportingId;
@@ -194,8 +194,8 @@ dictionary AuctionAd {
 };
 
 dictionary AuctionAdInterestGroupSize {
-  required DOMString width;
-  required DOMString height;
+  required USVString width;
+  required USVString height;
 };
 
 dictionary GenerateBidInterestGroup {

--- a/spec.bs
+++ b/spec.bs
@@ -182,7 +182,7 @@ Issue: TODO: Currently, several of the IDL fields in {{AuctionAdInterestGroup}} 
 USVString rather than DOMString, only because the Chromium implementation currently does. This may
 contradict <a href="https://webidl.spec.whatwg.org/#idl-USVString">the recommended use of
 DOMString</a>.
-(<a href="https://github.com/WICG/turtledove/issues/1254">WICG/turtledove#1250</a>)
+(<a href="https://github.com/WICG/turtledove/issues/1250">WICG/turtledove#1250</a>)
 
 <xmp class="idl">
 [SecureContext]

--- a/spec.bs
+++ b/spec.bs
@@ -5300,7 +5300,7 @@ An <dfn>interest group ad</dfn> is a [=struct=] with the following [=struct/item
     be returned by {{Navigator/runAdAuction()}}. This URL is intended to be loaded into an ad
     <{iframe}> (or a <{fencedframe}>).
   : <dfn>size group</dfn>
-  :: Null or a [=string=]. The name of the size group (collection of render sizes) bound to this ad.
+  :: Null or a [=string=], initially null. The name of the size group (collection of render sizes) bound to this ad.
   : <dfn>metadata</dfn>
   :: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
   : <dfn>buyer reporting ID</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -4381,6 +4381,12 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
           1. If |igAds| is not [=list/is empty=]:
             1. Set |ig|'s |interestGroupField| to |igAds|.
 
+        <dt>"`adSizes`"
+        <dd>
+        1. TODO
+        <dt>"`sizeGroups`"
+        <dd>
+        1. TODO
         <dt>"`additionalBidKey`"
         <dd>
         1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with |value|.

--- a/spec.bs
+++ b/spec.bs
@@ -185,7 +185,7 @@ partial interface Navigator {
 
 dictionary AuctionAd {
   required USVString renderURL;
-  USVString sizeGroup;
+  DOMString sizeGroup;
   any metadata;
 
   USVString buyerReportingId;
@@ -194,8 +194,8 @@ dictionary AuctionAd {
 };
 
 dictionary AuctionAdInterestGroupSize {
-  required USVString width;
-  required USVString height;
+  required DOMString width;
+  required DOMString height;
 };
 
 dictionary GenerateBidInterestGroup {

--- a/spec.bs
+++ b/spec.bs
@@ -1871,7 +1871,8 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
     1. Let |adIDL| be a new {{AuctionAd}}.
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
-    1. If |ad|'s [=interest group ad/size=] is not null, then [=map/set=] TODO.
+    1. If |ad|'s [=interest group ad/size group=] is not null, then [=map/set=]
+       |adIDL|["{{AuctionAd/sizeGroup}}"] to the |ad|'s [=interest group ad/size group=].
     1. If |ad|'s [=interest group ad/metadata=] is not null, then [=map/set=]
       |adIDL|["{{AuctionAd/metadata}}"] to the result of
       [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
@@ -5245,9 +5246,8 @@ An <dfn>interest group ad</dfn> is a [=struct=] with the following [=struct/item
   :: A [=URL=]. If this ad wins the auction, this URL (or a [=urn uuid=] that maps to this URL) will
     be returned by {{Navigator/runAdAuction()}}. This URL is intended to be loaded into an ad
     <{iframe}> (or a <{fencedframe}>).
-  : <dfn>render size</dfn>
-  :: Null or an [=ad size]. If this ad wins the auction, this size (if present) will be used to
-     render the ad when when loaded into a <{fencedframe}>.
+  : <dfn>size group</dfn>
+  :: Null or a [=string=]. The name of the size group (collection of render sizes) bound to this ad.
   : <dfn>metadata</dfn>
   :: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
   : <dfn>buyer reporting ID</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -350,6 +350,27 @@ This is detectable because it can change the set of fields that are read from th
     "slot-size", or "all-slots-requested-sizes", set |interestGroup|'s
     [=interest group/trusted bidding signals slot size mode=] to
     |group|["{{GenerateBidInterestGroup/trustedBiddingSignalsSlotSizeMode}}"].
+  1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
+     [=ad sizes=].
+  1. If |group|["{{GenerateBidInterestGroup/adSizes}}"] [=map/exists=]:
+    1. [=map/For each=] |sizeName| → |size| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
+      1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+      1. Let |parsedSize| be the result from running [=parse an AdRender ad size=] with |size|.
+      1. If |parsedSize| is null, [=exception/throw=] a {{TypeError}}.
+      1. [=map/Set=] |adSizes|[|sizeName|] to |parsedSize|.
+    1. Set |interestGroup|'s [=interest group/ad sizes=] to |adSizes|.
+  1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
+     are [=strings=].
+  1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
+    1. [=map/For each=] |groupName| → |sizeList| of
+       |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
+      1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
+      1. [=list/For each |sizeName| of |sizeList|:
+        1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+        1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
+               {{TypeError}}.
+      1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
+    1. Set |interestGroup|'s [=interest group/size groups=] to |sizeGroups|.
   1. For each |groupMember| and |interestGroupField| in the following table
     <table class="data">
       <thead><tr><th>Group member</th><th>Interest group field</th></tr></thead>
@@ -371,8 +392,12 @@ This is detectable because it can change the set of fields that are read from th
         * |renderURL| [=url/scheme=] is not "`https`";
         * |renderURL| [=includes credentials=].
       1. Set |igAd|'s [=interest group ad/render url=] to |renderURL|.
-      1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists=], then set |igAd|'s
-         [=interest group ad/size group=] to |ad|["{{AuctionAd/sizeGroup}}"].
+      1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists=]:
+        1. Let |sizeGroup| be |ad|["{{AuctionAd/sizeGroup}}}].
+        1. [=exception/Throw=] a {{TypeError}} if none of the following conditions hold:
+           1. |adSizes|[|sizeGroup|] [=map/exists=].
+           1. |sizeGroups|[|sizeGroup|] [=map/exists=].
+        1. Set |igAd|'s [=interest group ad/size group=] to |sizeGroup|.
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
         |igAd|'s [=interest group ad/metadata=] be the result of
         [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].
@@ -392,28 +417,6 @@ This is detectable because it can change the set of fields that are read from th
               a {{TypeError}}.
           1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
-  1. If |group|["{{GenerateBidInterestGroup/adSizes}}"] [=map/exists=]:
-    1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
-       [=ad sizes=].
-    1. [=map/For each=] |sizeName| → |size| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
-      1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
-      1. Let |parsedSize| be the result from running [=parse an AdRender ad size=] with |size|.
-      1. If |parsedSize| is null, [=exception/throw=] a {{TypeError}}.
-      1. [=map/Set=] |adSizes|[|sizeName|] to |parsedSize|.
-    1. Set |interestGroup|'s [=interest group/ad sizes=] to |adSizes|.
-  1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:
-    1. Let |adSizes| be |interestGroup|'s [=interest group/ad sizes=].
-    1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
-       are [=strings=].
-    1. [=map/For each=] |groupName| → |sizeList| of
-       |group|["{{GenerateBidInterestGroup/sizeGroups}}"]:
-      1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
-      1. [=list/For each |sizeName| of |sizeList|:
-        1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
-        1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
-               {{TypeError}}.
-      1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
-    1. Set |interestGroup|'s [=interest group/size groups=] to |sizeGroups|.
   1. If |group|["{{AuctionAdInterestGroup/additionalBidKey}}"] [=map/exists=]:
     1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with
       |group|["{{AuctionAdInterestGroup/additionalBidKey}}"].
@@ -4356,6 +4359,31 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
         Issue:  Serializing an Infra value to JSON bytes expects to be called within a valid ES realm. See
         <a href="https://github.com/whatwg/infra/issues/625">infra/625</a>
 
+        <dt>"`adSizes`"
+        <dd>
+        1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
+           [=ad sizes=].
+        1. [=map/For each=] |sizeName| → |size| of |value|:
+          1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+          1. Let |adSize| be the result from running [=parse an AdRender ad size=] with |size|.
+          1. If |adSize| is null, [=exception/throw=] a {{TypeError}}.
+          1. [=map/Set=] |adSizes|[|sizeName|] to |adSize|.
+        1. Set |ig|'s [=interest group/ad sizes=] to |adSizes|.
+
+        <dt>"`sizeGroups`"
+        <dd>
+        1. Let |adSizes| be |ig|'s [=interest group/ad sizes=].
+        1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
+           are [=strings=].
+        1. [=map/For each=] |groupName| → |sizeList| of |value|:
+          1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
+          1. [=list/For each |sizeName| of |sizeList|:
+            1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
+            1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
+               {{TypeError}}.
+          1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
+        1. Set |ig|'s [=interest group/size groups=] to |sizeGroups|.
+
         <dt>"`ads`"
         <dt>"`adComponents`"
         <dd>
@@ -4385,8 +4413,13 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
               * |renderURL| [=url/scheme=] is not "`https`";
               * |renderURL| [=includes credentials=].
             1. Set |igAd|'s [=interest group ad/render url=] to |renderURL|.
-            1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists]], then set |igAd|'s
-               [=interest group ad/size group=] to |ad|["{{AuctionAd/sizeGroup}}"].
+            1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists=]:
+              1. Let |sizeGroup| be |ad|["{{AuctionAd/sizeGroup}}}].
+              1. Jump to the step labeled <i><a href=#abort-update>Abort update</a></i> if none of
+                 the following conditions hold:
+                * |adSizes|[|sizeGroup|] [=map/exists=].
+                * |sizeGroups|[|sizeGroup|] [=map/exists=].
+              1. Set |igAd|'s [=interest group ad/size group=] to |sizeGroup|.
             1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
               |igAd|'s [=interest group ad/metadata=] be the result of
               [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].
@@ -4400,31 +4433,6 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
             1. [=list/Append=] |igAd| to |igAds|.
           1. If |igAds| is not [=list/is empty=]:
             1. Set |ig|'s |interestGroupField| to |igAds|.
-
-        <dt>"`adSizes`"
-        <dd>
-        1. Let |adSizes| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are
-           [=ad sizes=].
-        1. [=map/For each=] |sizeName| → |size| of |value|:
-          1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
-          1. Let |adSize| be the result from running [=parse an AdRender ad size=] with |size|.
-          1. If |adSize| is null, [=exception/throw=] a {{TypeError}}.
-          1. [=map/Set=] |adSizes|[|sizeName|] to |adSize|.
-        1. Set |ig|'s [=interest group/ad sizes=] to |adSizes|.
-
-        <dt>"`sizeGroups`"
-        <dd>
-        1. Let |adSizes| be |ig|'s [=interest group/ad sizes=].
-        1. Let |sizeGroups| be a new [=map=] whose [=map/keys=] are [=strings=] and [=map/values=]
-           are [=strings=].
-        1. [=map/For each=] |groupName| → |sizeList| of |value|:
-          1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
-          1. [=list/For each |sizeName| of |sizeList|:
-            1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
-            1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
-               {{TypeError}}.
-          1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
-        1. Set |ig|'s [=interest group/size groups=] to |sizeGroups|.
 
         <dt>"`additionalBidKey`"
         <dd>

--- a/spec.bs
+++ b/spec.bs
@@ -396,7 +396,7 @@ This is detectable because it can change the set of fields that are read from th
         1. Let |sizeGroup| be |ad|["{{AuctionAd/sizeGroup}}}].
         1. [=exception/Throw=] a {{TypeError}} if none of the following conditions hold:
            * |adSizes|[|sizeGroup|] [=map/exists=].
-           1. |sizeGroups|[|sizeGroup|] [=map/exists=].
+           * |sizeGroups|[|sizeGroup|] [=map/exists=].
         1. Set |igAd|'s [=interest group ad/size group=] to |sizeGroup|.
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
         |igAd|'s [=interest group ad/metadata=] be the result of

--- a/spec.bs
+++ b/spec.bs
@@ -4388,9 +4388,8 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
         1. [=map/For each=] |groupName| → |sizeList| of |value|:
           1. If |groupName| is "", [=exception/throw=] a {{TypeError}}.
           1. [=list/For each=] |sizeName| of |sizeList|:
-            1. If |sizeName| is "", [=exception/throw=] a {{TypeError}}.
-            1. If |adSizes|[|sizeName|] does not [=map/exist=], then [=exception/throw=] a
-               {{TypeError}}.
+            1. If |sizeName| is "" or |adSizes|[|sizeName|] does not [=map/exist=],
+               [=exception/throw=] a {{TypeError}}.
           1. [=map/Set=] |sizeGroups|[|groupName|] to |sizeList|.
         1. Set |ig|'s [=interest group/size groups=] to |sizeGroups|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -393,9 +393,11 @@ This is detectable because it can change the set of fields that are read from th
           1. Set |igAd|'s [=interest group ad/allowed reporting origins=] to |allowedReportingOrigins|.
       1. [=list/Append=] |igAd| to |interestGroup|'s |interestGroupField|.
   1. If |group|["{{AuctionAdInterestGroup/adSizes}}"] [=map/exists=]:
-    1. TODO
+    1. [=map/For each=] |key| → |value| of |group|["{{AuctionAdInterestGroup/adSizes}}"]:
+      1. TODO
   1. If |group|["{{AuctionAdInterestGroup/sizeGroups}}"] [=map/exists=]:
-    1. TODO
+    1. [=map/For each=] |key| → |value| of |group|["{{AuctionAdInterestGroup/sizeGroups}}"]:
+      1. TODO
   1. If |group|["{{AuctionAdInterestGroup/additionalBidKey}}"] [=map/exists=]:
     1. Let |decodedKey| be the result of running [=forgiving-base64 decode=] with
       |group|["{{AuctionAdInterestGroup/additionalBidKey}}"].
@@ -1869,6 +1871,7 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
     1. Let |adIDL| be a new {{AuctionAd}}.
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
+    1. If |ad|'s [=interest group ad/size=] is not null, then [=map/set=] TODO.
     1. If |ad|'s [=interest group ad/metadata=] is not null, then [=map/set=]
       |adIDL|["{{AuctionAd/metadata}}"] to the result of
       [=parsing a JSON string to a JavaScript value=] given |ad|'s [=interest group ad/metadata=].
@@ -5242,6 +5245,9 @@ An <dfn>interest group ad</dfn> is a [=struct=] with the following [=struct/item
   :: A [=URL=]. If this ad wins the auction, this URL (or a [=urn uuid=] that maps to this URL) will
     be returned by {{Navigator/runAdAuction()}}. This URL is intended to be loaded into an ad
     <{iframe}> (or a <{fencedframe}>).
+  : <dfn>render size</dfn>
+  :: Null or an [=ad size]. If this ad wins the auction, this size (if present) will be used to
+     render the ad when when loaded into a <{fencedframe}>.
   : <dfn>metadata</dfn>
   :: Null or a [=string=]. Extra arbitary information about this ad, passed to `generateBid()`.
   : <dfn>buyer reporting ID</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -397,7 +397,8 @@ This is detectable because it can change the set of fields that are read from th
        [=ad sizes=].
     1. [=map/For each=] |key| → |value| of |group|["{{GenerateBidInterestGroup/adSizes}}"]:
       1. If |key| is "", [=exception/throw=] a {{TypeError}}.
-      1. TODO: Convert |value| to an [=ad size=] |adSize|.
+      1. Let |adSize| be the result from running [=parse an AdRender ad size=] with |value|.
+      1. If |adSize| is null, [=exception/throw=] a {{TypeError}}.
       1. [=map/Set=] |adSizes|[|key|] to |adSize|.
     1. Set |interestGroup|'s [=interest group/ad sizes=] to |adSizes|.
   1. If |group|["{{GenerateBidInterestGroup/sizeGroups}}"] [=map/exists=]:

--- a/spec.bs
+++ b/spec.bs
@@ -395,7 +395,7 @@ This is detectable because it can change the set of fields that are read from th
       1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists=]:
         1. Let |sizeGroup| be |ad|["{{AuctionAd/sizeGroup}}}].
         1. [=exception/Throw=] a {{TypeError}} if none of the following conditions hold:
-           1. |adSizes|[|sizeGroup|] [=map/exists=].
+           * |adSizes|[|sizeGroup|] [=map/exists=].
            1. |sizeGroups|[|sizeGroup|] [=map/exists=].
         1. Set |igAd|'s [=interest group ad/size group=] to |sizeGroup|.
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let

--- a/spec.bs
+++ b/spec.bs
@@ -800,7 +800,10 @@ To <dfn>construct a pending fenced frame config</dfn> given an [=auction config=
     :: "<a for=visibility>`opaque`</a>"
 
   : [=fenced frame config/container size=]
-  :: TODO: fill this in once container size is spec'd to be in |config|
+  :: the result of
+
+   Issue: converting |config|'s [=auction config/requested size=] to pixel values
+   (<a href="https://github.com/WICG/turtledove/issues/986">WICG/turtledove#986</a>)
 
   : [=fenced frame config/content size=]
   :: null

--- a/spec.bs
+++ b/spec.bs
@@ -371,7 +371,7 @@ This is detectable because it can change the set of fields that are read from th
         * |renderURL| [=url/scheme=] is not "`https`";
         * |renderURL| [=includes credentials=].
       1. Set |igAd|'s [=interest group ad/render url=] to |renderURL|.
-      1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists]], then set |igAd|'s
+      1. If |ad|["{{AuctionAd/sizeGroup}}"] [=map/exists=], then set |igAd|'s
          [=interest group ad/size group=] to |ad|["{{AuctionAd/sizeGroup}}"].
       1. If |ad|["{{AuctionAd/metadata}}"] [=map/exists=], then let
         |igAd|'s [=interest group ad/metadata=] be the result of
@@ -5184,7 +5184,7 @@ An <dfn>interest group</dfn> is a [=struct=] with the following [=struct/items=]
     can be used to construct ads composed of multiple pieces — a top-level ad template "container"
     which includes some slots that can be filled in with specific "products".
   : <dfn>ad sizes</dfn>
-  :: Null or a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are TODO ad sizes.
+  :: Null or a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=ad sizes=].
      Contains named sizes (width and height) that can be bound to ads to specify their render size.
   : <dfn>size groups</dfn>
   :: Null or a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=lists=] of


### PR DESCRIPTION
Add size fields to the API surface for interest group joining / updating, and propagate those fields into interest group browser signals.

Note: Currently, the IDL fields sizeGroup in AuctionAd and width/height AuctionAdInterestGroupSize are specified to use USVString rather than DOMString, only because the Chromium implementation currently does. This contradicts the recommended use of DOMString for anything that won't appear in a UI. This issue is tracked at https://github.com/WICG/turtledove/issues/1250


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gtanzer/turtledove/pull/1210.html" title="Last updated on Aug 19, 2024, 7:14 PM UTC (042eefb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1210/1647301...gtanzer:042eefb.html" title="Last updated on Aug 19, 2024, 7:14 PM UTC (042eefb)">Diff</a>