### PR TITLE
Try to fix build after fenced frame spec container size removal.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -832,14 +832,11 @@ To <dfn>construct a pending fenced frame config</dfn> given an [=auction config=
     : [=mapped url/visibility=]
     :: "<a for=visibility>`opaque`</a>"
 
-  : [=fenced frame config/container size=]
+  : [=fenced frame config/content size=]
   :: the result of
 
    Issue: converting |config|'s [=auction config/requested size=] to pixel values
    (<a href="https://github.com/WICG/turtledove/issues/986">WICG/turtledove#986</a>)
-
-  : [=fenced frame config/content size=]
-  :: null
 
   : [=fenced frame config/interest group descriptor=]
   :: a [=struct=] with the following [=struct/items=]:
@@ -1067,9 +1064,6 @@ To <dfn>create nested configs</dfn> given [=generated bid/ad component descripto
 
       : [=mapped url/visibility=]
       :: "<a for=visibility>`opaque`</a>"
-
-    : [=fenced frame config/container size=]
-    :: null
 
     : [=fenced frame config/content size=]
     :: If |adComponentDescriptor|'s [=ad descriptor/size=] is null, then null. Otherwise, a


### PR DESCRIPTION
I think one of our uses of it was probably meant to be content size instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/turtledove/pull/1270.html" title="Last updated on Sep 5, 2024, 2:35 PM UTC (fb7aef0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1270/815f0f1...morlovich:fb7aef0.html" title="Last updated on Sep 5, 2024, 2:35 PM UTC (fb7aef0)">Diff</a>