### PR TITLE
[Spec] Fix bug in bid generation

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1854,11 +1854,11 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
                |browserSignals|["{{BiddingBrowserSignals/crossOriginDataVersion}}"] to |dataVersion|.
             1. Otherwise, [=map/set=] |browserSignals|["{{BiddingBrowserSignals/dataVersion}}"] to
                |dataVersion|.
-          1. Let « |bidsBatch|, |bidDebugReportInfo| » be the result of
-            [=generate potentially multiple bids=] given |allTrustedBiddingSignals|,
-            |crossOriginTrustedBiddingSignalsOrigin|, |auctionSignals|, a [=map/clone=] of
-            |browserSignals|, |perBuyerSignals|, |directFromSellerSignalsForBuyer|, |perBuyerTimeout|,
-            |expectedCurrency|, |multiBidLimit|, |ig|, |auctionStartTime|, and |settings|.
+          1. Let |generateBidResult| be the result of [=generate potentially multiple bids=] given
+            |allTrustedBiddingSignals|, |crossOriginTrustedBiddingSignalsOrigin|, |auctionSignals|,
+            a [=map/clone=] of |browserSignals|, |perBuyerSignals|,
+            |directFromSellerSignalsForBuyer|, |perBuyerTimeout|, |expectedCurrency|,
+            |multiBidLimit|, |ig|, |auctionStartTime|, and |settings|.
           1. If |generateBidResult| is failure, then:
             1. If |optedInForRealTimeReporting| is true, then [=add a platform contribution=] with
               [=bidding script failure bucket=], |realTimeContributionsMap| and |buyer|.


### PR DESCRIPTION
The algorithm "generate potentially multiple bids" returns an error or 3-tuple, but the spec was assigning that to a 2 tuple and then using an uninitialized value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/turtledove/pull/1271.html" title="Last updated on Sep 5, 2024, 8:15 PM UTC (0e74004)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1271/d9ad4d1...caraitto:0e74004.html" title="Last updated on Sep 5, 2024, 8:15 PM UTC (0e74004)">Diff</a>