### PR TITLE
Add optional dataVersion field in the response schema and example.

### DIFF
--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -378,6 +378,10 @@ The content of each compressed blob is a CBOR list of partition outputs. This ob
         "description": "Unique id of the partition from the request",
         "type": "unsigned integer"
       },
+      "dataVersion" {
+        "description": "An optional field to indicate the state of the data that generated this response, which will then be available in bid generation/scoring and reporting.",
+        "type": "unsigned integer"
+      },
       "keyGroupOutputs": {
         "type": "array",
         "items": {
@@ -414,10 +418,6 @@ The content of each compressed blob is a CBOR list of partition outputs. This ob
                   ]
                 }
               }
-            },
-            "dataVersion" {
-              "description": "An optional field to indicate the state of the data that generated this response, which will then be available in bid generation/scoring and reporting.",
-              "type": "unsigned integer"
             }
           }
         }
@@ -434,6 +434,7 @@ Example:
 [
   {
     "id": 0,
+    "dataVersion": 102,
     "keyGroupOutputs": [
       {
         "tags": [
@@ -443,8 +444,7 @@ Example:
           "InterestGroup1": {
             "value": "{\"priorityVector\":{\"signal1\":1}}"
           }
-        },
-        "dataVersion": 102
+        }
       },
       {
         "tags": [

--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -414,6 +414,10 @@ The content of each compressed blob is a CBOR list of partition outputs. This ob
                   ]
                 }
               }
+            },
+            "dataVersion" {
+              "description": "An optional field to indicate the state of the data that generated this response, which will then be available in bid generation/scoring and reporting.",
+              "type": "unsigned integer"
             }
           }
         }
@@ -439,7 +443,8 @@ Example:
           "InterestGroup1": {
             "value": "{\"priorityVector\":{\"signal1\":1}}"
           }
-        }
+        },
+        "dataVersion": 102
       },
       {
         "tags": [


### PR DESCRIPTION
Based on the discussion between Chroma and KV teams, we agree to add a new optional field "dataVersion" for a single partition object under compressionGroups/content