### PR TITLE
[spec] Remove redundant 'is chaff' field

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2796,7 +2796,6 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug report
     Issue: TODO: Link deserialization to IETF standard when available.
     (<a href="https://github.com/WICG/turtledove/issues/1254">WICG/turtledove#1254</a>)
 1. If |response| is failure, then return failure.
-1. If |response|'s [=server auction response/is chaff=] is true, return failure.
 1. If |response|'s [=server auction response/top level seller=] is not null:
   1. If |topLevelAuctionConfig| is null return failure.
   1. If |topLevelAuctionConfig|'s [=auction config/seller=] is not equal to
@@ -3057,8 +3056,6 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
 from an auction executed on the trusted auction server. It has the following [=struct/items=]:
 
 <dl dfn-for="server auction response">
-  : <dfn>is chaff</dfn>
-  :: A [=boolean=] field indicating whether this response should be ignored.
   : <dfn>ad render url</dfn>
   :: [=URL=]. The [=leading bid info/leading bid=]'s [=generated bid/ad descriptor=]'s [=ad descriptor/url=] from the
      auction.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brusshamilton/turtledove/pull/1282.html" title="Last updated on Sep 23, 2024, 3:27 PM UTC (f0aaace)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1282/3911315...brusshamilton:f0aaace.html" title="Last updated on Sep 23, 2024, 3:27 PM UTC (f0aaace)">Diff</a>