### PR TITLE
Fix previous wins and ad render ID

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -198,6 +198,7 @@ dictionary AuctionAd {
   USVString buyerReportingId;
   USVString buyerAndSellerReportingId;
   sequence<USVString> allowedReportingOrigins;
+  sequence<DOMString> adRenderId;
 };
 
 dictionary AuctionAdInterestGroupSize {
@@ -408,6 +409,10 @@ This is detectable because it can change the set of fields that are read from th
         |igAd|'s [=interest group ad/metadata=] be the result of
         [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].
         This can [=exception/throw=] a {{TypeError}}.
+      1. If |ad|["{{AuctionAd/adRenderId}}"] [=map/exists=]:
+        1. If |ad|["{{AuctionAd/adRenderId}}"]'s [=string/length=] is greater than 12, [=exception/throw=] a {{TypeError}}.
+        1. If any [=code point=] in |ad|["{{AuctionAd/adRenderId}}"] is not an [=ASCII code point=], [=exception/throw=] a {{TypeError}}.
+        1. Set |igAd|'s [=interest group ad/ad render id=] to |ad|["{{AuctionAd/adRenderId}}"].
       1. If |groupMember| is "{{GenerateBidInterestGroup/ads}}":
         1. If |ad|["{{AuctionAd/buyerReportingId}}"] [=map/exists=], then set
           |igAd|'s [=interest group ad/buyer reporting ID=] to it.
@@ -1482,8 +1487,7 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     [=interest group ad/metadata=] is |bid|'s [=generated bid/bid ad=]'s
     [=interest group ad/metadata=], and whose [=interest group ad/ad render ID=] is
     |bid|'s [=generated bid/bid ad=]'s [=interest group ad/ad render ID=].
-  1. Set |win|'s [=previous win/ad json=] to the result of
-    [=serializing an Infra value to a JSON string=] given |ad|.
+  1. Set |win|'s [=previous win/ad=] to |ad|.
   1. [=list/Append=] |win| to |loadedIg|'s [=interest group/previous wins=].
   1. [=list/Replace=] the [=interest group=] that has |loadedIg|'s [=interest group/owner=] and
     [=interest group/name=] in the [=user agent=]'s [=interest group set=] with |loadedIg|.
@@ -1585,10 +1589,8 @@ the script or wasm, otherwise a [=tuple=] of ([=list=] of [=generated bids=],
     1. Let |timeDelta| be |auctionStartTime| minus |prevWin|'s [=previous win/time=].
     1. Set |timeDelta| to 0 if |timeDelta| is negative, |timeDelta|'s nearest second (rounding down)
       otherwise.
-    1. Let |prevWinIDL| be a new {{PreviousWin}}.
-    1. [=map/Set=] |prevWinIDL|["{{PreviousWin/timeDelta}}"] to |timeDelta|.
-    1. [=map/Set=] |prevWinIDL|["{{PreviousWin/adJSON}}"] to |prevWin|'s [=previous win/ad json=].
-    1. [=list/Append=] |prevWinIDL| to |prevWins|.
+    1. Let |prevWin| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |prevWin|'s [=previous win/ad=]».
+    1. [=list/Append=] |prevWin| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
   1. Let |biddingScriptFetcher| be the result of [=creating a new script fetcher=] with
     |ig|'s [=interest group/bidding url=], and |frameOrigin|.
@@ -3000,7 +3002,7 @@ The <dfn for=Navigator method>getInterestGroupAdAuctionData(|config|)</dfn> meth
         : [=server auction previous win/time delta=]
         :: |timeDelta|
         : [=server auction previous win/ad render ID=]
-        :: the value of the "adRenderId" field in |prevWin|'s [=previous win/ad json=], or the empty string if not present
+        :: the value of the [=interest group ad/ad render ID=] field in |prevWin|'s [=previous win/ad=], or the empty string if not present
       1. [=list/Append=] |serverPrevWin| to |prevWins|.
     1. Let |browserSignals| be a new [=server auction browser signals=] with the following [=struct/items=]:
       : [=server auction browser signals/bid count=]
@@ -5657,10 +5659,8 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
 # Structures # {#structures}
 
 <xmp class="idl">
-dictionary PreviousWin {
-  required long long timeDelta;
-  required DOMString adJSON;
-};
+typedef (long long or AuctionAd) PreviousWinElement;
+typedef sequence<PreviousWinElement> PreviousWin;
 
 dictionary BiddingBrowserSignals {
   required DOMString topWindowHostname;
@@ -6011,8 +6011,8 @@ frequency capping. It's a [=struct=] with the following [=struct/items=]:
 <dl dfn-for="previous win">
   : <dfn>time</dfn>
   :: A [=moment=]. Approximate time the [=interest group=] won an auction.
-  : <dfn>ad json</dfn>
-  :: A [=string=]. A JSON serialized object corresponding to the ad that won the auction.
+  : <dfn>ad</dfn>
+  :: An [=interest group ad=]. The ad that won the auction.
 </dl>
 
 A <dfn>seller capability</dfn> is a permission granted by an [=interest group=] to sellers. It's

--- a/spec.bs
+++ b/spec.bs
@@ -1591,14 +1591,14 @@ the script or wasm, otherwise a [=tuple=] of ([=list=] of [=generated bids=],
     1. Let |timeDelta| be |auctionStartTime| minus |prevWin|'s [=previous win/time=].
     1. Set |timeDelta| to 0 if |timeDelta| is negative, |timeDelta|'s nearest second (rounding down)
       otherwise.
-    1. Let |prevWinIDL| be a new {{AuctionAd}} with the following [=struct/items=]:
+    1. Let |prevWinAdIDL| be a new {{AuctionAd}} with the following [=struct/items=]:
       : {{AuctionAd/renderURL}}
-      :: |prevWin|'s [=interest group ad/render url=]
+      :: the [=URL serializer|serialization=] of |prevWin|'s [=interest group ad/render url=]
       : {{AuctionAd/metadata}}
       :: |prevWin|'s [=interest group ad/metadata=]
       : {{AuctionAd/adRenderId}}
       :: |prevWin|'s [=interest group ad/ad render ID=]
-    1. Let |prevWinElement| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |prevWinIDL|».
+    1. Let |prevWinElement| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |prevWinAdIDL|».
     1. [=list/Append=] |prevWinElement| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
   1. Let |biddingScriptFetcher| be the result of [=creating a new script fetcher=] with
@@ -6022,6 +6022,7 @@ frequency capping. It's a [=struct=] with the following [=struct/items=]:
   :: A [=moment=]. Approximate time the [=interest group=] won an auction.
   : <dfn>ad</dfn>
   :: An [=interest group ad=]. The ad that won the auction.
+    Fields except [=interest group ad/render url=], [=interest group ad/metadata=] and [=interest group ad/ad render ID=] are excluded.
 </dl>
 
 A <dfn>seller capability</dfn> is a permission granted by an [=interest group=] to sellers. It's

--- a/spec.bs
+++ b/spec.bs
@@ -410,7 +410,7 @@ This is detectable because it can change the set of fields that are read from th
         [=serializing a JavaScript value to a JSON string=], given |ad|["{{AuctionAd/metadata}}"].
         This can [=exception/throw=] a {{TypeError}}.
       1. If |ad|["{{AuctionAd/adRenderId}}"] [=map/exists=]:
-        1. If |ad|["{{AuctionAd/adRenderId}}"]'s [=string/length=] is greater than 12, [=exception/throw=] a {{TypeError}}.
+        1. If |ad|["{{AuctionAd/adRenderId}}"]'s [=string/length=] &gt; 12, [=exception/throw=] a {{TypeError}}.
         1. If any [=code point=] in |ad|["{{AuctionAd/adRenderId}}"] is not an [=ASCII code point=], [=exception/throw=] a {{TypeError}}.
         1. Set |igAd|'s [=interest group ad/ad render id=] to |ad|["{{AuctionAd/adRenderId}}"].
       1. If |groupMember| is "{{GenerateBidInterestGroup/ads}}":
@@ -1589,7 +1589,7 @@ the script or wasm, otherwise a [=tuple=] of ([=list=] of [=generated bids=],
     1. Let |timeDelta| be |auctionStartTime| minus |prevWin|'s [=previous win/time=].
     1. Set |timeDelta| to 0 if |timeDelta| is negative, |timeDelta|'s nearest second (rounding down)
       otherwise.
-    1. Let |prevWin| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |prevWin|'s [=previous win/ad=]».
+    1. Let |prevWin| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |win|'s [=previous win/ad=]».
     1. [=list/Append=] |prevWin| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
   1. Let |biddingScriptFetcher| be the result of [=creating a new script fetcher=] with

--- a/spec.bs
+++ b/spec.bs
@@ -6073,7 +6073,7 @@ frequency capping. It's a [=struct=] with the following [=struct/items=]:
   :: A [=moment=]. Approximate time the [=interest group=] won an auction.
   : <dfn>ad</dfn>
   :: An [=interest group ad=]. The ad that won the auction.
-    Fields except [=interest group ad/render url=], [=interest group ad/metadata=] and [=interest group ad/ad render ID=] are excluded.
+    [=struct/Items=] except [=interest group ad/render url=], [=interest group ad/metadata=] and [=interest group ad/ad render ID=] are excluded.
 </dl>
 
 A <dfn>seller capability</dfn> is a permission granted by an [=interest group=] to sellers. It's

--- a/spec.bs
+++ b/spec.bs
@@ -1592,14 +1592,14 @@ the script or wasm, otherwise a [=tuple=] of ([=list=] of [=generated bids=],
     1. Set |timeDelta| to 0 if |timeDelta| is negative, |timeDelta|'s nearest second (rounding down)
       otherwise.
     1. Let |prevWinIDL| be a new {{AuctionAd}} with the following [=struct/items=]:
-      : [=AuctionAd/renderURL=]
+      : {{AuctionAd/renderURL}}
       :: |prevWin|'s [=interest group ad/render url=]
-      : [=AuctionAd/metadata=]
+      : {{AuctionAd/metadata}}
       :: |prevWin|'s [=interest group ad/metadata=]
-      : [=AuctionAd/adRenderId=]
-      :: |prevWin|'s [=ad render ID=]
-    1. Let |prevWin| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |win|'s [=previous win/ad=]».
-    1. [=list/Append=] |prevWin| to |prevWins|.
+      : {{AuctionAd/adRenderId}}
+      :: |prevWin|'s [=interest group ad/ad render ID=]
+    1. Let |prevWinElement| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |prevWinIDL|».
+    1. [=list/Append=] |prevWinElement| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.
   1. Let |biddingScriptFetcher| be the result of [=creating a new script fetcher=] with
     |ig|'s [=interest group/bidding url=], and |frameOrigin|.

--- a/spec.bs
+++ b/spec.bs
@@ -198,7 +198,7 @@ dictionary AuctionAd {
   USVString buyerReportingId;
   USVString buyerAndSellerReportingId;
   sequence<USVString> allowedReportingOrigins;
-  sequence<DOMString> adRenderId;
+  DOMString adRenderId;
 };
 
 dictionary AuctionAdInterestGroupSize {
@@ -1482,11 +1482,13 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     [=interest group/name=] is |ig|'s [=interest group/name=], return if none found.
   1. Let |win| be a new [=previous win=].
   1. Set |win|'s [=previous win/time=] to the [=current wall time=].
-  1. Let |ad| be an [=interest group ad=] whose [=interest group ad/render url=] is |bid|'s
-    [=generated bid/bid ad=]'s [=interest group ad/render url=], whose
-    [=interest group ad/metadata=] is |bid|'s [=generated bid/bid ad=]'s
-    [=interest group ad/metadata=], and whose [=interest group ad/ad render ID=] is
-    |bid|'s [=generated bid/bid ad=]'s [=interest group ad/ad render ID=].
+  1. Let |ad| be a new [=interest group ad=] with the following [=struct/items=]:
+    : [=interest group ad/render url=]
+    :: |bid|'s [=generated bid/bid ad=]'s [=interest group ad/render url=]
+    : [=interest group ad/metadata=]
+    :: |bid|'s [=generated bid/bid ad=]'s [=interest group ad/metadata=]
+    : [=interest group ad/ad render ID=]
+    :: |bid|'s [=generated bid/bid ad=]'s [=interest group ad/ad render ID=]
   1. Set |win|'s [=previous win/ad=] to |ad|.
   1. [=list/Append=] |win| to |loadedIg|'s [=interest group/previous wins=].
   1. [=list/Replace=] the [=interest group=] that has |loadedIg|'s [=interest group/owner=] and
@@ -1589,6 +1591,13 @@ the script or wasm, otherwise a [=tuple=] of ([=list=] of [=generated bids=],
     1. Let |timeDelta| be |auctionStartTime| minus |prevWin|'s [=previous win/time=].
     1. Set |timeDelta| to 0 if |timeDelta| is negative, |timeDelta|'s nearest second (rounding down)
       otherwise.
+    1. Let |prevWinIDL| be a new {{AuctionAd}} with the following [=struct/items=]:
+      : [=AuctionAd/renderURL=]
+      :: |prevWin|'s [=interest group ad/render url=]
+      : [=AuctionAd/metadata=]
+      :: |prevWin|'s [=interest group ad/metadata=]
+      : [=AuctionAd/adRenderId=]
+      :: |prevWin|'s [=ad render ID=]
     1. Let |prevWin| be the <code>[=sequence=]<{{PreviousWinElement}}></code> «|timeDelta|, |win|'s [=previous win/ad=]».
     1. [=list/Append=] |prevWin| to |prevWins|.
   1. [=map/Set=] |browserSignals|["{{BiddingBrowserSignals/prevWinsMs}}"] to |prevWins|.


### PR DESCRIPTION
Fix prevWinMs format - it's actually a sequence of time/ad pairs, not a sequence of dictionaries with timestamp/ad JSON members.
Pipe ad render ID in from IDL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brusshamilton/turtledove/pull/1258.html" title="Last updated on Sep 4, 2024, 5:31 PM UTC (22cd84d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1258/815f0f1...brusshamilton:22cd84d.html" title="Last updated on Sep 4, 2024, 5:31 PM UTC (22cd84d)">Diff</a>