### PR TITLE
[SPEC] Fix for selectedBuyerAndSellerReportingId

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2165,7 +2165,7 @@ To <dfn>convert to an AuctionAd sequence</dfn> given a [=list=]-or-null |ads|:
     1. [=map/Set=] |adIDL|["{{AuctionAd/renderURL}}"] to the [=URL serializer|serialization=] of
       |ad|'s [=interest group ad/render url=].
     1. If |ad|'s [=interest group ad/selectable buyer and seller reporting IDs=] is not null:
-      1.[=map/Set=] |adIDL|["{{AuctionAd/selectableBuyerAndSellerReportingIds}}"] to
+      1. [=map/Set=] |adIDL|["{{AuctionAd/selectableBuyerAndSellerReportingIds}}"] to
         |ad|'s [=interest group ad/selectable buyer and seller reporting IDs=].
       1. If |ad|'s [=interest group ad/buyer and seller reporting id=] is not null then
         [=map/set=] |adIDL|["{{AuctionAd/buyerAndSellerReportingId}}"] to

--- a/spec.bs
+++ b/spec.bs
@@ -5199,8 +5199,8 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. Set |bid|'s [=generated bid/bid ad=] to |bidAd|.
   1. If |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"] [=map/exists=]:
     1. If |bidAd|'s [=interest group ad/selectable buyer and seller reporting IDs=] does not
-    [=list/contain=] |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"],
-    return failure.
+      [=list/contain=] |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"],
+      return failure.
     1. Set |bid|'s [=generated bid/selected buyer and seller reporting ID=] to
       |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"].
   1. If |generateBidOutput|["{{GenerateBidOutput/adComponents}}"] [=map/exists=]:

--- a/spec.bs
+++ b/spec.bs
@@ -5896,6 +5896,9 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer reporting ID=] if the field is not null.
   1. The [=string/length=] of |ad|'s [=interest group ad/buyer and seller reporting ID=] if the
     field is not null.
+  1. If |ad|'s [=interest group ad/selectable buyer and seller reporting IDs=] is not null,
+    [=list/for each=] |id| of it:
+    1. The [=string/length=] of |id|.
   1. If |ad|'s [=interest group ad/allowed reporting origins=] is not null, [=list/for each=]
     |origin| of it:
     1. The [=string/length=] of the [=serialization of an origin|serialization=] of |origin|.

--- a/spec.bs
+++ b/spec.bs
@@ -5198,7 +5198,7 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. Set |bid|'s [=generated bid/ad descriptor=] to |adDescriptor|.
   1. Set |bid|'s [=generated bid/bid ad=] to |bidAd|.
   1. If |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"] [=map/exists=]:
-    1. If |bidAd|'s [=interest group ad/selectable buyer and seller reporting IDs=] does not
+    1. If |bidAd|'s [=interest group ad/selectable buyer and seller reporting IDs=] is null, or does not
       [=list/contain=] |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"],
       return failure.
     1. Set |bid|'s [=generated bid/selected buyer and seller reporting ID=] to

--- a/spec.bs
+++ b/spec.bs
@@ -5198,6 +5198,9 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
   1. Set |bid|'s [=generated bid/ad descriptor=] to |adDescriptor|.
   1. Set |bid|'s [=generated bid/bid ad=] to |bidAd|.
   1. If |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"] [=map/exists=]:
+    1. If |bidAd|'s [=interest group ad/selectable buyer and seller reporting IDs=] does not
+    [=list/contain=] |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"],
+    return failure.
     1. Set |bid|'s [=generated bid/selected buyer and seller reporting ID=] to
       |generateBidOutput|["{{GenerateBidOutput/selectedBuyerAndSellerReportingId}}"].
   1. If |generateBidOutput|["{{GenerateBidOutput/adComponents}}"] [=map/exists=]:


### PR DESCRIPTION
Adds a check to ensure that the generated bid's `selectedBuyerAndSellerReportingId`, is present within the bid ad's `selectableBuyerAndSellerReportingIds`, otherwise will return a failure.

Also adds the size of `selectableBuyerAndSellerReportingIds` to the `estimated size`  algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HabibiYou/turtledove/pull/1317.html" title="Last updated on Oct 29, 2024, 3:00 PM UTC (fe6ef34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1317/9f8d951...HabibiYou:fe6ef34.html" title="Last updated on Oct 29, 2024, 3:00 PM UTC (fe6ef34)">Diff</a>