### PR TITLE
docs: remove version from ohttp media type

### DIFF
--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -78,8 +78,6 @@ Since we are [repurposing the OHTTP encapsulation mechanism, we are required to 
 * The OHTTP response media type is “message/ad-auction-trusted-signals-response”
 Note that these media types are [concatenated with other fields when creating the HPKE encryption context](https://www.rfc-editor.org/rfc/rfc9458.html#name-encapsulation-of-requests), and are not HTTP content or media types.
 
-The version information is of the format `major.minor` where `major` and `minor` are integers.
-
 Inside the ciphertext, the request/response is framed with a 5 byte header, where the first byte is the format+compression byte, and the following 4 bytes are the length of the request message in network byte order. Then the request is zero padded to a set of pre-configured lengths.
 
 The lower 2 bits are used for compression specification. The higher 6 bits are currently unused.

--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -73,8 +73,8 @@ We will use [Oblivious HTTP](https://datatracker.ietf.org/doc/draft-ietf-ohai-oh
 *   0x0001 HKDF-SHA256 for KDF (key derivation functions)
 *   AES256GCM for AEAD scheme.
 
-* The OHTTP request has media type “message/ad-auction-trusted-signals-request; v=2.0”
-* The OHTTP response has media type “message/ad-auction-trusted-signals-response; v=2.0”
+* The OHTTP request has media type “message/ad-auction-trusted-signals-request”
+* The OHTTP response has media type “message/ad-auction-trusted-signals-response”
 
 The version information is of the format `major.minor` where `major` and `minor` are integers.
 

--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -73,8 +73,10 @@ We will use [Oblivious HTTP](https://datatracker.ietf.org/doc/draft-ietf-ohai-oh
 *   0x0001 HKDF-SHA256 for KDF (key derivation functions)
 *   AES256GCM for AEAD scheme.
 
-* The OHTTP request has media type “message/ad-auction-trusted-signals-request”
-* The OHTTP response has media type “message/ad-auction-trusted-signals-response”
+Since we are [repurposing the OHTTP encapsulation mechanism, we are required to define new media types](https://www.rfc-editor.org/rfc/rfc9458.html#name-repurposing-the-encapsulati):
+* The OHTTP request media type is “message/ad-auction-trusted-signals-request”
+* The OHTTP response media type is “message/ad-auction-trusted-signals-response”
+Note that these media types are [concatenated with other fields when creating the HPKE encryption context](https://www.rfc-editor.org/rfc/rfc9458.html#name-encapsulation-of-requests), and are not HTTP content or media types.
 
 The version information is of the format `major.minor` where `major` and `minor` are integers.
 

--- a/FLEDGE_Key_Value_Server_API.md
+++ b/FLEDGE_Key_Value_Server_API.md
@@ -76,6 +76,7 @@ We will use [Oblivious HTTP](https://datatracker.ietf.org/doc/draft-ietf-ohai-oh
 Since we are [repurposing the OHTTP encapsulation mechanism, we are required to define new media types](https://www.rfc-editor.org/rfc/rfc9458.html#name-repurposing-the-encapsulati):
 * The OHTTP request media type is “message/ad-auction-trusted-signals-request”
 * The OHTTP response media type is “message/ad-auction-trusted-signals-response”
+
 Note that these media types are [concatenated with other fields when creating the HPKE encryption context](https://www.rfc-editor.org/rfc/rfc9458.html#name-encapsulation-of-requests), and are not HTTP content or media types.
 
 Inside the ciphertext, the request/response is framed with a 5 byte header, where the first byte is the format+compression byte, and the following 4 bytes are the length of the request message in network byte order. Then the request is zero padded to a set of pre-configured lengths.


### PR DESCRIPTION
Remove versioning scheme, as V1/V2 are distinguished by auction and interest group configuration.