### PR TITLE
Add I2S to Selectable Reporting IDs on feature detection page

### DIFF
--- a/PA_Feature_Detecting.md
+++ b/PA_Feature_Detecting.md
@@ -139,6 +139,7 @@ navigator.protectedAudience && navigator.protectedAudience.queryFeatureSupport(
 ```
 
 ## Selectable Reporting IDs
+[Intent to Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/1cWqBPHngd0)
 
 From context of a web page:
 ```


### PR DESCRIPTION
This is to match all of the other features on that page, each of which has a link to their corresponding I2S.