### PR TITLE
[Spec] Fix the abort steps in promise handling

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1705,26 +1705,24 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
       1. Let |compWinnerInfo| be the result of running [=generate and score bids=] with |component|,
         |auctionConfig|, |global|, |bidIgs|, |bidDebugReportInfoList|, and |realTimeContributionsMap|.
     1. If [=recursively wait until configuration input promises resolve=] given |auctionConfig|
-      returns failure, or |compWinnerInfo| is failure, then:
-      1. Decrement |pendingComponentAuctions| by 1.
-      1. Abort these steps.
-    1. If |topLevelDirectFromSellerSignalsRetrieved| is false:
-      1. Let |topLevelDirectFromSellerSignals| be the result of running
-        [=get direct from seller signals=] given |seller|, |auctionConfig|'s
-        [=auction config/direct from seller signals header ad slot=], and |capturedAuctionHeaders|.
-      1. Set |topLevelDirectFromSellerSignalsForSeller| to the result of running
-        [=get direct from seller signals for a seller=] given |topLevelDirectFromSellerSignals|.
-      1. Set |topLevelDirectFromSellerSignalsRetrieved| to true.
-    1. If |compWinnerInfo|'s [=leading bid info/leading bid=] is not null, then run
-      [=score and rank a bid=] with |auctionConfig|, |compWinnerInfo|'s
-      [=leading bid info/leading bid=], |leadingBidInfo|, |decisionLogicFetcher|,
-      |trustedScoringSignalsBatcher|, null, "top-level-auction", null, and |topLevelOrigin|.
-    1. If |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]
-      is not null, then run [=score and rank a bid=] with |auctionConfig|,
-      |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=],
-      |leadingBidInfo|, |decisionLogicFetcher|, |trustedScoringSignalsBatcher|,
-      |topLevelDirectFromSellerSignalsForSeller|, null, "top-level-auction", null, |topLevelOrigin|,
-      and |realTimeContributionsMap|.
+      does not return failure, and |compWinnerInfo| is not failure, then:
+      1. If |topLevelDirectFromSellerSignalsRetrieved| is false:
+        1. Let |topLevelDirectFromSellerSignals| be the result of running
+          [=get direct from seller signals=] given |seller|, |auctionConfig|'s
+          [=auction config/direct from seller signals header ad slot=], and |capturedAuctionHeaders|.
+        1. Set |topLevelDirectFromSellerSignalsForSeller| to the result of running
+          [=get direct from seller signals for a seller=] given |topLevelDirectFromSellerSignals|.
+        1. Set |topLevelDirectFromSellerSignalsRetrieved| to true.
+      1. If |compWinnerInfo|'s [=leading bid info/leading bid=] is not null, then run
+        [=score and rank a bid=] with |auctionConfig|, |compWinnerInfo|'s
+        [=leading bid info/leading bid=], |leadingBidInfo|, |decisionLogicFetcher|,
+        |trustedScoringSignalsBatcher|, null, "top-level-auction", null, and |topLevelOrigin|.
+      1. If |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]
+        is not null, then run [=score and rank a bid=] with |auctionConfig|,
+        |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=],
+        |leadingBidInfo|, |decisionLogicFetcher|, |trustedScoringSignalsBatcher|,
+        |topLevelDirectFromSellerSignalsForSeller|, null, "top-level-auction", null, |topLevelOrigin|,
+        and |realTimeContributionsMap|.
     1. Decrement |pendingComponentAuctions| by 1.
   1. Wait until |pendingComponentAuctions| is 0.
   1. If |auctionConfig|'s [=auction config/aborted=] is true, return failure.


### PR DESCRIPTION
I thought the "abort these steps" for a component auction only aborted the steps for that component auction. But since all component auctions' steps are added to the same queue (which has a single [algorithm queue](https://html.spec.whatwg.org/multipage/infrastructure.html#algorithm-queue) that all steps are added to and then run in series), so the "abort these steps" may mean abort all component auctions' steps, at least it's ambiguous. It's different from what we wanted it say.
This is just a quick fix to let the algorithm match our intention and be less ambiguous. We may want to change the parallel queue to just "in parallel", or multiple queues, to let component auctions run simultaneously, but  that needs further consideration and more care about how to deal race conditions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1300.html" title="Last updated on Oct 10, 2024, 6:32 PM UTC (9e306a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1300/1349420...qingxinwu:9e306a7.html" title="Last updated on Oct 10, 2024, 6:32 PM UTC (9e306a7)">Diff</a>