### PR TITLE
[Spec] Add downsampling forDebuggingOnly support for B&A response

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3115,7 +3115,8 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
       [=bid debug reporting info/bidder debug loss report url=] to |maybeDebugReportUrl|.
 1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/server filtered debugging only reports=]
   to [=server auction response/server filtered debugging only reports=].
-1. Set |reportingContextMap|[|auctionConfig|] to |bidDebugReportingInfo|.
+1. Set |reportingContextMap|[|auctionConfig|]'s [=reporting context/debug reporting info=] to
+  |bidDebugReportingInfo|.
 1. Let |reportingId| be a [=reporting bid key=] with the following [=struct/items=]:
   : [=reporting bid key/context=]
   :: |reportingContextMap|[|auctionConfig|]
@@ -3716,8 +3717,7 @@ an [=origin=] |origin| and [=worklet function=] |workletFunction|:
 </div>
 
 A <dfn>reporting context map</dfn> is a [=map=] from [=auction config=] to [=reporting context=].
-Here the keys are configurations for auctions that actually produce bids (e.g. not the top-level
-auction in a multi-seller auction).
+Here the keys are configurations for auctions that actually produce bids.
 
 <div algorithm>
   To <dfn>create a reporting context map</dfn> given the [=auction config=] |auctionConfig| and
@@ -3842,13 +3842,19 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
           1. If the result of running [=is debugging only in cooldown or lockout=] with
             |invokingOrigin| is false, then [=update debug report cooldown=] with |invokingOrigin|.
           1. [=iteration/Continue=].
+
+          Note: An entry for |invokingOrigin| is still needed when |debugURLs| is empty. It could
+            happen when the forDebuggingOnly API is called but the bidding and auction server
+            filtered the debug report URL out with downsampling algorithm. In this case the client
+            still needs to know that the debug report API was called and update its cooldown
+            information.
         1. [=list/For each=] |url| of |debugURLs|:
           1. [=Collect a single forDebuggingOnly report=] with |url|, |invokingOrigin|,
             |fromServer| (true), and |auctionReportInfo|'s [=auction report info/debug loss report urls=].
 
-            Note: For server filtered ones, post auction signals were filled on the server side. As
-              a result, there's no difference if they go to loss or win lists, since post auction
-              signals was the difference.
+            Note: For server filtered ones, post auction signals were filled on the server side, so
+              it's fine to collect them all to [=auction report info/debug loss report urls=] without
+              the need of getting post auction signals for debug win urls.
   1. Return |auctionReportInfo|.
 </div>
 
@@ -3902,7 +3908,7 @@ and [=map/values=] are [=moments=] at which the cool down for the origin key exp
 <div algorithm>
   To <dfn>sample a debug report</dfn> given an [=origin=] |origin| and a [=boolean=] |fromServer|:
 
-  Note: forDebuggingOnly reports from [=server auction response=] were downsampled on truested
+  Note: forDebuggingOnly reports from [=server auction response=] were downsampled on trusted
     auction servers, so do not downsample them again on client.
   1. Let |canSendAfterSampled| be false.
   1. Let |sampleRand| be a random {{long}}, 0 &le; |sampleRand| &lt; 1000, so each possible long would be

--- a/spec.bs
+++ b/spec.bs
@@ -3844,10 +3844,11 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
           1. [=iteration/Continue=].
 
           Note: An entry for |invokingOrigin| is still needed when |debugURLs| is empty. It could
-            happen when the forDebuggingOnly API is called but the bidding and auction server
+            happen when forDebuggingOnly API is called but the bidding and auction server
             filtered the debug report URL out with downsampling algorithm. In this case the client
-            still needs to know that the debug report API was called and update its cooldown
-            information.
+            still needs to know that forDebuggingOnly API was called and update its cooldown
+            information. This is different from forDebuggingOnly API not being called by one origin,
+            in which case the list won't have an entry for that origin.
         1. [=list/For each=] |url| of |debugURLs|:
           1. [=Collect a single forDebuggingOnly report=] with |url|, |invokingOrigin|,
             |fromServer| (true), and |auctionReportInfo|'s [=auction report info/debug loss report urls=].

--- a/spec.bs
+++ b/spec.bs
@@ -4430,7 +4430,7 @@ from querying the server during an auction.
               1. Let |reportingHashCode| be the result of [=query reporting ID k-anonymity count=]
                 given |ig|, |igAd|, and |selectableReportingId|. 
               1. If [=query k-anonymity cache=] for |reportingHashCode| returns true, then
-                [=list/Append=] |selectableReportingId| to |kAnonRestrictedSelectableReportingIds|.
+                [=list/append=] |selectableReportingId| to |kAnonRestrictedSelectableReportingIds|.
             1. Set |igAd|'s [=interest group ad/selectable buyer and seller reporting IDs=] to
               |kAnonRestrictedSelectableReportingIds|.
           1. [=list/Append=] |igAd| to |kAnonRestrictedIG|'s [=interest group/ads=].

--- a/spec.bs
+++ b/spec.bs
@@ -3070,6 +3070,27 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
      equals |componentAd|. If there is no matching element, return failure.
   1. [=list/Append=] a new [=ad descriptor=] whose [=ad descriptor/url=] is
      |componentAd| to |winningAdComponents|.
+1. Let |bidDebugReportingInfo| be a new [=bid debug reporting info=].
+1. [=list/For each=] |key| → |maybeDebugReportUrl| in |response|'s
+  [=server auction response/component win debugging only reports=]:
+  1. If |key|'s [=server auction debug report key/from seller=] is true:
+    1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/component seller=] to |seller|.
+    1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
+      |bidDebugReportingInfo|'s [=bid debug reporting info/seller debug win report url=] to
+      |maybeDebugReportUrl|.
+    1. Otherwise, then set |bidDebugReportingInfo|'s
+      [=bid debug reporting info/seller debug loss report url=] to |maybeDebugReportUrl|.
+  1. Otherwise,
+    1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/interest group owner=] to
+      |response|'s [=server auction response/interest group owner=].
+    1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
+      |bidDebugReportingInfo|'s [=bid debug reporting info/bidder debug win report url=] to
+      |maybeDebugReportUrl|.
+    1. Otherwise, then set |bidDebugReportingInfo|'s
+      [=bid debug reporting info/bidder debug loss report url=] to |maybeDebugReportUrl|.
+1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/server filtered debugging only reports=]
+  to [=server auction response/server filtered debugging only reports=].
+1. Set |reportingContextMap|[|auctionConfig|] to |bidDebugReportingInfo|.
 1. Let |reportingId| be a [=reporting bid key=] with the following [=struct/items=]:
   : [=reporting bid key/context=]
   :: |reportingContextMap|[|auctionConfig|]
@@ -3174,23 +3195,6 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
   1. If [=current coarsened wall time=] &minus; |ig|'s [=interest group/last updated=] ≥
      |updateIfOlderThan|, set |ig|'s [=interest group/next update after=] to the
      [=current coarsened wall time=] + |updateIfOlderThan|.
-1. Let |bidDebugReportingInfo| be a new [=bid debug reporting info=]. 
-1. [=list/For each=] |key| → |maybeDebugReportUrl| in |response|'s
-  [=server auction response/component win debugging only reports=]:
-  1. If |key|'s [=server auction debug report key/from seller=] is true:
-    1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
-      |bidDebugReportingInfo|'s [=bid debug reporting info/seller debug win report url=] to
-      |maybeDebugReportUrl|.
-    1. Otherwise, then set |bidDebugReportingInfo|'s
-      [=bid debug reporting info/seller debug loss report url=] to |maybeDebugReportUrl|.
-  1. Otherwise,
-    1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
-      |bidDebugReportingInfo|'s [=bid debug reporting info/bidder debug win report url=] to
-      |maybeDebugReportUrl|.
-    1. Otherwise, then set |bidDebugReportingInfo|'s
-      [=bid debug reporting info/bidder debug loss report url=] to |maybeDebugReportUrl|.
-1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/server filtered debugging only reports=]
-  to [=server auction response/server filtered debugging only reports=].
 1. Return |winningBidInfo|.
 
 </div>
@@ -3879,7 +3883,6 @@ and [=map/values=] are [=moments=] at which the cool down for the origin key exp
     [=short cooldown period=] otherwise.
   1. Set [=user agent=]'s [=debug report cooldown=][|origin|] to [=current coarsened wall time=]
     plus |cooldownPeriod|.
-  1. Return |canSendAfterSampled|.
 </div>
 
 ## {{InterestGroupBiddingAndScoringScriptRunnerGlobalScope/realTimeReporting}} ## {#real-time-reporting-header}

--- a/spec.bs
+++ b/spec.bs
@@ -3717,7 +3717,6 @@ an [=origin=] |origin| and [=worklet function=] |workletFunction|:
 </div>
 
 A <dfn>reporting context map</dfn> is a [=map=] from [=auction config=] to [=reporting context=].
-Here the keys are configurations for auctions that actually produce bids.
 
 <div algorithm>
   To <dfn>create a reporting context map</dfn> given the [=auction config=] |auctionConfig| and
@@ -3845,8 +3844,8 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
 
           Note: An entry for |invokingOrigin| is still needed when |debugURLs| is empty. It could
             happen when forDebuggingOnly API is called but the bidding and auction server
-            filtered the debug report URL out with downsampling algorithm. In this case the client
-            still needs to know that forDebuggingOnly API was called and update its cooldown
+            filtered the debug report URL out with the downsampling algorithm. In this case the
+            client still needs to know that forDebuggingOnly API was called and update its cooldown
             information. This is different from forDebuggingOnly API not being called by one origin,
             in which case the list won't have an entry for that origin.
         1. [=list/For each=] |url| of |debugURLs|:

--- a/spec.bs
+++ b/spec.bs
@@ -3078,7 +3078,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
     1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
       |bidDebugReportingInfo|'s [=bid debug reporting info/seller debug win report url=] to
       |maybeDebugReportUrl|.
-    1. Otherwise, then set |bidDebugReportingInfo|'s
+    1. Otherwise, set |bidDebugReportingInfo|'s
       [=bid debug reporting info/seller debug loss report url=] to |maybeDebugReportUrl|.
   1. Otherwise,
     1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/interest group owner=] to
@@ -3086,7 +3086,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
     1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
       |bidDebugReportingInfo|'s [=bid debug reporting info/bidder debug win report url=] to
       |maybeDebugReportUrl|.
-    1. Otherwise, then set |bidDebugReportingInfo|'s
+    1. Otherwise, set |bidDebugReportingInfo|'s
       [=bid debug reporting info/bidder debug loss report url=] to |maybeDebugReportUrl|.
 1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/server filtered debugging only reports=]
   to [=server auction response/server filtered debugging only reports=].

--- a/spec.bs
+++ b/spec.bs
@@ -3022,17 +3022,18 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
      equals |componentAd|. If there is no matching element, return failure.
   1. [=list/Append=] a new [=ad descriptor=] whose [=ad descriptor/url=] is
      |componentAd| to |winningAdComponents|.
+1. Let |reportingId| be a [=reporting bid key=] with the following [=struct/items=]:
+  : [=reporting bid key/context=]
+  :: |reportingContextMap|[|auctionConfig|]
+  : [=reporting bid key/source=]
+  :: [=reporting bid source/bidding-and-auction-services=]
+  : [=reporting bid key/bidder origin=]
+  :: |response|'s [=server auction response/interest group owner=]
+  : [=reporting bid key/bid identifier=]
+  :: |response|'s [=server auction response/interest group name=]
 1. Let |winningBid| be a new [=generated bid=] with the following [=struct/items=]:
   : [=generated bid/reporting id=]
-  :: A [=reporting bid key=] with the following [=struct/items=]:
-    : [=reporting bid key/context=]
-    :: |reportingContextMap|[|auctionConfig|]
-    : [=reporting bid key/source=]
-    :: [=reporting bid source/bidding-and-auction-services=]
-    : [=reporting bid key/bidder origin=]
-    :: |response|'s [=server auction response/interest group owner=]
-    : [=reporting bid key/bid identifier=]
-    :: |response|'s [=server auction response/interest group name=]
+  :: |reportingId|
   : [=generated bid/bid=]
   :: |response|'s [=server auction response/bid=]
   : [=generated bid/bid in seller currency=]
@@ -3125,6 +3126,23 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
   1. If [=current wall time=] &minus; |ig|'s [=interest group/last updated=] ≥
      |updateIfOlderThan|, set |ig|'s [=interest group/next update after=] to the
         [=current wall time=] + |updateIfOlderThan|.
+1. Let |bidDebugReportingInfo| be a new [=bid debug reporting info=]. 
+1. [=list/For each=] |key| → |maybeDebugReportUrl| in |response|'s
+  [=server auction response/component win debugging only reports=]:
+  1. If |key|'s [=server auction debug report key/from seller=] is true:
+    1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
+      |bidDebugReportingInfo|'s [=bid debug reporting info/seller debug win report url=] to
+      |maybeDebugReportUrl|.
+    1. Otherwise, then set |bidDebugReportingInfo|'s
+      [=bid debug reporting info/seller debug loss report url=] to |maybeDebugReportUrl|.
+  1. Otherwise,
+    1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
+      |bidDebugReportingInfo|'s [=bid debug reporting info/bidder debug win report url=] to
+      |maybeDebugReportUrl|.
+    1. Otherwise, then set |bidDebugReportingInfo|'s
+      [=bid debug reporting info/bidder debug loss report url=] to |maybeDebugReportUrl|.
+1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/server filtered debugging only reports=]
+  to [=server auction response/server filtered debugging only reports=].
 1. Return |winningBidInfo|.
 
 </div>
@@ -3244,6 +3262,8 @@ dictionary AdAuctionDataBuyerConfig {
     specified.
 </dl>
 
+A <dfn>server auction</dfn> is an auction executed on a trusted auction server.
+
 A <dfn>server auction interest group</dfn> is a [=struct=] with the following [=struct/items=]:
 <dl dfn-for="server auction interest group">
   : <dfn>name</dfn>
@@ -3301,8 +3321,8 @@ A <dfn>server auction request context</dfn> is a [=struct=] with the following [
      [Section 2.2.4 of Bidding and Auction Services](https://privacysandbox.github.io/draft-ietf-bidding-and-auction-services/draft-ietf-bidding-and-auction-services.html#name-generating-a-request)
 </dl>
 
-A <dfn>server auction response</dfn> is a [=struct=] that contains auction result
-from an auction executed on the trusted auction server. It has the following [=struct/items=]:
+A <dfn>server auction response</dfn> is a [=struct=] that contains auction result from a
+[=server auction=]. It has the following [=struct/items=]:
 
 <dl dfn-for="server auction response">
   : <dfn>ad render url</dfn>
@@ -3355,6 +3375,11 @@ from an auction executed on the trusted auction server. It has the following [=s
   :: Null or [=server auction reporting info=].
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
+  : <dfn>component win debugging only reports</dfn>
+  :: A [=map=] whose [=map/keys=] are [=server auction debug report keys=], and whose [=map/values=]
+    are [=lists=] of [=urls=].
+  : <dfn>server filtered debugging only reports</dfn>
+  :: A [=map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=lists=] of [=urls=].
 </dl>
 
 A <dfn>server auction reporting info</dfn> is a [=struct=] with the following [=struct/items=]:
@@ -3364,6 +3389,14 @@ A <dfn>server auction reporting info</dfn> is a [=struct=] with the following [=
   : <dfn>beacon urls</dfn>
   :: [=ordered map=] whose [=map/keys=] are [=strings=] and whose [=map/values=]
      are [=URLs=] whose [=url/schemes=] are "`https`".
+</dl>
+
+a <dfn>server auction debug report key</dfn> is a [=struct=] with the following [=struct/items=]:
+<dl dfn-for="server auction debug report key">
+  : <dfn>from seller</dfn>
+  :: A [=boolean=].
+  : <dfn>is debug win</dfn>
+  :: A [=boolean=].
 </dl>
 
 <div algorithm="getInterestGroupAdAuctionData()">
@@ -3566,7 +3599,7 @@ A <dfn>reporting context</dfn> is a [=struct=] with the following [=struct/items
 
 A <dfn>reporting context map</dfn> is a [=map=] from [=auction config=] to [=reporting context=].
 Here the keys are configurations for auctions that actually produce bids (e.g. not the top-level
-auction in a multi-party auction).
+auction in a multi-seller auction).
 
 <div algorithm>
   To <dfn>create a reporting context map</dfn> given [=auction config=] |auctionConfig|:
@@ -3590,7 +3623,7 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
 
 <div algorithm>
   To <dfn>collect a single forDebuggingOnly report</dfn> given a [=URL=] |reportUrl|, an [=origin=]
-  |invokingOrigin|, and a [=list=] |debugReportUrls|:
+  |invokingOrigin|, a [=boolean=] |fromServer|, and a [=list=] |debugReportUrls|:
 
   Note: While the browser is experimenting with third party cookie deprecation (before they have
   been fully removed), the {{InterestGroupBiddingAndScoringScriptRunnerGlobalScope/forDebuggingOnly}}
@@ -3599,8 +3632,8 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
 
   1. If |reportUrl| is null, or the result of running [=is debugging only in cooldown or lockout=]
     with |invokingOrigin| is true, then return.
-  1. If the result of running [=sample a debug report=] with |invokingOrigin| is true, then
-    [=list/append=] |reportUrl| to |debugReportUrls|.
+  1. If the result of running [=sample a debug report=] with |invokingOrigin| and |fromServer| is
+    true, then [=list/append=] |reportUrl| to |debugReportUrls|.
 </div>
 
 <div algorithm>
@@ -3613,42 +3646,57 @@ methods for event-level <dfn>forDebuggingOnly reports</dfn> for winning and losi
   1. [=map/For each=] _ → |reportingContext| of |reportingContextMap|:
     1. [=map/For each=] |reportingId| -> |bidDebugReportInfo| of |reportingContext|'s
       [=reporting context/debug reporting info=]:
+      1. Let |fromServer| be true if |reportingId|'s [=reporting bid key/source=] is
+        [=reporting bid source/bidding-and-auction-services=], false otherwise.
       1. If |winningBid| is not null and |reportingId| is equal to |winningBid|'s
         [=generated bid/reporting id=]:
         1. [=Assert=] that |winningBid|'s [=generated bid/reporting id=] is not null.
         1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
           [=bid debug reporting info/bidder debug win report url=], |bidDebugReportInfo|'s
-          [=bid debug reporting info/interest group owner=], and |auctionReportInfo|'s
+          [=bid debug reporting info/interest group owner=], |fromServer|, and |auctionReportInfo|'s
           [=auction report info/debug win report urls=].
         1. If |bidDebugReportInfo|'s [=bid debug reporting info/component seller=] is null:
           1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
-            [=bid debug reporting info/seller debug win report url=], |seller|, and
+            [=bid debug reporting info/seller debug win report url=], |seller|, |fromServer|, and
             |auctionReportInfo|'s [=auction report info/debug win report urls=].
         1. Otherwise:
           1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
             [=bid debug reporting info/seller debug win report url=], |bidDebugReportInfo|'s
-            [=bid debug reporting info/component seller=], |auctionReportInfo|'s
+            [=bid debug reporting info/component seller=], |fromServer|, and |auctionReportInfo|'s
             [=auction report info/debug win report urls=].
           1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
-            [=bid debug reporting info/top level seller debug win report url=], |seller|, and
-            |auctionReportInfo|'s [=auction report info/debug win report urls=].
+            [=bid debug reporting info/top level seller debug win report url=], |seller|, |fromServer|,
+            and |auctionReportInfo|'s [=auction report info/debug win report urls=].
       1. Otherwise:
         1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
           [=bid debug reporting info/bidder debug loss report url=], |bidDebugReportInfo|'s
-          [=bid debug reporting info/interest group owner=], and |auctionReportInfo|'s
+          [=bid debug reporting info/interest group owner=], |fromServer|, and |auctionReportInfo|'s
           [=auction report info/debug loss report urls=].
         1. If |bidDebugReportInfo|'s [=bid debug reporting info/component seller=] is null:
           1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
-            [=bid debug reporting info/seller debug loss report url=], |seller|, and
+            [=bid debug reporting info/seller debug loss report url=], |seller|, |fromServer|, and
             |auctionReportInfo|'s [=auction report info/debug loss report urls=].
         1. Otherwise:
           1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
             [=bid debug reporting info/seller debug loss report url=], |bidDebugReportInfo|'s
-            [=bid debug reporting info/component seller=], |auctionReportInfo|'s
+            [=bid debug reporting info/component seller=], |fromServer|, |auctionReportInfo|'s
             [=auction report info/debug loss report urls=].
           1. [=Collect a single forDebuggingOnly report=] with |bidDebugReportInfo|'s
-            [=bid debug reporting info/top level seller debug loss report url=], |seller|, and
-            |auctionReportInfo|'s [=auction report info/debug loss report urls=].
+            [=bid debug reporting info/top level seller debug loss report url=], |seller|,
+            |fromServer|, and |auctionReportInfo|'s [=auction report info/debug loss report urls=].
+      1. [=map/For each=] |invokingOrigin| → |debugURLs| of |bidDebugReportInfo|'s
+        [=bid debug reporting info/server filtered debugging only reports=]:
+        1. If |debugURLs| [=list/is empty=]:
+          1. If the result of running [=is debugging only in cooldown or lockout=] with
+            |invokingOrigin| is false, then [=update debug report cooldown=] with |invokingOrigin|.
+          1. [=iteration/Continue=].
+        1. [=list/For each=] |url| of |debugURLs|:
+          1. [=Collect a single forDebuggingOnly report=] with |url|, |invokingOrigin|,
+            |fromServer| (true), and |auctionReportInfo|'s [=auction report info/debug loss report urls=].
+
+            Note: For server filtered ones, post auction signals were filled on the server side. As
+              a result, there's no difference if they go to loss or win lists, since post auction
+              signals was the difference.
   1. Return |auctionReportInfo|.
 </div>
 
@@ -3723,23 +3771,30 @@ and [=map/values=] are [=moments=] at which the cool down for the origin key exp
 </div>
 
 <div algorithm>
-  To <dfn>sample a debug report</dfn> given an [=origin=] |origin|:
+  To <dfn>sample a debug report</dfn> given an [=origin=] |origin| and a [=boolean=] |fromServer|:
 
+  Note: forDebuggingOnly reports from [=server auction response=] were downsampled on truested
+    auction servers, so do not downsample them again on client.
   1. Let |canSendAfterSampled| be false.
   1. Let |sampleRand| be a random {{long}}, 0 &le; |sampleRand| &lt; 1000, so each possible long would be
     chosen with a probability equal to [=sampling rate=].
-  1. If |sampleRand| is 0:
+  1. If |fromServer| is true or |sampleRand| is 0:
     1. Set |canSendAfterSampled| to true.
     1. Set [=user agent=]'s [=debug report lockout until=] to [=current wall time=] plus
       [=lockout period=].
-  1. Let |cooldownRand| be a random {{long}} &ge; 0 and &lt; 10, which corresponds to
+  1. [=Update debug report cooldown=] with |origin|.
+  1. Return |canSendAfterSampled|.
+</div>
 
+<div algorithm>
+  To <dfn>update debug report cooldown</dfn> given an [=origin=] |origin|:
+
+  1. Let |cooldownRand| be a random {{long}} &ge; 0 and &lt; 10, which corresponds to
     [=long cooldown rate=].
   1. Let |cooldownPeriod| be [=long cooldown period=] if |cooldownRand| is 0,
     [=short cooldown period=] otherwise.
   1. Set [=user agent=]'s [=debug report cooldown=][|origin|] to [=current wall time=] plus
     |cooldownPeriod|.
-  1. Return |canSendAfterSampled|.
 </div>
 
 ## {{InterestGroupBiddingAndScoringScriptRunnerGlobalScope/realTimeReporting}} ## {#real-time-reporting-header}
@@ -7817,6 +7872,9 @@ A <dfn>bid debug reporting info</dfn> is a [=struct=] with the following [=struc
     won it, and was then scored by the top-level seller. Set by top-level seller's `scoreAd()`'s
     {{InterestGroupBiddingAndScoringScriptRunnerGlobalScope/forDebuggingOnly}}'s
     {{ForDebuggingOnly/reportAdAuctionLoss(url)}}.
+  : <dfn>server filtered debugging only reports</dfn>
+  :: A [=map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=lists=] of [=urls=].
+    forDebuggingOnly reports that have been filtered (also downsampled) by the trusted auction server.
 </dl>
 
 A <dfn>bid with currency</dfn> is a [=struct=] with the following [=struct/items=]:


### PR DESCRIPTION
Client side support of downsampling forDebuggingOnly reports for auctions run on bidding and auction service.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1325.html" title="Last updated on Nov 22, 2024, 8:24 PM UTC (84abc36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1325/ad8b634...qingxinwu:84abc36.html" title="Last updated on Nov 22, 2024, 8:24 PM UTC (84abc36)">Diff</a>