### PR TITLE
[Spec] Remove B&A fDO report handling todo

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -785,8 +785,8 @@ The <dfn for=Navigator method>runAdAuction(|config|)</dfn> method steps are:
 1. [=parallel queue/enqueue steps|Enqueue the following steps=] to |queue|:
   1. Let |bidDebugReportInfoList| be a new [=list=] of [=bid debug reporting info=].
   1. If |auctionConfig|'s [=auction config/server response=] is not null:
-    1. Let |winnerInfo| be the result of running [=parse and validate server response=] with |auctionConfig|,
-      null, |global|, |bidIgs|, and |bidDebugReportInfoList|.
+    1. Let |winnerInfo| be the result of running [=parse and validate server response=] with
+      |auctionConfig|, null, |global|, and |bidIgs|.
   1. Otherwise:
     1. Let |realTimeContributionsMap| be a new [=real time reporting contributions map=].
     1. Let |winnerInfo| be the result of running [=generate and score bids=] with |auctionConfig|,
@@ -1718,7 +1718,7 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
     [=parallel queue/enqueue steps|enqueue the following steps=] to |queue|:
     1. If |component|'s [=auction config/server response=] is not null:
       1. Let |compWinnerInfo| be the result of running [=parse and validate server response=] with
-         |component|, |auctionConfig|, |global|, |bidIgs|, and |bidDebugReportInfoList|.
+         |component|, |auctionConfig|, |global|, and |bidIgs|.
     1. Otherwise:
       1. Let |compWinnerInfo| be the result of running [=generate and score bids=] with |component|,
         |auctionConfig|, |global|, |bidIgs|, |bidDebugReportInfoList|, and |realTimeContributionsMap|.
@@ -2819,9 +2819,9 @@ a {{ReportingBrowserSignals}} |browserSignals|, a [=direct from seller signals=]
 
 <div algorithm>
 To <dfn>parse and validate server response</dfn> given an [=auction config=] |auctionConfig|, an
-[=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|,
-a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug reporting info=]
-|bidDebugReportInfoList|, perform the following steps. They return a [=leading bid info=] or a failure.
+[=auction config=]-or-null |topLevelAuctionConfig|, a [=global object=] |global|, and a [=list=] of
+[=interest groups=] |bidIgs|, perform the following steps. They return a [=leading bid info=] or a
+failure.
 
 1. [=Assert=] that these steps are running [=in parallel=].
 1. If [=waiting until server response promise resolves=] given |auctionConfig| returns failure, then
@@ -2964,10 +2964,6 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=list=] of [=bid debug report
   1. If [=current wall time=] &minus; |ig|'s [=interest group/last updated=] ≥
      |updateIfOlderThan|, set |ig|'s [=interest group/next update after=] to the
         [=current wall time=] + |updateIfOlderThan|.
-1. Insert the debug reporting URLs from |response| into |bidDebugReportInfoList|.
-
-    Issue: TODO: Handle forDebuggingOnly reports from server auction.
-    (<a href="https://github.com/WICG/turtledove/issues/1254">WICG/turtledove#1254</a>)
 1. Return |winningBidInfo|.
 
 </div>


### PR DESCRIPTION
Since the [referenced github issue](https://github.com/WICG/turtledove/issues/1254) (which lists B&A spec tasks required for I2S) is closed, and the fDO or PAgg parts for B&A would come in future separate pull requests which do not block the B&A I2S.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1301.html" title="Last updated on Oct 11, 2024, 5:32 PM UTC (31e1653)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1301/a5912c0...qingxinwu:31e1653.html" title="Last updated on Oct 11, 2024, 5:32 PM UTC (31e1653)">Diff</a>