### PR TITLE
[spec] Fix semantics around Abort Signal for runAdAuction()

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -791,7 +791,8 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
     1. Set |auctionReportInfo|'s [=auction report info/real time reporting contributions map=] to
       |realTimeContributionsMap|.
   1. If |auctionConfig|'s [=auction config/aborted=] is true:
-    1. [=Reject=] |p| with |auctionConfig|'s [=auction config/abort reason=].
+    1. [=Queue a global task=] on the [=DOM manipulation task source=], given |global|, to
+       [=reject=] |p| with |auctionConfig|'s [=auction config/abort reason=].
   1. Otherwise if |winnerInfo| is failure, then [=queue a global task=] on [=DOM manipulation task source=],
     given |global|, to [=reject=] |p| with a "{{TypeError}}".
   1. Otherwise if |winnerInfo| is null or |winnerInfo|'s [=leading bid info/leading bid=] is null:
@@ -813,10 +814,10 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
     1. If |auctionConfig|'s [=auction config/resolve to config=] is false, then set |result| to |urn|.
     1. [=Queue a global task=] on the [=DOM manipulation task source=], given |global|, to
        resolve |p| with |result|.
+    1. Run [=update previous wins=] with |winner|.
   1. Run [=interest group update=] with |auctionConfig|'s [=auction config/interest group buyers=]
     and |settings|'s [=environment settings object/policy container=].
   1. Run [=update bid counts=] with |bidIgs|.
-  1. Run [=update previous wins=] with |winner|.
 1. Return |p|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -767,10 +767,10 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
   1. Let |signal| be |config|["{{AuctionAdConfig/signal}}"].
   1. If |signal| is [=AbortSignal/aborted=], then [=reject=] |p| with |signal|'s
     [=AbortSignal/abort reason=] and return |p|.
-  1. Else [=AbortSignal/Add|Add the following abort steps=] to |signal|:
+  1. Otherwise [=AbortSignal/Add|add the following abort steps=] to |signal|:
     1. Set |auctionConfig|'s [=auction config/aborted=] to true.
     1. Set |auctionConfig|'s [=auction config/abort reason=] to |signal|'s [=AbortSignal/abort reason=].
-    1. For each |auction| in |auctionConfig|'s [=auction config/component auctions=]:
+    1. [=list/For each=] |auction| in |auctionConfig|'s [=auction config/component auctions=]:
       1. Set |auction|'s [=auction config/aborted=] to true.
 1. [=Assert=] that |settings|'s [=environment settings object/origin=] is not an [=opaque origin=]
   and its [=origin/scheme=] is "`https`".

--- a/spec.bs
+++ b/spec.bs
@@ -765,11 +765,8 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 1. Let |bidIgs| be a new [=list=] of [=interest groups=].
 1. If |config|["{{AuctionAdConfig/signal}}"] [=map/exists=], then:
   1. Let |signal| be |config|["{{AuctionAdConfig/signal}}"].
-  1. If |signal|'s [=AbortSignal/aborted=] is true, then:
-    1. Set |auctionConfig|'s [=auction config/aborted=] to true.
-    1. Set |auctionConfig|'s [=auction config/abort reason=] to |signal|'s [=AbortSignal/abort reason=].
-    1. For each |auction| in |auctionConfig|'s [=auction config/component auctions=]:
-      1. Set |auction|'s [=auction config/aborted=] to true.
+  1. If |signal| is [=AbortSignal/aborted=], then [=reject=] |p| with |signal|'s
+    [=AbortSignal/abort reason=] and return |p|.
   1. Else [=AbortSignal/Add|Add the following abort steps=] to |signal|:
     1. Set |auctionConfig|'s [=auction config/aborted=] to true.
     1. Set |auctionConfig|'s [=auction config/abort reason=] to |signal|'s [=AbortSignal/abort reason=].

--- a/spec.bs
+++ b/spec.bs
@@ -6305,14 +6305,16 @@ An <dfn>auction config</dfn> is a [=struct=] with the following [=struct/items=]
   : <dfn>aborted</dfn>
   :: A [=boolean=] indicating whether the auction has been aborted, initially false.
   : <dfn>abort reason</dfn>
-  :: Null or a [=string=], initially null.
+  :: {{any}}.
 </dl>
 
 <div algorithm>
 To <dfn>wait until configuration input promises resolve</dfn> given an [=auction config=]
 |auctionConfig|:
 
-  1. Wait until |auctionConfig|'s [=auction config/pending promise count=] is 0.
+  1. Wait until either |auctionConfig|'s [=auction config/pending promise count=] is 0
+     or |auctionConfig|'s [=auction config/aborted=] is true.
+  1. If |auctionConfig|'s [=auction config/aborted=] is true, return failure.
   1. [=Assert=] |auctionConfig|'s [=auction config/auction signals=], [=auction config/seller signals=],
     [=auction config/per buyer signals=], [=auction config/per buyer currencies=],
     [=auction config/per buyer timeouts=], [=auction config/per buyer cumulative timeouts=],

--- a/spec.bs
+++ b/spec.bs
@@ -765,13 +765,16 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 1. Let |bidIgs| be a new [=list=] of [=interest groups=].
 1. If |config|["{{AuctionAdConfig/signal}}"] [=map/exists=], then:
   1. Let |signal| be |config|["{{AuctionAdConfig/signal}}"].
-  1. If |signal| is [=AbortSignal/aborted=], then [=reject=] |p| with |signal|'s
-    [=AbortSignal/abort reason=] and return |p|.
-  1. [=AbortSignal/Add|Add the following abort steps=] to |signal|:
-    1. [=Reject=] |p| with |signal|’s [=AbortSignal/abort reason=].
-    1. Run [=update bid counts=] with |bidIgs|.
-    1. Run [=interest group update=] with |auctionConfig|'s [=auction config/interest group buyers=]
-      and |settings|'s [=environment settings object/policy container=].
+  1. If |signal|'s [=AbortSignal/aborted=] is true, then:
+    1. Set |auctionConfig|'s [=auction config/aborted=] to true.
+    1. Set |auctionConfig|'s [=auction config/abort reason=] to |signal|'s [=AbortSignal/abort reason=].
+    1. For each |auction| in |auctionConfig|'s [=auction config/component auctions=]:
+      1. Set |auction|'s [=auction config/aborted=] to true.
+  1. Else [=AbortSignal/Add|Add the following abort steps=] to |signal|:
+    1. Set |auctionConfig|'s [=auction config/aborted=] to true.
+    1. Set |auctionConfig|'s [=auction config/abort reason=] to |signal|'s [=AbortSignal/abort reason=].
+    1. For each |auction| in |auctionConfig|'s [=auction config/component auctions=]:
+      1. Set |auction|'s [=auction config/aborted=] to true.
 1. [=Assert=] that |settings|'s [=environment settings object/origin=] is not an [=opaque origin=]
   and its [=origin/scheme=] is "`https`".
 1. Let |queue| be the result of [=starting a new parallel queue=].
@@ -790,7 +793,9 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
       |bidDebugReportInfoList| and |winnerInfo|.
     1. Set |auctionReportInfo|'s [=auction report info/real time reporting contributions map=] to
       |realTimeContributionsMap|.
-  1. If |winnerInfo| is failure, then [=queue a global task=] on [=DOM manipulation task source=],
+  1. If |auctionConfig|'s [=auction config/aborted=] is true:
+    1. [=Reject=] |p| with |auctionConfig|'s [=auction config/abort reason=].
+  1. Otherwise if |winnerInfo| is failure, then [=queue a global task=] on [=DOM manipulation task source=],
     given |global|, to [=reject=] |p| with a "{{TypeError}}".
   1. Otherwise if |winnerInfo| is null or |winnerInfo|'s [=leading bid info/leading bid=] is null:
     1. [=Queue a global task=] on [=DOM manipulation task source=], given |global|, to [=resolve=]
@@ -1644,6 +1649,7 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
   |auctionConfig|'s [=auction config/decision logic url=] and |settings|.
 1. Let « |bidGenerators|, |negativeTargetInfo| » be the result of running
   [=build bid generators map=] with |auctionConfig|.
+1. If |auctionConfig|'s [=auction config/aborted=] is true, return failure.
 1. Let |leadingBidInfo| be a new [=leading bid info=].
 1. Let |queue| be the result of [=starting a new parallel queue=].
 1. Let |capturedAuctionHeaders| be |global|'s [=associated Document's=] [=node navigable's=]
@@ -1679,6 +1685,7 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
       "top-level-auction", null, |topLevelOrigin|, and |realTimeContributionsMap|.
     1. Decrement |pendingComponentAuctions| by 1.
   1. Wait until |pendingComponentAuctions| is 0.
+  1. If |auctionConfig|'s [=auction config/aborted=] is true, return failure.
   1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, return null.
   1. Let |winningComponentConfig| be |leadingBidInfo|'s [=leading bid info/auction config=].
   1. Set |leadingBidInfo|'s [=leading bid info/auction config=] to |auctionConfig|.
@@ -1921,6 +1928,7 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
               |componentAuctionExpectedCurrency|, |topLevelOrigin|, and |realTimeContributionsMap|.
   1. Decrement |pendingBuyers| by 1.
 1. Wait until both |pendingBuyers| and |pendingAdditionalBids| are 0.
+1. If |auctionConfig|'s [=auction config/aborted=] is true, return failure.
 1. If |leadingBidInfo|'s [=leading bid info/leading bid=] is null, return null.
 1. If |topLevelAuctionConfig| is null:
   1. Let « |sellerSignals|, |reportResultBrowserSignals| » be the result of running
@@ -3948,6 +3956,7 @@ from querying the server during an auction.
 
 <div algorithm>
   To <dfn>update k-anonymity cache for key</dfn> given a [=SHA-256=] |hashCode|:
+    1. [=Assert=] that these steps are running [=in parallel=].
     1. Let |record| be a new [=k-anonymity record=].
     1. Set |record|'s [=k-anonymity record/timestamp=] field to the [=current wall time=].
     1. Set |record|'s [=k-anonymity record/is k-anonymous=] field to the result of executing [=query k-anonymity count=] for |hashCode|.
@@ -3956,6 +3965,7 @@ from querying the server during an auction.
 
 <div algorithm>
   To <dfn>update k-anonymity cache for interest group</dfn> given an [=interest group=] |ig|:
+    1. [=Assert=] that these steps are running [=in parallel=].
     1. [=list/For each=] |igAd| of |ig|'s [=interest group/ads=]:
       1. Compute the |adHashCode| following [=compute the key hash of ad=] for |ig| and |igAd|.
       1. Run [=update k-anonymity cache for key=] on |adHashCode|.
@@ -6292,6 +6302,10 @@ An <dfn>auction config</dfn> is a [=struct=] with the following [=struct/items=]
     encrypted response stored in [=auction config=]'s [=auction config/server response=] field.
     Must be null when [=auction config=]'s [=auction config/server response=] is null,
     and non-null otherwise.
+  : <dfn>aborted</dfn>
+  :: A [=boolean=] indicating whether the auction has been aborted, initially false.
+  : <dfn>abort reason</dfn>
+  :: Null or a [=string=], initially null.
 </dl>
 
 <div algorithm>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brusshamilton/turtledove/pull/1266.html" title="Last updated on Sep 23, 2024, 6:58 PM UTC (13b9d18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1266/815f0f1...brusshamilton:13b9d18.html" title="Last updated on Sep 23, 2024, 6:58 PM UTC (13b9d18)">Diff</a>