### PR TITLE
[Spec] Handle Ad-Auction-Result response header.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2781,7 +2781,9 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug report
 1. Let |hash| be the [=SHA-256=] of |auctionConfig|'s [=auction config/server response=].
 1. Let |capturedAuctionHeaders| be |global|'s [=associated Document's=] [=node navigable's=]
   [=traversable navigable's=] [=traversable navigable/captured ad auction result headers=].
-1. If |capturedAuctionHeaders| does not [=list/contain=] |hash|, then return failure.
+1. Let |seller| be |auctionConfig|'s [=auction config/seller=].
+1. If |capturedAuctionHeaders|[|seller|] does not [=map/exist=] or does not [=list/contain=] |hash|,
+  then return failure.
 1. Let |requestId| be the value of |auctionConfig|'s [=auction config/server response id=].
 1. Let |requestContexts| be the value of |global|'s [=associated Document's=] [=node navigable's=]
   [=traversable navigable's=] [=traversable navigable/saved Bidding and Auction request context=].
@@ -5583,8 +5585,8 @@ their intended auction.
 Any {{Document}} in a [=traversable navigable=] may run a Protected Audience auction (with
 {{Window/navigator}}.{{Navigator/runAdAuction()}}) whose [=script runners=] functions receive signal
 objects derived from JSON from an [:Ad-Auction-Signals:] header, or [=additional bids=] derived from
-an [:Ad-Auction-Additional-Bid:] header, or auction blob derived from an [:Ad-Auction-Result:]
-header, captured by a {{WindowOrWorkerGlobalScope/fetch()}} call
+an [:Ad-Auction-Additional-Bid:] header, or response blob's [=base64url=] encoded [=SHA-256=] hash
+derived from an [:Ad-Auction-Result:] header, captured by a {{WindowOrWorkerGlobalScope/fetch()}} call
 (using the {{RequestInit/adAuctionHeaders}} option) initiated by any *other* {{Document}} in the
 *same* [=traversable navigable=], or from an
 <a spec="html" lt="navigate an iframe or frame">iframe navigation</a>
@@ -5623,7 +5625,8 @@ are [=server auction request contexts=].
 </div>
 
 Each [=traversable navigable=] has a <dfn for="traversable navigable">captured ad auction result
-headers</dfn>, which is a [=list=] of [=strings=].
+headers</dfn>, which is a [=map=] whose [=map/keys=] are [=origins=] and [=map/values=] are
+[=strings=].
 
 <div algorithm="fetch capture adAuctionHeaders boolean patch">
 Modify the definition of a [=request=]:
@@ -5807,8 +5810,10 @@ The following algorithm will be added to the [[FETCH#fetching]] section:
     1. Let |base64Result| be the result of running [=convert base64url to base64=] with |result|.
     1. If |base64Result| is failure, then [=iteration/continue=].
     1. Let |hash| be the result of running [=forgiving-base64 decode=] with |base64Result|.
-    1. If |hash| is not failure, and |hash|'s [=string/length=] is 32, then [=list/append=] |hash|
-      to |storedAuctionResultHeaders|.
+    1. If |hash| is not failure, and |hash|'s [=string/length=] is 32:
+      1. If |storedAuctionResultHeaders|[|requestOrigin|] [=map/exists=], then [=list/append=] |hash|
+        to |storedAuctionResultHeaders|.
+      1. Otherwise, [=map/set=] |storedAuctionResultHeaders|[|requestOrigin|] to « |hash| ».
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -5806,10 +5806,11 @@ The following algorithm will be added to the [[FETCH#fetching]] section:
     [:Ad-Auction-Result:] from |responseHeaders|.
   1. If |adAuctionResults| is not null, [=list/for each=] |result| of |adAuctionResults|:
     1. [=Strip leading and trailing ASCII whitespace=] from |result|.
-    1. If |result| is "", then [=iteration/continue=].
-    1. Let |base64Result| be the result of running [=convert base64url to base64=] with |result|.
-    1. If |base64Result| is failure, then [=iteration/continue=].
-    1. Let |hash| be the result of running [=forgiving-base64 decode=] with |base64Result|.
+    1. If |result| is "", or contains [=code points=] U+002B (`+`) or U+002F (`/`), then
+      [=iteration/continue=].
+    1. Replace every U+2212 (`-`) [=code point=] in |result| with U+002B (`+`).
+    1. Replace every U+005F(`_`) [=code point=] in |result| with U+002F (`/`).
+    1. Let |hash| be the result of running [=forgiving-base64 decode=] with |result|.
     1. If |hash| is not failure, and |hash|'s [=string/length=] is 32:
       1. If |storedAuctionResultHeaders|[|requestOrigin|] [=map/exists=], then [=list/append=] |hash|
         to |storedAuctionResultHeaders|.
@@ -5864,18 +5865,6 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
         </dl>
 
     1. Set |storedSignalsHeaders|[|signalsKey|] to |processedSignals|.
-</div>
-
-<div algorithm>
-To <dfn>convert base64url to base64</dfn> given a [=string=] |adAuctionResult|:
-
-  1. If |adAuctionResult| contains [=code points=] U+002B (`+`) or U+002F (`/`), return failure.
-  1. Replace every U+2212 (`-`) [=code point=] in |adAuctionResult| with U+002B (`+`).
-  1. Replace every U+005F(`_`) [=code point=] in |adAuctionResult| with U+002F (`/`).
-  1. Let |paddingSize| be <code>|adAuctionResult|'s [=string/length=] % 4</code>.
-  1. [=list/For each=] <var ignore>i</var> in [=the range=] from 0 to |paddingSize|, exclusive:
-    1. Append U+003D(`=`) to the end of |adAuctionResult|.
-  1. Return |adAuctionResult|.
 </div>
 
 

--- a/spec.bs
+++ b/spec.bs
@@ -2894,7 +2894,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug report
    : [=leading bid info/top level seller signals=]
    :: Null
    : [=leading bid info/component seller=]
-   :: Null if |topLevelAuctionConfig| is not null, otherwise |auctionConfig|'s [=auction config/seller=].
+   :: Null if |topLevelAuctionConfig| is null, otherwise |auctionConfig|'s [=auction config/seller=].
    : [=leading bid info/bidding data version=]
    :: Null
    : [=leading bid info/scoring data version=]

--- a/spec.bs
+++ b/spec.bs
@@ -2894,7 +2894,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug report
    : [=leading bid info/top level seller signals=]
    :: Null
    : [=leading bid info/component seller=]
-   :: Null if |topLevelAuctionConfig| is null, otherwise |auctionConfig|'s [=auction config/seller=].
+   :: Null if |topLevelAuctionConfig| is not null, otherwise |auctionConfig|'s [=auction config/seller=].
    : [=leading bid info/bidding data version=]
    :: Null
    : [=leading bid info/scoring data version=]

--- a/spec.bs
+++ b/spec.bs
@@ -35,6 +35,8 @@ urlPrefix: https://github.com/WICG/turtledove/blob/main/FLEDGE_k_anonymity_serve
   type: dfn; text: k-anonymity; url: what-is-k-anonymity
 urlPrefix: https://developer.chrome.com/en/docs/privacy-sandbox/glossary/
   type: dfn; text: ad creative; url: ad-creative
+spec: RFC4648; urlPrefix: https://datatracker.ietf.org/doc/html/rfc4648
+  type: dfn; text: base64url; url: section-5
 spec: RFC6234; urlPrefix: https://www.ietf.org/rfc/rfc6234.txt
   type: dfn; text: SHA-256
 urlPrefix: https://datatracker.ietf.org/doc/html/rfc8032
@@ -2769,13 +2771,17 @@ a {{ReportingBrowserSignals}} |browserSignals|, a [=direct from seller signals=]
 To <dfn>parse and validate server response</dfn> given an [=auction config=] |auctionConfig|, an
 [=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|,
 a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug reporting info=]
-|bidDebugReportInfoList|:
+|bidDebugReportInfoList|, perform the following steps. They return a [=leading bid info=] or a failure.
 
 1. [=Assert=] that these steps are running [=in parallel=].
 1. [=Assert=] that |topLevelAuctionConfig| is null.
 
     Issue: TODO: Support multi-level auctions.
     (<a href="https://github.com/WICG/turtledove/issues/1254">WICG/turtledove#1254</a>)
+1. Let |hash| be the [=SHA-256=] of |auctionConfig|'s [=auction config/server response=].
+1. Let |capturedAuctionHeaders| be |global|'s [=associated Document's=] [=node navigable's=]
+  [=traversable navigable's=] [=traversable navigable/captured ad auction result headers=].
+1. If |capturedAuctionHeaders| does not [=list/contain=] |hash|, then return failure.
 1. Let |requestId| be the value of |auctionConfig|'s [=auction config/server response id=].
 1. Let |requestContexts| be the value of |global|'s [=associated Document's=] [=node navigable's=]
   [=traversable navigable's=] [=traversable navigable/saved Bidding and Auction request context=].
@@ -5570,9 +5576,6 @@ prevents a leak of the user's ad interest group membership to the server.
 
 # Fetch Patch for Auction Headers # {#fetch-patch-for-auction-headers}
 
-    Issue: TODO: Handle Bidding and Auction Server header.
-    (<a href="https://github.com/WICG/turtledove/issues/1254">WICG/turtledove#1254</a>)
-
 This section specifies a manner by which some data, including [=additional bids=] and
 [=direct from seller signals=], may be provided to auctions such that the data is only used within
 their intended auction.
@@ -5580,7 +5583,8 @@ their intended auction.
 Any {{Document}} in a [=traversable navigable=] may run a Protected Audience auction (with
 {{Window/navigator}}.{{Navigator/runAdAuction()}}) whose [=script runners=] functions receive signal
 objects derived from JSON from an [:Ad-Auction-Signals:] header, or [=additional bids=] derived from
-an [:Ad-Auction-Additional-Bid:] header, captured by a {{WindowOrWorkerGlobalScope/fetch()}} call
+an [:Ad-Auction-Additional-Bid:] header, or auction blob derived from an [:Ad-Auction-Result:]
+header, captured by a {{WindowOrWorkerGlobalScope/fetch()}} call
 (using the {{RequestInit/adAuctionHeaders}} option) initiated by any *other* {{Document}} in the
 *same* [=traversable navigable=], or from an
 <a spec="html" lt="navigate an iframe or frame">iframe navigation</a>
@@ -5617,6 +5621,9 @@ and Auction request context</dfn>, which is a [=map=] whose [=map/keys=] are
 the [=string representation=] of a [=version 4 UUID=] and whose [=map/values=]
 are [=server auction request contexts=].
 </div>
+
+Each [=traversable navigable=] has a <dfn for="traversable navigable">captured ad auction result
+headers</dfn>, which is a [=list=] of [=strings=].
 
 <div algorithm="fetch capture adAuctionHeaders boolean patch">
 Modify the definition of a [=request=]:
@@ -5712,6 +5719,24 @@ corresponds to a single [=additional bid=]. The response may include more than o
 by specifying multiple instances of the [:Ad-Auction-Additional-Bid:] response header.
 </div>
 
+<h3 id=ad-auction-result-header>The \`<a http-header><code>Ad-Auction-Result</code></a>\`
+HTTP response header.</h3>
+
+The \`<dfn http-header><code>Ad-Auction-Result</code></dfn>\` response header provides the
+[=base64url=] encoded [=SHA-256=] hash of the response blob. Multiple hashes can be included in a
+response by either repeating the header or by specifying multiple hashes separated by a "`,`" character.
+
+<div id="ad-auction-result-example" class=example>
+  <pre highlight="js">
+    Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0=,9UTB-u-WshX66Xqz5DNCpEK9z-x5oCS5SXvgyeoRB1k=
+  </pre>
+  is equivalent to
+  <pre highlight="js">
+    Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0=
+    Ad-Auction-Result: 9UTB-u-WshX66Xqz5DNCpEK9z-x5oCS5SXvgyeoRB1k=
+  </pre>
+</div>
+
 <div algorithm="ad auction fetch redirect patch">
 The following steps will be added to the [=HTTP fetch=] algorithm, immediately under the step "If
 <var ignore>internalResponse</var>’s [=status=] is a [=redirect status=]:"
@@ -5734,7 +5759,8 @@ The following step will be added to the [=HTTP fetch=] algorithm, before step
     [=node navigable=]'s [=traversable navigable=].
   1. Run [=update captured headers=] with |navigable|'s
     [=traversable navigable/captured ad auction signals headers=], |navigable|'s
-    [=traversable navigable/captured ad auction additional bids headers=], |response|'s
+    [=traversable navigable/captured ad auction additional bids headers=], |navigable|'s
+    [=traversable navigable/captured ad auction result headers=], |response|'s
     [=response/header list=], and |request|'s [=request/URL=]'s [=url/origin=].
 
 </div>
@@ -5745,6 +5771,7 @@ The following algorithm will be added to the [[FETCH#fetching]] section:
   To <dfn id=concept-update-captured-headers>update captured headers</dfn> with a [=traversable
   navigable/captured ad auction signals headers=] |storedSignalsHeaders|,
   [=traversable navigable/captured ad auction additional bids headers=] |storedAdditionalBidsHeaders|,
+  [=traversable navigable/captured ad auction result headers=] |storedAuctionResultHeaders|,
   [=header list=] |responseHeaders|, and [=origin=] |requestOrigin|:
   1. Let |adAuctionSignals| be the result of [=header list/getting=] [:Ad-Auction-Signals:] from
     |responseHeaders|.
@@ -5756,6 +5783,7 @@ The following algorithm will be added to the [[FETCH#fetching]] section:
       the header value.
     1. [=Handle ad auction signals header value=] given |adAuctionSignals|, |storedSignalsHeaders| and
       |requestOrigin|.
+
   1. Let |additionalBids| be the result of [=header list/getting, decoding, and splitting=]
     [:Ad-Auction-Additional-Bid:] from |responseHeaders|.
   1. If |additionalBids| is not null:
@@ -5770,6 +5798,17 @@ The following algorithm will be added to the [[FETCH#fetching]] section:
       1. Let |nonce| be |nonceAndAdditionalBid|[0].
       1. If |nonce|'s [=string/length=] is not 36, then [=iteration/continue=].
       1. Set |storedAdditionalBidsHeaders|[|nonce|] to |nonceAndAdditionalBid|[1].
+
+  1. Let |adAuctionResults| be the result of [=header list/getting, decoding, and splitting=]
+    [:Ad-Auction-Result:] from |responseHeaders|.
+  1. If |adAuctionResults| is not null, [=list/for each=] |result| of |adAuctionResults|:
+    1. [=Strip leading and trailing ASCII whitespace=] from |result|.
+    1. If |result| is "", then [=iteration/continue=].
+    1. Let |base64Result| be the result of running [=convert base64url to base64=] with |result|.
+    1. If |base64Result| is failure, then [=iteration/continue=].
+    1. Let |hash| be the result of running [=forgiving-base64 decode=] with |base64Result|.
+    1. If |hash| is not failure, and |hash|'s [=string/length=] is 32, then [=list/append=] |hash|
+      to |storedAuctionResultHeaders|.
 
 </div>
 
@@ -5820,6 +5859,18 @@ To <dfn>handle ad auction signals header value</dfn> given a [=byte sequence=] |
         </dl>
 
     1. Set |storedSignalsHeaders|[|signalsKey|] to |processedSignals|.
+</div>
+
+<div algorithm>
+To <dfn>convert base64url to base64</dfn> given a [=string=] |adAuctionResult|:
+
+  1. If |adAuctionResult| contains [=code points=] U+002B (`+`) or U+002F (`/`), return failure.
+  1. Replace every U+2212 (`-`) [=code point=] in |adAuctionResult| with U+002B (`+`).
+  1. Replace every U+005F(`_`) [=code point=] in |adAuctionResult| with U+002F (`/`).
+  1. Let |paddingSize| be <code>|adAuctionResult|'s [=string/length=] % 4</code>.
+  1. [=list/For each=] <var ignore>i</var> in [=the range=] from 0 to |paddingSize|, exclusive:
+    1. Append U+003D(`=`) to the end of |adAuctionResult|.
+  1. Return |adAuctionResult|.
 </div>
 
 


### PR DESCRIPTION
Parses Ad-Auction-Result response header, and verifies a Fetch request to the seller’s origin with "adAuctionHeaders: true" that included an Ad-Auction-Result header with hash of auction config's response_blob.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1280.html" title="Last updated on Sep 23, 2024, 1:46 AM UTC (9d9460b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1280/61665eb...qingxinwu:9d9460b.html" title="Last updated on Sep 23, 2024, 1:46 AM UTC (9d9460b)">Diff</a>