### PR TITLE
Trusted Signals KVv2 Support Feature Detection

### DIFF
--- a/PA_Feature_Detecting.md
+++ b/PA_Feature_Detecting.md
@@ -146,6 +146,15 @@ navigator.protectedAudience && navigator.protectedAudience.queryFeatureSupport(
     "selectableReportingIds")
 ```
 
+## Trusted Signals KVv2 Support
+Intent to Ship(TBD)
+
+From context of a web page:
+```
+navigator.protectedAudience && navigator.protectedAudience.queryFeatureSupport(
+    "trustedSignalsKVv2")
+```
+
 ## Getting browser-side detectable features as an object
 Sometimes it's desirable to get status of all features detectable via `queryFeatureSupport` in a
 forward-compatible way. Sufficiently recent versions provide this functionality via


### PR DESCRIPTION
Add a section for how to detect if Trusted Signals KVv2 Support feature is enabled. Intent to ship link is TBD and will be added after I2S process is started.