### PR TITLE
Add Trusted Signals KVv2 support to W3C Spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2701,6 +2701,8 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
 are [=strings=] and values are [=tuples=] consisting of an interger and an integer , and a [=boolean=]
 |isBiddingSignal|:
 
+1. If |body| is null, set |signals| to failure and return.
+
 1. Let |request| be a new [=request=] with the following properties:
   :   [=request/URL=]
   ::  |url|
@@ -8188,27 +8190,28 @@ A <dfn>bidding signals per interest group data</dfn> is a [=struct=] with the fo
     or explicitly by the {{Navigator/updateAdInterestGroups()}} method.
 </dl>
 
-A <dfn>compression group</dfn> is a collection of [=partitions=] that can be compressed together
-in the signals response. It's a [=struct=] with the following [=struct/items=]:
+A <dfn>bidding compression group</dfn> is a collection of [=bidding partitions=] that can be compressed
+together in the signals response. It's a [=struct=] with the following [=struct/items=]:
 
-<dl dfn-for="compression group">
+<dl dfn-for="bidding compression group">
   : <dfn>compression group id</dfn>
   :: An integer indicates the index of this compression group.
   : <dfn>partitions</dfn>
-  :: A [=list=] of [=partition=]. Contains all the partitions belong to this compression group.
+  :: A [=list=] of [=bidding partition=]. Contains all the [=bidding partitions=] belong to this compression
+    group.
 </dl>
 
-A <dfn>partition</dfn> is a collection of [=trusted bidding signals batcher/keys=] that can be
-processed together by the service without any potential privacy leakage. It's a [=struct=] with
-the following [=struct/items=]:
+A <dfn>bidding partition</dfn> is a collection of [=trusted bidding signals batcher/keys=] and 
+[=trusted bidding signals batcher/ig names=] that can be processed together by the service without
+any potential privacy leakage. It's a [=struct=] with the following [=struct/items=]:
 
-<dl dfn-for="partition">
+<dl dfn-for="bidding partition">
   : <dfn>id</dfn>
   :: An integer indicates the index of this partition.
   : <dfn>namespace</dfn>
   :: A [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of
-    [=strings=]. A namespace contains all [=interest group/name=]s and
-    [=interest group/trusted bidding signals keys=]s in the partition.
+    [=strings=]. A namespace contains all [=interest group/names=] and
+    [=interest group/trusted bidding signals keys=] in the partition.
   : <dfn>metadata</dfn>
   :: A [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 </dl>
@@ -8375,58 +8378,64 @@ To <dfn>build trusted key value bidding signals request body</dfn> given a [=set
 an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
 |slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
 
-1. Let |compressionGroups| be an empty [=list=], whose [=list/items=] are [=compression groups=].
+1. Let |compressionGroups| be an empty [=list=], whose [=list/items=] are [=bidding compression groups=].
 1. Let |compressionGroupMap| be an empty [=map=], where the [=map/keys=] are integers as
-  [=compression group/compression group id=], and the [=map/values=] are [=maps=] with integers as [=map/keys=]
-  for [=partition/id=], and [=partitions=] as their [=map/values=].
+  [=bidding compression group/compression group id=], and the [=map/values=] are [=maps=] with integers as [=map/keys=]
+  for [=bidding partition/id=], and [=bidding partitions=] as their [=map/values=].
 1. Let |compressionIdMap| be an empty [=map=], whose [=map/keys=] are [=origins=] and [=map/values=] are integers.
 1. Let |interestGroupIdMap| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=tuples=]
   of (interger, integer).
 1. Let |slotSizeParams| be the result of [=strictly splitting=] |slotSizeQueryParam| on U+003D (=).
 1. Let |nextCompressionGroupId| be 0.
 1. [=list/For each=] |group| of |interestGroups|:
-  1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
-  1. Let |partitionId| be an integer.
+  1. Let |joiningOrigin| be |group|'s [=interest group/joining origin=].
   1. If |compressionIdMap| does not [=map/contain=] |joiningOrigin|:
     1. [=map/Set=] |compressionIdMap|[|joiningOrigin|] to |nextCompressionGroupId|.
     1. Increment |nextCompressionGroupId| by 1.
   1. Let |compressionGroupId| be |compressionIdMap|[|joiningOrigin|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose [=map/keys=] are integers
+    1.[=map/Set=] |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers
       and [=map/values=] are [=maps=].
-  1. Set |executionMode| to |group|'s [=interest group/execution mode=].
-  1. If |executionMode| equal to "`group-by-origin`", set |partitionId| to 0.
+  1. If |group|'s [=interest group/execution mode=] is "`group-by-origin`", set |partitionId| to 0.
   1. Otherwise:
     1. If |compressionGroupMap|[|compressionGroupId|] [=map/contains=] 0, set |partitionId| to
       [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
     1. Otherwise, set |partitionId| to sum [=list/size=] of |compressionGroupMap|[|joiningOrigin|]
       and 1.
-  1. Set |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of |compressionGroupId|
-    and |partitionId|.
-  1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|:
-    1. Let |partition| be an empty [=partition=].
-    1. Set |partition|'s [=partition/id=] to |partitionId|.
-    1. Let |namespace| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=]
-      of [=strings=].
-    1. Set |namespace|["interest_group_names"] to [|group|'s [=interest group/name=]].
-    1. Set |namespace|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
-    1. Set |partition|'s [=partition/namespace=] to |namespace|.
-    1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
-    1. Set |metadata|["experiment_group_id"] to |experimentGroupId|.
-    1. Set |metadata|[|slotSizeParams|[0]] to |slotSizeParams|[1].
-    1. Set |partition|'s [=partition/metadata=] to |metadata|.
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
+  1. [=map/Set=] |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of
+    (|compressionGroupId|, |partitionId|).
+  1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|, Set
+    |compressionGroupMap|[|compressionGroupId|][|partitionId|] with the following [=struct/items=]:
+    : [=bidding partition=]
+    :: a [=struct=] with the following [=struct/items=]:
+      : [=bidding partition/id=]
+      :: an integer records the identifier of this [=bidding partition=].
+
+      : [=bidding partition/namespace=]
+      :: a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of [=strings=].
+
+      : [=bidding partition/metadata=]
+      :: a [=map=] whose [=map/keys=] and [=map/values=] are [=strings=].
+
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/namespace=]["interest_group_names"]
+      to [|group|'s [=interest group/name=]].
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/namespace=]["bidding_keys"] to
+      |group|'s [=interest group/trusted bidding signals keys=].
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/metadata=]["experiment_group_id"]
+      to |experimentGroupId|.
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/metadata=][|slotSizeParams|[0]] to
+      |slotSizeParams|[1].
   1. Otherwise:
     1. [=list/Append=] |group|'s [=interest group/name=] into |compressionGroupMap|[|compressionGroupId|]
       [|partitionId|]["interest_group_names"].
     1. [=list/Append=] |group|'s [=interest group/trusted bidding signals keys=] into
       |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=compression group=].
-  1. Set |compressionGroup|'s [=compression group/compression group id=] to |id|.
-  1. Set |compressionGroup|'s [=compression group/partition=] to an empty [=list=].
+  1. Let |compressionGroup| be an empty [=bidding compression group=].
+  1. Set |compressionGroup|'s [=bidding compression group/compression group id=] to |id|.
+  1. Set |compressionGroup|'s [=bidding compression group/partition=] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
-    1. [=list/Append=] |partition| to |compressionGroup|'s [=compression group/partition=].
+    1. [=list/Append=] |partition| to |compressionGroup|'s [=bidding compression group/partition=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
 1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
@@ -8434,7 +8443,9 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
 1. Set |metadata|["hostname"] to |hostname|.
 1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |owner| and
   |coordinator|.
-1. Let (|requestBlob|, |context|) be the result of generating request |keyInfo|, |metadata| and
+1. If |keyInfo| is failure:
+  1. Return « null, null, and null ».
+1. Let (|requestBlob|, |context|) be the result of generating request with |keyInfo|, |metadata| and
   |compressionGroups|. The generation method may follow that described in 
   [Section 2.2.4 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-generating-a-request).
 1. Return |requestBlob|, |interestGroupIdMap| and |context|.
@@ -8531,6 +8542,32 @@ A <dfn>trusted scoring signals reply</dfn> is a [=struct=] with the following [=
   :: A [=ordered map=] or failure.
   : <dfn>data version</dfn>
   :: An {{unsigned long}} or null.
+</dl>
+
+A <dfn>scoring compression group</dfn> is a collection of [=scoring partitions=] that can be compressed
+together in the signals response. It's a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="scoring compression group">
+  : <dfn>compression group id</dfn>
+  :: An integer indicates the index of this compression group.
+  : <dfn>partitions</dfn>
+  :: A [=list=] of [=scoring partition=]. Contains all the [=scoring partitions=] belong to this compression
+    group.
+</dl>
+
+A <dfn>scoring partition</dfn> is a collection of [=trusted scoring signals request/render URLs=] and 
+[=trusted scoring signals request/ad component URLs=] that can be processed together by the service
+without any potential privacy leakage. It's a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="scoring partition">
+  : <dfn>id</dfn>
+  :: An integer indicates the index of this partition.
+  : <dfn>namespace</dfn>
+  :: A [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of
+    [=strings=]. A namespace contains all [=trusted scoring signals request/render URLs=] and 
+    [=trusted scoring signals request/ad component URLs=] in the partition.
+  : <dfn>metadata</dfn>
+  :: A [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 </dl>
 
 <div algorithm>
@@ -8632,8 +8669,10 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 [=trusted scoring signals requests=] |entriesToBatch|:
 
 1. Let |firstRequest| be |entriesToBatch|[0].
-1. Let |compressionGroups| be an empty [=list=], whose values are [=maps=].
-1. Let |compressionGroupMap| be an empty [=map=], whose [=map/keys=] are integers and keys are [=maps=].
+1. Let |compressionGroups| be an empty [=list=], whose [=list/items=] are [=scoring compression groups=].
+1. Let |compressionGroupMap| be an empty [=map=], where the [=map/keys=] are integers as
+  [=scoring compression group/compression group id=], and the [=map/values=] are [=maps=] with integers as [=map/keys=]
+  for [=scoring partition/id=], and [=scoring partitions=] as their [=map/values=].
 1. Let |compressionIdMap| be an empty [=map=], whose [=map/keys=] are [=tuples=] of ([=origin=],
   [=origin=]) and [=map/values=] are integers.
 1. Let |renderUrlIdMap| be an empty [=map=], whose [=map/keys=] are [=URLs=] and [=map/values=] are [=tuples=]
@@ -8651,27 +8690,30 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   1. Let |partitionId| be [=list/size=] of |compressionGroupMap|[|compressionGroupId|].
   1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
     of (|compressionGroupId|, |partitionId|).
-  1. Let |partition| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
-      [=list=] of [=strings=].
-  1. Set |partition|["id"] to |partitionId|.
-  1. Let |namespace| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
-      [=list=] of [=strings=].
-  1. Set |namespace|["render_url"] to [|request|'s [=trusted scoring signals request/render URL=]].
-  1. Set |namespace|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
-    component URLs=].
-  1. Set |partition|["namespace"] to |namespace|.
-  1. Let |partitionMetadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
-  1. Set |partitionMetadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
-      request/seller experiment group id=].
-  1. Set |partition|["metadata"] to |partitionMetadata|.
-  1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
+  1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] with the following [=struct/items=]:
+    : [=scoring partition=]
+    :: a [=struct=] with the following [=struct/items=]:
+      : [=scoring partition/id=]
+      :: an integer records the identifier of this [=scoring partition=].
+
+      : [=scoring partition/namespace=]
+      :: a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of [=strings=].
+
+      : [=scoring partition/metadata=]
+      :: a [=map=] whose [=map/keys=] and [=map/values=] are [=strings=].
+
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=scoring partition/namespace=]["render_urls"]
+      to [|request|'s [=trusted scoring signals request/render URL=]].
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=scoring partition/namespace=]["ad_component_render_urls"]
+      to |request|'s [=trusted scoring signals request/ad component URLs=].
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=scoring partition/metadata=]["experiment_group_id"]
+      to |firstRequest|'s [=trusted scoring signals request/seller experiment group id=].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
-    [=lists=] of [=maps=].
-  1. Set |compressionGroup|["compression_group_id"] to |id|.
-  1. Set |compressionGroup|["partitions"] to an empty [=list=].
+  1. Let |compressionGroup| be an empty [=scoring compression group=].
+  1. Set |compressionGroup|'s [=scoring compression group/compression group id=] to |id|.
+  1. Set |compressionGroup|'s [=bidding compression group/partition=] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
-    1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
+    1. [=list/Append=] |partition| to |compressionGroup|'s [=scoring compression group/partition=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
 1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
@@ -8681,10 +8723,12 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |firstRequest|'s
   [=trusted scoring signals request/seller=] and |firstRequest|'s [=trusted scoring signals
   request/signal coordinator=].
-1. Let (|requestBlob|, |context|) be the result of generating request |keyInfo|, |metadata| and
+1. If |keyInfo| is failure:
+  1. Return « null, null, and null ».
+1. Let (|requestBlob|, |context|) be the result of generating request with |keyInfo|, |metadata| and
   |compressionGroups|. The generation method may follow that described in
   [Section 2.2.4 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-generating-a-request).
-1. Return |requestBlob|, |renderUrlIdMap| and |context|.
+1. Return « |requestBlob|, |renderUrlIdMap| and |context| ».
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -8394,7 +8394,7 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     1. Increment |nextCompressionGroupId| by 1.
   1. Let |compressionGroupId| be |compressionIdMap|[|joiningOrigin|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1.[=map/Set=] |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers
+    1. [=map/Set=] |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers
       and [=map/values=] are [=maps=].
   1. If |group|'s [=interest group/execution mode=] is "`group-by-origin`", set |partitionId| to 0.
   1. Otherwise:
@@ -8404,17 +8404,16 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. [=map/Set=] |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of
     (|compressionGroupId|, |partitionId|).
   1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|, set
-    |compressionGroupMap|[|compressionGroupId|][|partitionId|] to a [=bidding partition=] with the following items:
+    |compressionGroupMap|[|compressionGroupId|][|partitionId|] to a [=bidding partition=] with the following [=struct/items=]:
     : [=bidding partition/id=]
     :: |partitionId|
 
     : [=bidding partition/namespace=]
-    :: "interest_group_names" → [|group|'s [=interest group/name=]]
-    :: "bidding_keys" → |group|'s [=interest group/trusted bidding signals keys=]
+    :: The [=ordered map=] «[ "interestGroupNames" → « [|group|'s [=interest group/name=]],
+      "biddingKeys" → |group|'s [=interest group/trusted bidding signals keys=] ]»
 
     : [=bidding partition/metadata=]
-    :: "experiment_group_id" → |experimentGroupId|
-    :: |slotSizeParams|[0] → |slotSizeParams|[1]
+    :: The [=ordered map=] «[ "experimentGroupId" → |experimentGroupId|, |slotSizeParams|[0] → |slotSizeParams|[1] ]»
   1. Otherwise:
     1. [=list/Append=] |group|'s [=interest group/name=] into |compressionGroupMap|[|compressionGroupId|]
       [|partitionId|]["interest_group_names"].
@@ -8668,7 +8667,7 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   of (interger, integer).
 1. Let |nextCompressionGroupId| be 0.
 1. [=map/For each=] |request| of |entriesToBatch|:
-  1. Let |mapKey| be a tuple of (|request|'s [=trusted scoring signals request/owner origin=],
+  1. Let |mapKey| be a [=tuple=] of (|request|'s [=trusted scoring signals request/owner origin=],
     |request|'s [=trusted scoring signals request/joining origin=]).
   1. If |compressionIdMap| does not [=map/contain=] |mapKey|:
     1. [=map/Set=] |compressionIdMap|[|mapKey|] to |nextCompressionGroupId|.
@@ -8685,16 +8684,16 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
     :: |partitionId|
 
     : [=scoring partition/namespace=]
-    :: "render_urls" → [|request|'s [=trusted scoring signals request/render URL=]]
-    :: "ad_component_render_urls" → [=trusted scoring signals request/ad component URLs=]
+    :: The [=ordered map=] «[ "render_urls" → [|request|'s [=trusted scoring signals request/render URL=]],
+      "ad_component_render_urls" → |request|'s [=trusted scoring signals request/ad component URLs=] ]»
 
     : [=scoring partition/metadata=]
-    :: "experiment_group_id" → |firstRequest|'s [=trusted scoring signals request/seller experiment group id=]
+    :: The [=ordered map=] «[ "experiment_group_id" → |firstRequest|'s [=trusted scoring signals request/seller experiment group id=] ]»
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
   1. Let |compressionGroup| be an [=scoring compression group=] whose [=scoring compression group/compression group id=]
     is |id| and [=scoring compression group/partition=] is an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
-    1. [=list/Append=] |partition| to |compressionGroup|'s [=scoring compression group/partition=].
+    1. [=list/Append=] |partition| to |compressionGroup|'s [=scoring compression group/partitions=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
 1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the

--- a/spec.bs
+++ b/spec.bs
@@ -2766,7 +2766,7 @@ interger and an integer , and a [=boolean=] |isBiddingSignal|:
 
 <div algorithm="update CORS-safelisted request-header">
 
-Add "message/ad-auction-trusted-signals-request" to essence check list under content-type in
+Add "message/ad-auction-trusted-signals-request" to mimeType’s essence check list under content-type in
 [CORS-safelisted request-header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -2728,7 +2728,7 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
   deserialization method may follow that described in
   [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
 1. Let |signals| be null.
-1. Let |dataVersion| be an empty [=ordered map=].
+1. Let |dataVersion| be an empty [=ordered map=], whose keys are [=strings=] and values are integers.
 1. Let |perInterestGroupData| be an [=ordered map=].
 1. [=Fetch=] |request| with [=fetch/useParallelQueue=] set to true, and
   [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
@@ -7571,7 +7571,11 @@ An <dfn export>interest group</dfn> is a [=struct=] with the following [=struct/
   :: A {{long}} integer, initially 0. Indicates the maximum trusted bidding signals fetch url length
     for the interest group. 0 means no limit.
   : <dfn>trusted bidding signals coordinator</dfn>
-  :: Null or an [=origin=].
+  :: Null or an [=origin=]. This is used to specify where to obtain the public key used for
+    encryption and decryption in communication with a trusted bidding signal server running in a
+    Trust Execution Environment (TEE). When this field is specified, the request will be sent to
+    a trusted bidding signals server running in a TEE, and the value of
+    [=interest group/trusted bidding signals url=] is ignored.
   : <dfn>user bidding signals</dfn>
   :: Null or a [=string=]. Additional metadata that the owner can use during on-device bidding.
   : <dfn>ads</dfn>
@@ -7732,7 +7736,11 @@ An <dfn export>auction config</dfn> is a [=struct=] with the following [=struct/
   :: A {{long}} integer, initially 0. Indicates the maximum trusted scoring signals fetch url length
     for the auction config. 0 means no limit.
   : <dfn>trusted scoring signals coordinator</dfn>
-  :: Null or an [=origin=].
+  :: Null or an [=origin=]. This is used to specify where to obtain the public key used for
+    encryption and decryption in communication with a trusted scoring signal server running in a
+    Trust Execution Environment (TEE). When this field is specified, the request will be sent to
+    a trusted scoring signals server running in a TEE, and the value of
+    [=auction config/max trusted scoring signals url length=] is ignored.
   : <dfn>interest group buyers</dfn>
   :: Null or a [=list=] of [=origins=].
     Owners of interest groups allowed to participate in the auction. Each [=origin's=]
@@ -8328,7 +8336,7 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
     1. If |keyValueInterestGroups| [=map/contain=] |key|, [=set/Append=] |ig| to |keyValueInterestGroups|
       [|key|].
     1. Otherwise:
-      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=].
+      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=], whose values are [=strings=].
       1. [=set/Append=] |ig| to |keyValueInterestGroups| [|key|].
 
 </div>
@@ -8339,22 +8347,23 @@ To <dfn>build trusted key value bidding signals request body</dfn> given a [=set
 an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
 |slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
 
-1. Let |compressionGroups| be an empty [=list=].
-1. Let |compressionGroupMap| be an empty [=map=].
-1. Let |compressionIdMap| be an empty [=map=].
-1. Let |interestGroupIdMap| be an empty [=map=].
+1. Let |compressionGroups| be an empty [=list=], whose values are [=maps=].
+1. Let |compressionGroupMap| be an empty [=map=], whose keys are integers and values are [=maps=].
+1. Let |compressionIdMap| be an empty [=map=], whose keys [=origins=] and values are integers.
+1. Let |interestGroupIdMap| be an empty [=map=], whose keys are [=strings=] and values are [=tuples=]
+  of (interger, integer).
 1. Let |slotSizeParams| be the result of [=strictly splitting=] |slotSizeQueryParam| on U+003D (=).
 1. Let |nextCompressionGroupId| be 0.
 1. [=list/For each=] |group| of |interestGroups|:
   1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
-  1. Let |compressionGroupId| be an integer.
   1. Let |partitionId| be an integer.
   1. If |compressionIdMap| does not [=map/contain=] |joiningOrigin|:
     1. [=map/Set=] |compressionIdMap|[|joiningOrigin|] to |nextCompressionGroupId|.
     1. Increment |nextCompressionGroupId| by 1.
-  1. Set |compressionGroupId| to |compressionIdMap|[|joiningOrigin|].
+  1. Let |compressionGroupId| be |compressionIdMap|[|joiningOrigin|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=].
+    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose keys are integers
+      and values are [=maps=].
   1. Set |executionMode| to |group|'s [=interest group/execution mode=].
   1. If |executionMode| equal to "`group-by-origin`", set |partitionId| to 0.
   1. Otherwise:
@@ -8365,13 +8374,15 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. Set |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of |compressionGroupId|
     and |partitionId|.
   1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|:
-    1. Let |partition| be an empty [=map=].
+    1. Let |partition| be an empty [=map=], whose keys are [=strings=] and values are integers or
+      [=maps=].
     1. Set |partition|["id"] to |partitionId|.
-    1. Let |namespace| be an empty [=map=].
+    1. Let |namespace| be an empty [=map=], whose keys are [=strings=] and values are [=strings=] or
+      [=list=] of [=strings=].
     1. Set |namespace|["interest_group_names"] to [|group|'s [=interest group/name=]].
     1. Set |namespace|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
     1. Set |partition|["namespace"] to |namespace|.
-    1. Let |metadata| be an empty [=map=].
+    1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
     1. Set |metadata|["experiment_group_id"] to |experimentGroupId|.
     1. Set |metadata|[|slotSizeParams|[0]] to |slotSizeParams|[1].
     1. Set |partition|["metadata"] to |metadata|.
@@ -8382,13 +8393,14 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     1. [=list/Append=] |group|'s [=interest group/trusted bidding signals keys=] into
       |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=map=].
+  1. Let |compressionGroup| be an empty [=map=], whose keys are [=strings=] and values are integers or
+    [=lists=] of [=maps=].
   1. Set |compressionGroup|["compression_group_id"] to |id|.
   1. Set |compressionGroup|["partitions"] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
-1. Let |metadata| be an empty [=map=].
+1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |topLevelOrigin| using [=component percent-encode set=].
 1. Set |metadata|["hostname"] to |hostname|.
@@ -8411,8 +8423,8 @@ an [=origin=] |scriptOrigin|, an {{unsigned short}}-or-null |experimentGroupId|,
   1. [=map/For each=] (|coordinator|, |owner|) → |interestGroups| of [=trusted bidding signals
     batcher/key value interest groups=]:
     1. Let « |requestBody|, |interestGroupIdMap|, |context| » be the result of [=building trusted
-      key value bidding signals request body=] with |signalsUrl|, |interestGroups|,
-      |experimentGroupId|, |topLevelOrigin|, |slotSizeQueryParam|, |coordinator| and |owner|.
+      key value bidding signals request body=] with |interestGroups|, |experimentGroupId|,
+      |topLevelOrigin|, |slotSizeQueryParam|, |coordinator| and |owner|.
     1. Let « |partialTrustedBiddingSignals|, |partialPerInterestGroupData|, |dataVersion| » be the
       result of [=fetching trusted key value signals=] with |signalsUrl|, |requestBody|, |context|,
       |scriptOrigin|, |policyContainer|, |interestGroupIdMap| and true.
@@ -8592,12 +8604,14 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 [=trusted scoring signals requests=] |entriesToBatch|:
 
 1. Let |firstRequest| be |entriesToBatch|[0].
-1. Let |compressionGroupMap| be an empty [=map=].
-1. Let |compressionIdMap| be an empty [=map=].
-1. Let |renderUrlIdMap| be an empty [=map=].
+1. Let |compressionGroups| be an empty [=list=], whose values are [=maps=].
+1. Let |compressionGroupMap| be an empty [=map=], whose keys are integers and keys are [=maps=].
+1. Let |compressionIdMap| be an empty [=map=], whose keys are [=tuples=] of ([=origin=],
+  [=origin=]) and values are integers.
+1. Let |renderUrlIdMap| be an empty [=map=], whose keys are [=URLs=] and values are [=tuples=]
+  of (interger, integer).
 1. Let |nextCompressionGroupId| be 0.
 1. [=map/For each=] |request| of |entriesToBatch|:
-  1. Let |compressionGroupId| be an integer.
   1. Let |partitionId| be an integer.
   1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
   1. Let |ownerOrigin| be |request|'s [=trusted scoring signals request/owner origin=].
@@ -8605,32 +8619,36 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   1. If |compressionIdMap| does not [=map/contain=] |mapKey|:
     1. Set |compressionIdMap|[|mapKey|] to |nextCompressionGroupId|.
     1. Increase |nextCompressionGroupId| by 1.
-  1. Set |compressionGroupId| to |compressionIdMap|[|mapKey|].
+  1. Let |compressionGroupId| be |compressionIdMap|[|mapKey|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=].
-  1. Set |partitionId| to [=list/size=] of |compressionGroups|[|compressionGroupId|].
+    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose keys are integers
+      and values are [=maps=].
+  1. Set |partitionId| to [=list/size=] of |compressionGroupMap|[|compressionGroupId|].
   1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
     of |compressionGroupId| and |partitionId|.
-  1. Let |partition| be an empty [=map=].
+  1. Let |partition| be an empty [=map=], whose keys are [=strings=] and values are [=strings=] or
+      [=list=] of [=strings=].
   1. Set |partition|["id"] to |partitionId|.
-  1. Let |namespace| be an empty [=map=].
+  1. Let |namespace| be an empty [=map=], whose keys are [=strings=] and values are [=strings=] or
+      [=list=] of [=strings=].
   1. Set |namespace|["render_url"] to [|request|'s [=trusted scoring signals request/render URL=]].
   1. Set |namespace|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
     component URLs=].
   1. Set |partition|["namespace"] to |namespace|.
-  1. Let |metadata| be an empty [=map=].
+  1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
   1. Set |metadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
       request/seller experiment group id=].
   1. Set |partition|["metadata"] to |metadata|.
-  1. Set |compressionGroups|[|compressionGroupId|][|partitionId|] to |partition|.
+  1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=map=].
+  1. Let |compressionGroup| be an empty [=map=], whose keys are [=strings=] and values are integers or
+    [=lists=] of [=maps=].
   1. Set |compressionGroup|["compression_group_id"] to |id|.
   1. Set |compressionGroup|["partitions"] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
-1. Let |metadata| be an empty [=map=].
+1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |firstRequest|'s [=trusted scoring signals request/top
     level origin=] using [=component percent-encode set=].

--- a/spec.bs
+++ b/spec.bs
@@ -2752,15 +2752,15 @@ are [=strings=] and values are [=tuples=] consisting of an interger and an integ
       1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
         1. If |indexMap|[|name|] does not equal to |result|["index"], return « null, null, null ».
         1. [=map/Set=] |perInterestGroupData|[|name|] to |value|.
-        1. If |result| [=map/contains=] "`dataVersion`", set |dataVersion|[|name|] to |result|["dataVersion"].
+        1. If |result| [=map/contains=] "`dataVersion`", [=map/set=] |dataVersion|[|name|] to |result|["dataVersion"].
       1. [=map/For each=] |key| → |value| in |result|["keys"]:
-        1. Set |signalsMap|[|key|] to |value|.
+        1. [=map/Set=] |signalsMap|[|key|] to |value|.
     1. Otherwise:
       1. [=map/For each=] |url| → |value| in |result|["renderUrls"]:
-        1. Set |signalsMap|[|url|] to |value|.
-        1. If |result| [=map/contains=] `"dataVersion"`, set |dataVersion|[|url|] to |result|["dataVersion"].
+        1. [=map/Set=] |signalsMap|[|url|] to |value|.
+        1. If |result| [=map/contains=] `"dataVersion"`, [=map/set=] |dataVersion|[|url|] to |result|["dataVersion"].
       1. [=map/For each=] |url| → |value| in |result|["adComponentRenderUrls"]:
-        1. Set |signalsMap|[|url|] to |value|.
+        1. [=map/Set=] |signalsMap|[|url|] to |value|.
 1. If |signalsMap| is not empty, set |signals| to |signalsMap|.
 1. Return « |signals|, |perInterestGroupData|, |dataVersion| ».
 
@@ -8368,7 +8368,7 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
     1. Let |key| be [=tuple=] of (|ig|'s [=interest group/joining origin=], |ig|'s [=interest group/owner=]).
     1. If |keyValueInterestGroups| [=map/contains=] |key|, [=set/append=] |ig| to
       |keyValueInterestGroups|[|key|].
-    1. Otherwise, set |keyValueInterestGroups|[|key|] to a [=set=] « |ig| ».
+    1. Otherwise, [=map/set=] |keyValueInterestGroups|[|key|] to a [=set=] « |ig| ».
 
 </div>
 
@@ -8430,7 +8430,7 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
 1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |topLevelOrigin| using [=component percent-encode set=].
-1. Set |metadata|["hostname"] to |hostname|.
+1. [=map/Set=] |metadata|["hostname"] to |hostname|.
 1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |owner| and
   |coordinator|.
 1. If |keyInfo| is failure, then return « null, null, null ».
@@ -8677,7 +8677,7 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|, then set
     |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers.
   1. Let |partitionId| be [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
-  1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
+  1. [=map/Set=] |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
     of (|compressionGroupId|, |partitionId|).
   1. [=map/Set=] |compressionGroupMap|[|compressionGroupId|][|partitionId|] to a [=scoring partition=] with the
     following [=struct/items=]:
@@ -8700,7 +8700,7 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |firstRequest|'s [=trusted scoring signals request/top
     level origin=] using [=component percent-encode set=].
-1. Set |metadata|["hostname"] to |hostname|.
+1. [=map/Set=] |metadata|["hostname"] to |hostname|.
 1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |firstRequest|'s
   [=trusted scoring signals request/seller=] and |firstRequest|'s [=trusted scoring signals
   request/signal coordinator=].

--- a/spec.bs
+++ b/spec.bs
@@ -239,6 +239,7 @@ dictionary GenerateBidInterestGroup {
   sequence<USVString> trustedBiddingSignalsKeys;
   DOMString trustedBiddingSignalsSlotSizeMode = "none";
   long maxTrustedBiddingSignalsURLLength;
+  USVString trustedBiddingSignalsCoordinator;
   any userBiddingSignals;
   sequence<AuctionAd> ads;
   sequence<AuctionAd> adComponents;
@@ -379,6 +380,12 @@ This is detectable because it can change the set of fields that are read from th
       |interestGroup|'s [=interest group/max trusted bidding signals url length=] to
       |group|["{{GenerateBidInterestGroup/maxTrustedBiddingSignalsURLLength}}"], otherwise
       [=exception/throw=] a {{TypeError}}.
+  1. If |group|["{{GenerateBidInterestGroup/trustedBiddingSignalsCoordinator}}"] [=map/exists=]:
+    1. Let |parsedCoordinator| be the result of [=parsing an https origin=] on
+      |group|["{{GenerateBidInterestGroup/trustedBiddingSignalsCoordinator}}"].
+    1. If |parsedCoordinator| is failure, then [=exception/throw=] a {{TypeError}}.
+    1. Set |interestGroup|'s [=interest group/trusted bidding signals coordinator=] to
+      |parsedCoordinator|.
   1. If |group|["{{GenerateBidInterestGroup/userBiddingSignals}}"] [=map/exists=]:
     1. Set |interestGroup|'s [=interest group/user bidding signals=] to the result of
       [=serializing a JavaScript value to a JSON string=], given
@@ -742,6 +749,7 @@ dictionary AuctionAdConfig {
 
   USVString trustedScoringSignalsURL;
   long maxTrustedScoringSignalsURLLength;
+  USVString trustedScoringSignalsCoordinator;
   sequence<USVString> interestGroupBuyers;
   Promise<any> auctionSignals;
   Promise<any> sellerSignals;
@@ -1255,6 +1263,12 @@ To <dfn>validate and convert auction ad config</dfn> given an {{AuctionAdConfig}
     [=auction config/max trusted scoring signals url length=] to
     |config|["{{AuctionAdConfig/maxTrustedScoringSignalsURLLength}}"], otherwise [=exception/throw=]
     a {{TypeError}}.
+1. If |config|["{{AuctionAdConfig/trustedScoringSignalsCoordinator}}"] [=map/exists=]:
+    1. Let |parsedCoordinator| be the result of [=parsing an https origin=] on
+      |config|["{{AuctionAdConfig/trustedScoringSignalsCoordinator}}"].
+    1. If |parsedCoordinator| is failure, then [=exception/throw=] a {{TypeError}}.
+    1. Set |auctionConfig|'s [=auction config/trusted scoring signals coordinator=] to
+      |parsedCoordinator|.
 1. If |config|["{{AuctionAdConfig/interestGroupBuyers}}"] [=map/exists=]:
   1. Let |buyers| be a new empty [=list=].
   1. [=list/For each=] |buyerString| in |config|["{{AuctionAdConfig/interestGroupBuyers}}"]:
@@ -2011,6 +2025,8 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
             and |settings|'s [=environment settings object/policy container=].
         1. [=Fetch the current outstanding trusted signals batch=] given |trustedBiddingSignalsBatcher|,
             |signalsUrl|, |buyer|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
+        1. [=Fetch the trusted key value signals batch=] given |trustedBiddingSignalsBatcher|,
+            |signalsUrl|, |buyer|, |buyerExperimentGroupId|, |topLevelOrigin|, and |slotSizeQueryParam|.
       1. [=Process updateIfOlderThanMs=] with |buyer|, and |trustedBiddingSignalsBatcher|'s
          [=trusted bidding signals batcher/all per interest group data=].
       1. Let |fetchSignalDuration| be the [=duration from=] |fetchSignalStartTime| to |settings|'s
@@ -2178,6 +2194,8 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dd>|ig|'s [=interest group/trusted bidding signals slot size mode=]
       <dt>{{GenerateBidInterestGroup/maxTrustedBiddingSignalsURLLength}}
       <dd>|ig|'s [=interest group/max trusted bidding signals url length=]
+      <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsCoordinator}}
+      <dd>|ig|'s [=interest group/trusted bidding signals coordinator=]
       <dt>{{GenerateBidInterestGroup/userBiddingSignals}}
       <dd>[=Parse a JSON string to a JavaScript value=] given |ig|'s [=interest group/user bidding signals=]
 
@@ -2259,6 +2277,15 @@ contributions map=] |realTimeContributionsMap|, and a [=policy container=] |poli
 
       : [=trusted scoring signals request/policy container=]
       :: |policyContainer|
+
+      : [=trusted scoring signals request/signal coordinator=]
+      :: |auctionConfig|'s [=auction config/trusted scoring signals coordinator=]
+
+      : [=trusted scoring signals request/owner origin=]
+      :: |generatedBid|'s [=generated bid=/interest group=]'s [=interest group/owner=]
+
+      : [=trusted scoring signals request/joining origin=]
+      :: |generatedBid|'s [=generated bid=/interest group=]'s [=interest group/joining origin=]
 
   1. If |auctionConfig|'s [=auction config/trusted scoring signals url=]'s [=url/origin=] is not
     [=same origin=] with |auctionConfig|'s [=auction config/seller=], then set |isCrossOrigin| to
@@ -2662,6 +2689,81 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
     1. [=map/Set=] |signals|[|key|] to the result of [=serializing an Infra value to a JSON string=]
       given |value|.
   1. Return « |signals|, |perInterestGroupData|, |dataVersion| ».
+</div>
+
+<div algorithm>
+To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte sequence=] |body|, a string
+|context|, an [=origin=] |scriptOrigin|, a [=policy container=] |policyContainer|, an |indexMap|, and a
+[=boolean=] |isBiddingSignal|:
+
+1. Let |request| be a new [=request=] with the following properties:
+  :   [=request/URL=]
+  ::  |url|
+  :   [=request/method=]
+  ::  `POST`
+  :   [=request/body=]
+  ::  |body|
+  :   [=request/origin=]
+  ::  |scriptOrigin|
+  :   [=request/header list=]
+  ::  «`Accept`: `application/json`»
+  :   [=request/client=]
+  ::  `null`
+  :   [=request/mode=]
+  ::  "`cors`"
+  :   [=request/referrer=]
+  :: "`no-referrer`"
+  :   [=request/credentials mode=]
+  ::  "`omit`"
+  :   [=request/redirect mode=]
+  :: "`error`"
+  :   [=request/policy container=]
+  ::  A new [=policy container=] whose [=policy container/IP address space=] is |policyContainer|'s
+    [=policy container/IP address space=]
+
+  Issue: One of the side-effects of a `null` client for this subresource request is it neuters all
+  service worker interceptions, despite not having to set the service workers mode.
+
+1. Let |resultList| be the result of deserializing |responseBody| using |context|. The
+  deserialization method may follow that described in
+  [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
+1. Let |signals| be null.
+1. Let |dataVersion| be an empty [=ordered map=].
+1. Let |perInterestGroupData| be an [=ordered map=].
+1. [=Fetch=] |request| with [=fetch/useParallelQueue=] set to true, and
+  [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
+  and null, failure, or a [=byte sequence=] |responseBody|:
+  1. If [=validate fetching response=] with |response|, |responseBody| and
+    "`message/ad-auction-trusted-signals-response`" returns false, set |signals| to failure and return.
+  1. [=list/For each=] |result| in |resultList|:
+    1. If |isBiddingSignal| is true:
+      1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
+        1. If |indexMap|[|name|] does not equal to |result|["index"], set |signals| to failure and return.
+        1. Set |perInterestGroupData|[|name|] to |value|.
+        1. If |result| [=map/contain=] "dataVersion":
+          1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
+            2<sup>32</sup>&minus;1, set |signals| to failure and return.
+          1. Otherwise, set |dataVersion|[|name|] to |result|["dataVersion"].
+      1. [=map/For each=] |key| → |value| in |result|["keys"]:
+        1. Set |siganls|[|key|] to |value|.
+    1. Otherwise:
+      1. [=map/For each=] |url| → |value| in |result|["renderUrls"]:
+        1. Set |siganls|[|url|] to |value|.
+        1. If |result| [=map/contain=] `"dataVersion"`:
+          1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
+            2<sup>32</sup>&minus;1, set |signals| to failure and return.
+          1. Otherwise, set |dataVersion|[|url|] to |result|["dataVersion"].
+      1. [=map/For each=] |url| → |value| in |result|["adComponentRenderUrls"]:
+        1. Set |siganls|[|url|] to |value|.
+1. Return « |signals|, |perInterestGroupData|, |dataVersion| ».
+
+</div>
+
+<div algorithm="update CORS-safelisted request-header">
+
+Add "message/ad-auction-trusted-signals-request" to essence check list under content-type in
+[CORS-safelisted request-header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).
+
 </div>
 
 <div algorithm>
@@ -3560,11 +3662,11 @@ The <dfn for=Navigator method>getInterestGroupAdAuctionData(|configIDL|)</dfn> m
 </div>
 
 <div algorithm>
-  To <dfn>look up the server encryption key</dfn> given an [=origin=] |seller|
+  To <dfn>look up the server encryption key</dfn> given an [=origin=] |origin|
   and an [=origin=] |coordinator|:
   1. Let |keys| be a [=list=] of ([=byte sequence=], [=byte=]) [=tuples=] returned
      from looking up the [[RFC9180|HPKE]] public key encryption keys and their
-     corresponding key IDs for |seller| specified by |coordinator|. The actual
+     corresponding key IDs for |origin| specified by |coordinator|. The actual
      implementation of this lookup is [=implementation-defined=], and may
      consist of fetching the keys from a known [=URL=].
   1. If |keys| is failure or |keys| [=list/is empty=], return failure.
@@ -6427,6 +6529,16 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
             [=interest group/max trusted bidding signals url length=] to |convertedValue|.
         1. Otherwise, jump to the step labeled <i><a href=#abort-update>Abort update</a></i>.
 
+        <dt>"`trustedBiddingSignalsCoordinator`"
+        <dd>
+        1. If |value| is null:
+          1. Set |ig|'s [=interest group/trusted bidding signals coordinator=] to null.
+        1. If |value| is a [=string=]:
+          1. Let |parsedCoordinator| be the result of [=parsing an https origin=] on |value|.
+          1. If |parsedCoordinator| is a failure, jump to the step labeled <i><a href=#abort-update>
+            Abort update</a></i>.
+          1. Set |ig|'s [=interest group/trusted bidding signals coordinator=] to |parsedCoordinator|.
+
         <dt>"`userBiddingSignals`"
         <dd>
         1. Set |ig|'s [=interest group/user bidding signals=] to the result of [=serialize an Infra
@@ -6594,6 +6706,8 @@ The <dfn for=ProtectedAudience method>queryFeatureSupport(feature)</dfn> method 
     ::  true
     :   "reportingTimeout"
     ::  true
+    :   "trustedSignalsKVv2"
+    ::  true
 1. If |feature| is "*", then return |featuresTable|.
 1. If |featuresTable|[|feature|] [=map/exists=], then return |featuresTable|[|feature|].
 1. Return `undefined`.
@@ -6646,6 +6760,8 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
   1. The [=string/length=] of |key|.
 1. If |ig|'s [=interest group/max trusted bidding signals url length=] is not null:
   1. 4, which is the size of |ig|'s [=interest group/max trusted bidding signals url length=].
+1. If |ig|'s [=interest group/trusted bidding signals coordinator=] is not null:
+  1. The [=string/length=] of |ig|'s [=interest group/trusted bidding signals coordinator=].
 1. The [=string/length=] of |ig|'s [=interest group/user bidding signals=].
 1. If |ig|'s [=interest group/ads=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
@@ -7454,6 +7570,8 @@ An <dfn export>interest group</dfn> is a [=struct=] with the following [=struct/
   : <dfn>max trusted bidding signals url length</dfn>
   :: A {{long}} integer, initially 0. Indicates the maximum trusted bidding signals fetch url length
     for the interest group. 0 means no limit.
+  : <dfn>trusted bidding signals coordinator</dfn>
+  :: Null or an [=origin=].
   : <dfn>user bidding signals</dfn>
   :: Null or a [=string=]. Additional metadata that the owner can use during on-device bidding.
   : <dfn>ads</dfn>
@@ -7613,6 +7731,8 @@ An <dfn export>auction config</dfn> is a [=struct=] with the following [=struct/
   : <dfn>max trusted scoring signals url length</dfn>
   :: A {{long}} integer, initially 0. Indicates the maximum trusted scoring signals fetch url length
     for the auction config. 0 means no limit.
+  : <dfn>trusted scoring signals coordinator</dfn>
+  :: Null or an [=origin=].
   : <dfn>interest group buyers</dfn>
   :: Null or a [=list=] of [=origins=].
     Owners of interest groups allowed to participate in the auction. Each [=origin's=]
@@ -8037,6 +8157,9 @@ into smaller number of fetches. It's a [=struct=] with the following [=struct/it
   : <dfn>length limit</dfn>
   :: A {{long}}, initially 2147483647 (the maximum value that it can hold). Describes the URL length
      limit the current batch is limited to, the smallest of the limits of the interest groups included.
+  : <dfn>key value interest groups</dfn>
+  :: An [=ordered map=] whose [=map/keys=] are a tuple of an [=origin=] and an [=origin=] and whose
+    [=map/values=] is a [=set=] of [=interest group=].
 </dl>
 
 A <dfn>bidding signals per interest group data</dfn> is a [=struct=] with the following
@@ -8162,40 +8285,148 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
      [=bidding signals per interest group data/updateIfOlderThanMs=], but it will get null passed in
      to its bidding function.
 
-  1. Let |putativeKeys| be a [=set/clone=] of |trustedBiddingSignalsBatcher|'s
-     [=trusted bidding signals batcher/keys=].
-  1. Let |putativeIgNames| be a [=set/clone=] of |trustedBiddingSignalsBatcher|'s
-     [=trusted bidding signals batcher/ig names=].
-  1. Let |putativeLengthLimit| be  |ig|'s [=interest group/max trusted bidding signals url length=].
-  1. If |ig|'s [=interest group/max trusted bidding signals url length=] is 0 or &gt;
-    |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=],
-    then set |putativeLengthLimit| to |trustedBiddingSignalsBatcher|'s
-    [=trusted bidding signals batcher/length limit=].
-  1. If |ig|'s [=interest group/trusted bidding signals keys=] is not null, [=list/extend=]
-     |putativeKeys| with |ig|'s [=interest group/trusted bidding signals keys=].
-  1. [=list/Append=] |igName| to |putativeIgNames|.
-  1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
-    |signalsUrl|, |putativeKeys|, |putativeIgNames|, |experimentGroupId|, |topLevelOrigin|, and
-    |slotSizeQueryParam|.
-  1. If [=URL serializer|serialized=] |biddingSignalsUrl|'s [=string/length=] &le; |putativeLengthLimit|:
-      1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to |putativeKeys|.
+  1. If |ig|'s [=interest group/trusted bidding signals coordinator=] is null:
+    1. Let |putativeKeys| be a [=set/clone=] of |trustedBiddingSignalsBatcher|'s
+      [=trusted bidding signals batcher/keys=].
+    1. Let |putativeIgNames| be a [=set/clone=] of |trustedBiddingSignalsBatcher|'s
+      [=trusted bidding signals batcher/ig names=].
+    1. Let |putativeLengthLimit| be  |ig|'s [=interest group/max trusted bidding signals url length=].
+    1. If |ig|'s [=interest group/max trusted bidding signals url length=] is 0 or &gt;
+      |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=],
+      then set |putativeLengthLimit| to |trustedBiddingSignalsBatcher|'s
+      [=trusted bidding signals batcher/length limit=].
+    1. If |ig|'s [=interest group/trusted bidding signals keys=] is not null, [=list/extend=]
+      |putativeKeys| with |ig|'s [=interest group/trusted bidding signals keys=].
+    1. [=list/Append=] |igName| to |putativeIgNames|.
+    1. Let |biddingSignalsUrl| be the result of [=building trusted bidding signals url=] with
+      |signalsUrl|, |putativeKeys|, |putativeIgNames|, |experimentGroupId|, |topLevelOrigin|, and
+      |slotSizeQueryParam|.
+    1. If [=URL serializer|serialized=] |biddingSignalsUrl|'s [=string/length=] &le; |putativeLengthLimit|:
+        1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to |putativeKeys|.
+        1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=] to
+          |putativeIgNames|.
+        1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=] to
+          |putativeLengthLimit|.
+    1. Otherwise:
+      1. [=Fetch the current outstanding trusted signals batch=] given |trustedBiddingSignalsBatcher|,
+        |signalsUrl|, |scriptOrigin|, |experimentGroupId|, |topLevelOrigin|, |slotSizeQueryParam|, and
+        |policyContainer|.
+      1. If |ig|'s [=interest group/trusted bidding signals keys=] is not null, set
+        |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to a
+        [=list/clone=] of |ig|'s [=interest group/trusted bidding signals keys=].
+      1. Otherwise, set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to a
+        new [=list=].
       1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=] to
-        |putativeIgNames|.
+          « |igName| ».
       1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=] to
-        |putativeLengthLimit|.
+        |ig|'s [=interest group/max trusted bidding signals url length=].
   1. Otherwise:
-    1. [=Fetch the current outstanding trusted signals batch=] given |trustedBiddingSignalsBatcher|,
-      |signalsUrl|, |scriptOrigin|, |experimentGroupId|, |topLevelOrigin|, |slotSizeQueryParam|, and
-      |policyContainer|.
-    1. If |ig|'s [=interest group/trusted bidding signals keys=] is not null, set
-      |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to a
-      [=list/clone=] of |ig|'s [=interest group/trusted bidding signals keys=].
-    1. Otherwise, set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/keys=] to a
-       new [=list=].
-    1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/ig names=] to
-        « |igName| ».
-    1. Set |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/length limit=] to
-      |ig|'s [=interest group/max trusted bidding signals url length=].
+    1. Let |keyValueInterestGroups| be |trustedBiddingSignalsBatcher|'s [=trusted bidding signals
+      batcher/key value interest groups=].
+    1. Let |key| be {|ig|'s [=interest group/trusted bidding signals coordinator=], |ig|'s
+      [=interest group/owner=]}.
+    1. If |keyValueInterestGroups| [=map/contain=] |key|, [=set/Append=] |ig| to |keyValueInterestGroups|
+      [|key|].
+    1. Otherwise:
+      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=].
+      1. [=set/Append=] |ig| to |keyValueInterestGroups| [|key|].
+
+</div>
+
+<div algorithm>
+
+To <dfn>build trusted key value bidding signals request body</dfn> given, a [=set=] |interestGroups|,
+an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
+|slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
+
+1. Let |compressionGroups| be an empty [=list=].
+1. Let |compressionGroupMap| be an empty [=map=].
+1. Let |compressionIdMap| be an empty [=map=].
+1. Let |interestGroupIdMap| be an empty [=map=].
+1. Let |slotSizeParams| be the result of [=strictly splitting=] |slotSizeQueryParam| on U+003D (=).
+1. Set |nextCompressionGroupId| to 0.
+1. [=list/For each=] |group| of |interestGroups|:
+  1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
+  1. Let |compressionGroupId| be an integer.
+  1. Let |partitionId| be an integer.
+  1. If |compressionIdMap| does not [=map/contain=] |joiningOrigin|:
+    1. Set |compressionIdMap|[|joiningOrigin|] to |nextCompressionGroupId|.
+    1. Increase |nextCompressionGroupId| by 1.
+  1. Set |compressionGroupId| to |compressionIdMap|[|joiningOrigin|].
+  1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
+    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=].
+  1. Set |executionMode| to |group|'s [=interest group/execution mode=].
+  1. If |executionMode| equal to "`group-by-origin`", set |partitionId| to 0.
+  1. Otherwise:
+    1. If |compressionGroupMap|[|compressionGroupId|] [=map/contain=] 0, set |partitionId| to
+      [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
+    1. Otherwise, set |partitionId| to sum [=list/size=] of |compressionGroupMap|[|joiningOrigin|]
+      and 1.
+  1. Set |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of |compressionGroupId|
+    and |partitionId|.
+  1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|:
+    1. Let |partition| be an empty [=map=].
+    1. Set |partition|["id"] to |partitionId|.
+    1. Set |partition|["interest_group_names"] to [|group|'s [=interest group/name=]].
+    1. Set |partition|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
+    1. Let |metadata| be an empty [=map=].
+    1. Set |metadata|["experiment_group_id"] to |experimentGroupId|.
+    1. Set |metadata|[|slotSizeParams|[0]] to |slotSizeParams|[1].
+    1. Set |partition|["metadata"] to |metadata|.
+    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
+  1. Otherwise:
+    1. [=list/Append=] |group|'s [=interest group/name=] into |compressionGroupMap|[|compressionGroupId|]
+      [|partitionId|]["interest_group_names"].
+    1. [=list/Append=] |group|'s [=interest group/trusted bidding signals keys=] into
+      |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
+1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
+  1. Let |compressionGroup| be an empty [=map=].
+  1. Set |compressionGroup|["compression_group_id"] to |id|.
+  1. Set |compressionGroup|["partitions"] to an empty [=list=].
+  1. [=list/For each=] |partition| in |group|'s [=map/values=]:
+    1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
+  1. [=list/Append=] |compressionGroup| to |compressionGroups|.
+1. Let |metadata| be an empty [=map=].
+1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
+  [=serialization of an origin|serialized=] |topLevelOrigin| using [=component percent-encode set=].
+1. Set |metadata|["hostname"] to |hostname|.
+1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |owner| and
+  |coordinator|.
+1. Let (|requestBlob|, |context|) be the result of generating request |keyInfo|, |metadata| and
+  |compressionGroups|. The generation method may follow that described in 
+  [Section 2.2.4 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-generating-a-request).
+1. Return |requestBlob|, |interestGroupIdMap| and |context|.
+
+</div>
+
+<div algorithm>
+To <dfn>fetch the trusted key value signals batch</dfn> given a
+[=trusted bidding signals batcher=] |trustedBiddingSignalsBatcher|, a [=URL=] |signalsUrl|,
+an [=origin=] |scriptOrigin|, an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=]
+|topLevelOrigin|, a [=string=] |slotSizeQueryParam|, and a [=policy container=] |policyContainer|:
+
+  1. If |signalsUrl| is null, return.
+  1. [=map/For each=] {|coordinator|, |owner|} → |interestGroups| of [=trusted bidding signals
+    batcher/key value interest groups=]:
+    1. Let « |requestBody|, |interestGroupIdMap|, |context| » be the result of [=building trusted
+      key value bidding signals request body=] with |signalsUrl|, |interestGroups|,
+      |experimentGroupId|, |topLevelOrigin|, |slotSizeQueryParam|, |coordinator| and |owner|.
+    1. Let « |partialTrustedBiddingSignals|, |partialPerInterestGroupData|, |dataVersion| » be the
+      result of [=fetching trusted key value signals=] with |signalsUrl|, |requestBody|, |context|,
+      |scriptOrigin|, |policyContainer|, |interestGroupIdMap| and true.
+    1. If |partialTrustedBiddingSignals| is not null:
+      1. [=map/For each=] |key| → |value| in |partialTrustedBiddingSignals|, [=map/set=]
+        |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/all trusted bidding
+        signals=][|key|] to |value|.
+      1. Let |igNames| be |interestGroupIdMap|'s [=map/keys=].
+      1. [=set/For each=] |igName| of |igNames|, [=map/set=] |trustedBiddingSignalsBatcher|'s
+        [=trusted bidding signals batcher/data versions=][|igName|] to |dataVersion|[|igName|].
+      1. [=Append to a bidding signals per-interest group data map=] with
+        |partialPerInterestGroupData|, |igNames|, and |trustedBiddingSignalsBatcher|'s
+        [=trusted bidding signals batcher/all per interest group data=].
+    1. Otherwise, [=set/for each=] |igName| of |igNames|:
+      1. [=map/Set=] |trustedBiddingSignalsBatcher|'s
+        [=trusted bidding signals batcher/no signals flags=][|igName|] to "fetch-failed".
 
 </div>
 
@@ -8210,9 +8441,9 @@ requests into smaller number of fetches. It's a [=struct=] with the following [=
     batching.
   : <dfn>request map</dfn>
   :: A [=map=] from a tuple of [=script fetcher=], a [=URL=] representating the trusted signals
-    base [=URL=], {{unsigned short}} or null for experiment ID, and
-    [=origin=], representing the top frame's [=origin=], to a [=list=] of [=trusted scoring signals
-    requests=]. This organizes fetches that can possibly be merged together.
+    base [=URL=], {{unsigned short}} or null for experiment ID, [=origin=] or null for coordinator,
+    and [=origin=], representing the top frame's [=origin], to a [=list=] of [=trusted scoring
+    signals requests=]. This organizes fetches that can possibly be merged together.
   : <dfn>url length limit</dfn>
   :: A {{long}} denoting a user-configured limit which should not be exceeded due to combining of
     fetches. 0 denotes no limit, and is the initial value.
@@ -8241,6 +8472,12 @@ invocation:
     fetch.
   : <dfn>policy container</dfn>
   :: A [=policy container=] to use for the network fetch.
+  : <dfn>signal coordinator</dfn>
+  :: An [=origin=] to use for the public key fetch.
+  : <dfn>owner origin</dfn>
+  :: An [=origin=] of the owner on behalf of the initial interest group.
+  : <dfn>joining origin</dfn>
+  :: An [=origin=] of the owner's joining origin on behalf of the initial interest group.
   : <dfn>reply</dfn>
   :: A [=trusted scoring signals reply=], null, or failure. Initially null. Set to a non-null value
     when the fetch has been completed.
@@ -8349,6 +8586,93 @@ scoring signals requests=] |entriesToBatch|:
 
 <div algorithm>
 
+To <dfn>build trusted key value scoring signals request body</dfn> given a non-empty [=list=] of
+[=trusted scoring signals requests=] |entriesToBatch|:
+
+1. Let |firstRequest| be |entriesToBatch|[0].
+1. Let |compressionGroupMap| be an empty [=map=].
+1. Let |compressionIdMap| be an empty [=map=].
+1. Let |renderUrlIdMap| be an empty [=map=].
+1. Let |nextCompressionGroupId| be 0.
+1. [=map/For each=] |request| of |entriesToBatch|:
+  1. Let |compressionGroupId| be an integer.
+  1. Let |partitionId| be an integer.
+  1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
+  1. Let |ownerOrigin| be |request|'s [=trusted scoring signals request/owner origin=].
+  1. Let |mapKey| be a tuple of |ownerOrigin| and |joiningOrigin|.
+  1. If |compressionIdMap| does not [=map/contain=] |mapKey|:
+    1. Set |compressionIdMap|[|mapKey|] to |nextCompressionGroupId|.
+    1. Increase |nextCompressionGroupId| by 1.
+  1. Set |compressionGroupId| to |compressionIdMap|[|mapKey|].
+  1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
+    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=].
+  1. Set |partitionId| to [=list/size=] of |compressionGroups|[|compressionGroupId|].
+  1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
+    of |compressionGroupId| and |partitionId|.
+  1. Let |partition| be an empty [=map=].
+  1. Set |partition|["id"] to |partitionId|.
+  1. Set |partition|["render_url"] to [|request|'s [=trusted scoring signals request/render URL=]].
+  1. Set |partition|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
+    component URLs=].
+  1. Let |metadata| be an empty [=map=].
+  1. Set |metadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
+      request/seller experiment group id=].
+  1. Set |partition|["metadata"] to |metadata|.
+  1. Set |compressionGroups|[|compressionGroupId|][|partitionId|] to |partition|.
+1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
+  1. Let |compressionGroup| be an empty [=map=].
+  1. Set |compressionGroup|["compression_group_id"] to |id|.
+  1. Set |compressionGroup|["partitions"] to an empty [=list=].
+  1. [=list/For each=] |partition| in |group|'s [=map/values=]:
+    1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
+  1. [=list/Append=] |compressionGroup| to |compressionGroups|.
+1. Let |metadata| be an empty [=map=].
+1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
+  [=serialization of an origin|serialized=] |firstRequest|'s [=trusted scoring signals request/top
+    level origin=] using [=component percent-encode set=].
+1. Set |metadata|["hostname"] to |hostname|.
+1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |firstRequest|'s
+  [=trusted scoring signals request/seller=] and |firstRequest|'s [=trusted scoring signals
+  request/signal coordinator=].
+1. Let (|requestBlob|, |context|) be the result of generating request |keyInfo|, |metadata| and
+  |compressionGroups|. The generation method may follow that described in
+  [Section 2.2.4 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-generating-a-request).
+1. Return |requestBlob|, |renderUrlIdMap| and |context|.
+
+</div>
+
+<div algorithm>
+
+To <dfn>build batched trusted key value scoring signals request body</dfn> given a non-empty [=list=] of
+[=trusted scoring signals requests=] |entriesToBatch|:
+
+1. Let |firstEntry| be |entriesToBatch|[0].
+1. Let |renderURLs| be an empty [=ordered set=] of [=strings=].
+1. Let |adComponentRenderURLs| be an empty [=ordered set=] of [=strings=]
+  |adComponentRenderURLs|
+1. [=list/For each=] |entry| of |entriesToBatch|:
+  1. [=Assert=] that |entry|'s [=trusted scoring signals request/base URL=] is equal to
+    |firstEntry|'s [=trusted scoring signals request/base URL=].
+  1. [=Assert=] that |entry|'s [=trusted scoring signals request/seller=] is equal to
+    |firstEntry|'s [=trusted scoring signals request/seller=].
+  1. [=Assert=] that |entry|'s [=trusted scoring signals request/seller experiment group id=] is
+    equal to |firstEntry|'s [=trusted scoring signals request/seller experiment group id=].
+  1. [=Assert=] that |entry|'s [=trusted scoring signals request/top level origin=] is equal to
+    |firstEntry|'s [=trusted scoring signals request/top level origin=].
+  1. [=Assert=] that |entry|'s [=trusted scoring signals request/seller script fetcher=] is equal to
+    |firstEntry|'s [=trusted scoring signals request/seller script fetcher=].
+  1. [=Assert=] that |entry|'s [=trusted scoring signals request/policy container=] is equal to
+    |firstEntry|'s [=trusted scoring signals request/policy container=].
+  1. [=set/Append=] |entry|'s [=trusted scoring signals request/render URL=] to |renderURLs|.
+  1. [=list/Extend=] |adComponentRenderURLs| with |entry|'s [=trusted scoring signals request/
+    ad component URLs=].
+1. Return the result of [=building trusted key value scoring signals request body=] with
+   |entriesToBatch|.
+
+</div>
+
+<div algorithm>
+
 To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring signals batcher=]
 |batcher|:
 
@@ -8372,49 +8696,81 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
     1. Let |key| be (|request|'s [=trusted scoring signals request/seller script fetcher=],
       |request|'s [=trusted scoring signals request/base url=], |request|'s [=trusted scoring
       signals request/seller experiment group id=], |request|'s [=trusted scoring signals request/
-      top level origin=]).
+      top level origin=], |request|'s [=trusted scoring signals request/signal coordinator=]).
     1. If |batcher|'s [=trusted scoring signals batcher/request map=][|key|] does not [=map/exist=],
       then [=map/set=] |batcher|'s [=trusted scoring signals batcher/request map=][|key|] to an
       [=list/is empty|empty=] [=list=].
     1. [=list/Append=] |request| to |batcher|'s [=trusted scoring signals batcher/request
       map=][|key|].
-  1. Some number of times, heuristically, select a |key| and a non-[=list/is empty|empty=] [=set/
-    subset=] of |batcher|'s [=trusted scoring signals batcher/request map=][|key|], called
-    |entriesToBatch|, such that [=checking if trusted scoring signals batch honors URL length
-    limit=] on |batcher| and |entriesToBatch| returns true:
+  1. Some number of times, heuristically, select a |key| from |batcher|'s [=trusted scoring signals
+    batcher/request map=]:
+    1. If |key|'s [=trusted scoring signals request/signal coordinator=] is null:
+      1. Select a non-[=list/is empty|empty=] [=set/subset=] of |batcher|'s [=trusted scoring
+        signals batcher/request map=][|key|], called |entriesToBatch|, such that [=checking if
+        trusted scoring signals batch honors URL length limit=] on |batcher| and |entriesToBatch|
+        returns true:
 
-      Note: implementations are free to wait to collect more requests to merge (by leaving things
-      in the |batcher|'s [=trusted scoring signals batcher/request map=]), or send them
-      individually, but need to take into account the configured URL length limit if they do combine
-      requests. All entries need to be handled eventually.
+        Note: implementations are free to wait to collect more requests to merge (by leaving things
+        in the |batcher|'s [=trusted scoring signals batcher/request map=]), or send them
+        individually, but need to take into account the configured URL length limit if they do
+        combine requests. All entries need to be handled eventually.
 
-      1. [=list/Remove=] |entriesToBatch| from |batcher|'s [=trusted scoring signals batcher/
-        request map=][|key|].
-      1. If |batcher|'s [=trusted scoring signals batcher/request map=][|key|] [=list/is empty=],
-        then [=map/remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
-      1. Let |fullSignalsUrl| be the result of [=building batched trusted scoring signals url=] for
-        |entriesToBatch|.
+        1. [=list/Remove=] |entriesToBatch| from |batcher|'s [=trusted scoring signals batcher/
+          request map=][|key|].
+        1. If |batcher|'s [=trusted scoring signals batcher/request map=][|key|] [=list/is empty=],
+          then [=map/remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
+        1. Let |fullSignalsUrl| be the result of [=building batched trusted scoring signals url=] for
+          |entriesToBatch|.
+        1. Let |seller| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller=].
+        1. Let |scriptFetcher| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller
+          script fetcher=].
+        1. Let |policyContainer| be |entriesToBatch|[0]'s [=trusted scoring signals request/policy
+          container=].
+        1. If |fullSignalsUrl|'s [=url/origin=] is not [=same origin=] with |seller| then:
+          1. Let |allowCrossOriginTrustedScoringSignalsFrom| be the result of [=wait for cross origin
+            trusted scoring signals authorization from a fetcher=] given |scriptFetcher|.
+          1. If |allowCrossOriginTrustedScoringSignalsFrom| does not [=list/contain=]
+            |fullSignalsUrl|'s [=url/origin=], set |fullSignalsUrl| to null.
+        1. Let |result| be failure.
+        1. If |fullSignalsUrl| is not null:
+          1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersion|» be
+            the result of [=fetching trusted signals=] with |fullSignalsUrl|, |seller|,
+            |policyContainer|, and false.
+          1. If |allTrustedScoringSignals| is an [=ordered map=]:
+            1. Set |result| to a new [=trusted scoring signals reply=]
+            1. Set |result|'s [=trusted scoring signals reply/all trusted scoring signals=] to
+              |allTrustedScoringSignals|.
+            1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersion|.
+        1. [=list/For each=] |entry| in |entriesToBatch|:
+          1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
+    1. Otherwise:
+      1. Set |entriesToBatch| to |batcher|'s [=trusted scoring signals batcher/request map=][|key|].
+      1. [=map/remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
+      1. Let « |requestBody|, |renderUrlIdMap|, |context| » be the result of [=building batched
+        trusted key value scoring signals request body=] for |entriesToBatch|.
+      1. Let |baseUrl| be |entriesToBatch|[0]'s [=trusted scoring signals request/base url=].
       1. Let |seller| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller=].
       1. Let |scriptFetcher| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller
         script fetcher=].
       1. Let |policyContainer| be |entriesToBatch|[0]'s [=trusted scoring signals request/policy
         container=].
-      1. If |fullSignalsUrl|'s [=url/origin=] is not [=same origin=] with |seller| then:
+      1. If |baseUrl|'s [=url/origin=] is not [=same origin=] with |seller| then:
         1. Let |allowCrossOriginTrustedScoringSignalsFrom| be the result of [=wait for cross origin
           trusted scoring signals authorization from a fetcher=] given |scriptFetcher|.
         1. If |allowCrossOriginTrustedScoringSignalsFrom| does not [=list/contain=]
-          |fullSignalsUrl|'s [=url/origin=], set |fullSignalsUrl| to null.
+          |baseUrl|'s [=url/origin=], set |baseUrl| to null.
       1. Let |result| be failure.
-      1. If |fullSignalsUrl| is not null:
+      1. If |baseUrl| is not null:
         1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersion|» be
-          the result of [=fetching trusted signals=] with |fullSignalsUrl|, |seller|,
-          |policyContainer|, and false.
+          the result of [=fetching trusted key value signals=] with |baseUrl|, |requestBody|,
+          |context|, |seller|, |policyContainer|, |renderUrlIdMap| and false.
         1. If |allTrustedScoringSignals| is an [=ordered map=]:
           1. Set |result| to a new [=trusted scoring signals reply=]
           1. Set |result|'s [=trusted scoring signals reply/all trusted scoring signals=] to
             |allTrustedScoringSignals|.
-          1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersion|.
       1. [=list/For each=] |entry| in |entriesToBatch|:
+        1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersion|
+          [|entry|'s [=trusted scoring signals request/render URL=]].
         1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -2766,7 +2766,8 @@ interger and an integer , and a [=boolean=] |isBiddingSignal|:
 
 <div algorithm="update CORS-safelisted request-header">
 
-Add "message/ad-auction-trusted-signals-request" to mimeType’s essence check list under content-type in
+Add "<code>message/ad-auction-trusted-signals-request</code>" to <var ignore>mimeType</var>’s
+<a for="MIME type">essence</a> check list under "<code>content-type</code>" in
 [CORS-safelisted request-header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).
 
 </div>
@@ -8419,8 +8420,8 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
       |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
   1. Let |compressionGroup| be a [=bidding compression group=], whose
-	  [=bidding compression group/compression group id=] is |id|, and
-	  [=bidding compression group/partition=] is an empty [=list=].
+    [=bidding compression group/compression group id=] is |id|, and
+    [=bidding compression group/partition=] is an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|'s [=bidding compression group/partition=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.

--- a/spec.bs
+++ b/spec.bs
@@ -2195,7 +2195,7 @@ To <dfn>build an interest group passed to generateBid</dfn> given an [=interest 
       <dt>{{GenerateBidInterestGroup/maxTrustedBiddingSignalsURLLength}}
       <dd>|ig|'s [=interest group/max trusted bidding signals url length=]
       <dt>{{GenerateBidInterestGroup/trustedBiddingSignalsCoordinator}}
-      <dd>|ig|'s [=interest group/trusted bidding signals coordinator=]
+      <dd>The [=serialization of an origin|serialization=] of |ig|'s [=interest group/trusted bidding signals coordinator=]
       <dt>{{GenerateBidInterestGroup/userBiddingSignals}}
       <dd>[=Parse a JSON string to a JavaScript value=] given |ig|'s [=interest group/user bidding signals=]
 
@@ -2692,7 +2692,7 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
 </div>
 
 <div algorithm>
-To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte sequence=] |body|, a string
+To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte sequence=] |body|, a [=string=]
 |context|, an [=origin=] |scriptOrigin|, a [=policy container=] |policyContainer|, an |indexMap|, and a
 [=boolean=] |isBiddingSignal|:
 
@@ -2739,7 +2739,7 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
     1. If |isBiddingSignal| is true:
       1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
         1. If |indexMap|[|name|] does not equal to |result|["index"], set |signals| to failure and return.
-        1. Set |perInterestGroupData|[|name|] to |value|.
+        1. [=map/Set=] |perInterestGroupData|[|name|] to |value|.
         1. If |result| [=map/contain=] "dataVersion":
           1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
             2<sup>32</sup>&minus;1, set |signals| to failure and return.
@@ -2749,7 +2749,7 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
     1. Otherwise:
       1. [=map/For each=] |url| → |value| in |result|["renderUrls"]:
         1. Set |siganls|[|url|] to |value|.
-        1. If |result| [=map/contain=] `"dataVersion"`:
+        1. If |result| [=map/contains=] `"dataVersion"`:
           1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
             2<sup>32</sup>&minus;1, set |signals| to failure and return.
           1. Otherwise, set |dataVersion|[|url|] to |result|["dataVersion"].
@@ -6761,7 +6761,7 @@ The <dfn for="interest group">estimated size</dfn> of an [=interest group=] |ig|
 1. If |ig|'s [=interest group/max trusted bidding signals url length=] is not null:
   1. 4, which is the size of |ig|'s [=interest group/max trusted bidding signals url length=].
 1. If |ig|'s [=interest group/trusted bidding signals coordinator=] is not null:
-  1. The [=string/length=] of |ig|'s [=interest group/trusted bidding signals coordinator=].
+  1. The [=string/length=] of the [=serialization of an origin|serialization=] of |ig|'s [=interest group/trusted bidding signals coordinator=].
 1. The [=string/length=] of |ig|'s [=interest group/user bidding signals=].
 1. If |ig|'s [=interest group/ads=] is not null, [=list/for each=] |ad| of it:
   1. The [=string/length=] of the [=URL serializer|serialization=] of |ad|'s
@@ -8158,8 +8158,8 @@ into smaller number of fetches. It's a [=struct=] with the following [=struct/it
   :: A {{long}}, initially 2147483647 (the maximum value that it can hold). Describes the URL length
      limit the current batch is limited to, the smallest of the limits of the interest groups included.
   : <dfn>key value interest groups</dfn>
-  :: An [=ordered map=] whose [=map/keys=] are a tuple of an [=origin=] and an [=origin=] and whose
-    [=map/values=] is a [=set=] of [=interest group=].
+  :: An [=ordered map=] whose [=map/keys=] are [=tuples=] of ([=origin=], [=origin=]) and whose
+    [=map/values=] are [=sets=] of [=interest groups=].
 </dl>
 
 A <dfn>bidding signals per interest group data</dfn> is a [=struct=] with the following
@@ -8335,7 +8335,7 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
 
 <div algorithm>
 
-To <dfn>build trusted key value bidding signals request body</dfn> given, a [=set=] |interestGroups|,
+To <dfn>build trusted key value bidding signals request body</dfn> given a [=set=] |interestGroups|,
 an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
 |slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
 
@@ -8344,14 +8344,14 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
 1. Let |compressionIdMap| be an empty [=map=].
 1. Let |interestGroupIdMap| be an empty [=map=].
 1. Let |slotSizeParams| be the result of [=strictly splitting=] |slotSizeQueryParam| on U+003D (=).
-1. Set |nextCompressionGroupId| to 0.
+1. Let |nextCompressionGroupId| be 0.
 1. [=list/For each=] |group| of |interestGroups|:
   1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
   1. Let |compressionGroupId| be an integer.
   1. Let |partitionId| be an integer.
   1. If |compressionIdMap| does not [=map/contain=] |joiningOrigin|:
-    1. Set |compressionIdMap|[|joiningOrigin|] to |nextCompressionGroupId|.
-    1. Increase |nextCompressionGroupId| by 1.
+    1. [=map/Set=] |compressionIdMap|[|joiningOrigin|] to |nextCompressionGroupId|.
+    1. Increment |nextCompressionGroupId| by 1.
   1. Set |compressionGroupId| to |compressionIdMap|[|joiningOrigin|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
     1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=].
@@ -8408,7 +8408,7 @@ an [=origin=] |scriptOrigin|, an {{unsigned short}}-or-null |experimentGroupId|,
 |topLevelOrigin|, a [=string=] |slotSizeQueryParam|, and a [=policy container=] |policyContainer|:
 
   1. If |signalsUrl| is null, return.
-  1. [=map/For each=] {|coordinator|, |owner|} → |interestGroups| of [=trusted bidding signals
+  1. [=map/For each=] (|coordinator|, |owner|) → |interestGroups| of [=trusted bidding signals
     batcher/key value interest groups=]:
     1. Let « |requestBody|, |interestGroupIdMap|, |context| » be the result of [=building trusted
       key value bidding signals request body=] with |signalsUrl|, |interestGroups|,

--- a/spec.bs
+++ b/spec.bs
@@ -2555,6 +2555,9 @@ failure, or a [=byte sequence=] |responseBody|, and a [=string=] |mimeType|:
     * |mimeType| is "`application/wasm`" and the result of [=header list/getting=] "`Content-Type`"
       from |response|'s [=response/header list=] is null or not [=byte-case-insensitive=] equal to
       "`application/wasm`".
+    * |mimeType| is "`message/ad-auction-trusted-signals-response`" and the result of
+      [=header list/getting=] "`Content-Type`" from |response|'s [=response/header list=] is null
+      or not [=byte-case-insensitive=] equal to "`message/ad-auction-trusted-signals-response`".
 
       Note: This was intended to match the behavior of [=compiling a potential WebAssembly
       response=], but diverges by failing to remove leading and trailing [=HTTP tab or space
@@ -2659,7 +2662,8 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
   1. Let |signals| be null.
   1. Let |dataVersion| be null.
   1. Let |formatVersion| be null.
-  1. Let |perInterestGroupData| be an [=ordered map=].
+  1. Let |perInterestGroupData| be an [=ordered map=] whose [=map/keys=] are [=interest group/name=]
+    [=strings=] and whose [=map/values=] are [=bidding signals per interest group data=].
   1. [=Fetch=] |request| with [=fetch/useParallelQueue=] set to true, and
     [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
     and null, failure, or a [=byte sequence=] |responseBody|:
@@ -2706,7 +2710,8 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
   :   [=request/origin=]
   ::  |scriptOrigin|
   :   [=request/header list=]
-  ::  «`Accept`: `application/json`»
+  ::  «`Content-Type`: `message/ad-auction-trusted-signals-request`»
+  ::  «`Accept`: `message/ad-auction-trusted-signals-response`»
   :   [=request/client=]
   ::  `null`
   :   [=request/mode=]
@@ -2723,18 +2728,18 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
   ::  A new [=policy container=] whose [=policy container/IP address space=] is |policyContainer|'s
     [=policy container/IP address space=]
 
-
-1. Let |resultList| be the result of deserializing |responseBody| using |context|. The
-  deserialization method may follow that described in
-  [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
 1. Let |signals| be null.
 1. Let |dataVersion| be an empty [=ordered map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers.
-1. Let |perInterestGroupData| be an [=ordered map=].
+1. Let |perInterestGroupData| be an [=ordered map=] whose [=map/keys=] are [=interest group/name=] [=strings=]
+  and whose [=map/values=] are [=bidding signals per interest group data=].
 1. [=Fetch=] |request| with [=fetch/useParallelQueue=] set to true, and
   [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
   and null, failure, or a [=byte sequence=] |responseBody|:
   1. If [=validate fetching response=] with |response|, |responseBody| and
     "`message/ad-auction-trusted-signals-response`" returns false, set |signals| to failure and return.
+  1. Let |resultList| be the result of deserializing |responseBody| using |context|. The
+    deserialization method may follow that described in
+    [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
   1. [=list/For each=] |result| in |resultList|:
     1. If |isBiddingSignal| is true:
       1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
@@ -7575,7 +7580,7 @@ An <dfn export>interest group</dfn> is a [=struct=] with the following [=struct/
     used for encryption and decryption in communication with a trusted bidding signal server running
     in a Trust Execution Environment (TEE). When this field is specified, the request will be sent to
     a trusted bidding signals server running in a TEE, and the value of
-    [=interest group/trusted bidding signals url=] is ignored.
+    [=interest group/max trusted bidding signals url length=] is ignored.
   : <dfn>user bidding signals</dfn>
   :: Null or a [=string=]. Additional metadata that the owner can use during on-device bidding.
   : <dfn>ads</dfn>
@@ -8166,7 +8171,8 @@ into smaller number of fetches. It's a [=struct=] with the following [=struct/it
   :: A {{long}}, initially 2147483647 (the maximum value that it can hold). Describes the URL length
      limit the current batch is limited to, the smallest of the limits of the interest groups included.
   : <dfn>key value interest groups</dfn>
-  :: An [=ordered map=] whose [=map/keys=] are [=tuples=] of ([=origin=], [=origin=]) and whose
+  :: An [=ordered map=] whose [=map/keys=] are [=tuples=] of (an [=origin=] for
+    [=interest group/joining origin=], an [=origin=] for [=interest group/owner=]) and whose
     [=map/values=] are [=sets=] of [=interest groups=].
 </dl>
 
@@ -8182,7 +8188,7 @@ A <dfn>bidding signals per interest group data</dfn> is a [=struct=] with the fo
     or explicitly by the {{Navigator/updateAdInterestGroups()}} method.
 </dl>
 
-A <dfn>compression group</dfn> is a collection of partitions that can be compressed together
+A <dfn>compression group</dfn> is a collection of [=partitions=] that can be compressed together
 in the signals response. It's a [=struct=] with the following [=struct/items=]:
 
 <dl dfn-for="compression group">
@@ -8192,17 +8198,19 @@ in the signals response. It's a [=struct=] with the following [=struct/items=]:
   :: A [=list=] of [=partition=]. Contains all the partitions belong to this compression group.
 </dl>
 
-A <dfn>partition</dfn> is a collection of keys that can be processed together by the service
-without any potential privacy leakage. It's a [=struct=] with the following [=struct/items=]:
+A <dfn>partition</dfn> is a collection of [=trusted bidding signals batcher/keys=] that can be
+processed together by the service without any potential privacy leakage. It's a [=struct=] with
+the following [=struct/items=]:
 
 <dl dfn-for="partition">
   : <dfn>id</dfn>
   :: An integer indicates the index of this partition.
   : <dfn>namespace</dfn>
-  :: An empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of
-    [=strings=].
+  :: A [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of
+    [=strings=]. A namespace contains all [=interest group/name=]s and
+    [=interest group/trusted bidding signals keys=]s in the partition.
   : <dfn>metadata</dfn>
-  :: An empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
+  :: A [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 </dl>
 
 <div algorithm>
@@ -8354,13 +8362,12 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
   1. Otherwise:
     1. Let |keyValueInterestGroups| be |trustedBiddingSignalsBatcher|'s [=trusted bidding signals
       batcher/key value interest groups=].
-    1. Let |key| be {|ig|'s [=interest group/trusted bidding signals coordinator=], |ig|'s
-      [=interest group/owner=]}.
-    1. If |keyValueInterestGroups| [=map/contain=] |key|, [=set/Append=] |ig| to |keyValueInterestGroups|
-      [|key|].
+    1. Let |key| be [=tuple=] of (|ig|'s [=interest group/joining origin=], |ig|'s [=interest group/owner=]).
+    1. If |keyValueInterestGroups| [=map/contains=] |key|, [=set/append=] |ig| to
+      |keyValueInterestGroups|[|key|].
     1. Otherwise:
-      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=], whose [=map/values=] are [=strings=].
-      1. [=set/Append=] |ig| to |keyValueInterestGroups| [|key|].
+      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=], whose [=set/items=] are [=strings=].
+      1. [=set/Append=] |ig| to |keyValueInterestGroups|[|key|].
 
 </div>
 
@@ -8370,9 +8377,11 @@ To <dfn>build trusted key value bidding signals request body</dfn> given a [=set
 an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
 |slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
 
-1. Let |compressionGroups| be an empty [=list=], whose values are [=compression group=].
-1. Let |compressionGroupMap| be an empty [=map=], whose [=map/keys=] are integers and [=map/values=] are [=maps=].
-1. Let |compressionIdMap| be an empty [=map=], whose keys [=origins=] and [=map/values=] are integers.
+1. Let |compressionGroups| be an empty [=list=], whose [=list/items=] are [=compression groups=].
+1. Let |compressionGroupMap| be an empty [=map=], where the [=map/keys=] are integers as
+  [=compression group/compression group id=], and the [=map/values=] are [=maps=] with integers as [=map/keys=]
+  for [=partition/id=], and [=partitions=] as their [=map/values=].
+1. Let |compressionIdMap| be an empty [=map=], whose [=map/keys=] are [=origins=] and [=map/values=] are integers.
 1. Let |interestGroupIdMap| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=tuples=]
   of (interger, integer).
 1. Let |slotSizeParams| be the result of [=strictly splitting=] |slotSizeQueryParam| on U+003D (=).
@@ -8390,7 +8399,7 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. Set |executionMode| to |group|'s [=interest group/execution mode=].
   1. If |executionMode| equal to "`group-by-origin`", set |partitionId| to 0.
   1. Otherwise:
-    1. If |compressionGroupMap|[|compressionGroupId|] [=map/contain=] 0, set |partitionId| to
+    1. If |compressionGroupMap|[|compressionGroupId|] [=map/contains=] 0, set |partitionId| to
       [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
     1. Otherwise, set |partitionId| to sum [=list/size=] of |compressionGroupMap|[|joiningOrigin|]
       and 1.
@@ -8441,11 +8450,11 @@ an [=origin=] |scriptOrigin|, an {{unsigned short}}-or-null |experimentGroupId|,
 |topLevelOrigin|, a [=string=] |slotSizeQueryParam|, and a [=policy container=] |policyContainer|:
 
   1. If |signalsUrl| is null, return.
-  1. [=map/For each=] (|coordinator|, |owner|) → |interestGroups| of [=trusted bidding signals
+  1. [=map/For each=] (|joining_origin|, |owner|) → |interestGroups| of [=trusted bidding signals
     batcher/key value interest groups=]:
     1. Let « |requestBody|, |interestGroupIdMap|, |context| » be the result of [=building trusted
       key value bidding signals request body=] with |interestGroups|, |experimentGroupId|,
-      |topLevelOrigin|, |slotSizeQueryParam|, |coordinator| and |owner|.
+      |topLevelOrigin|, |slotSizeQueryParam|, |joining_origin| and |owner|.
     1. Let « |partialTrustedBiddingSignals|, |partialPerInterestGroupData|, |dataVersion| » be the
       result of [=fetching trusted key value signals=] with |signalsUrl|, |requestBody|, |context|,
       |scriptOrigin|, |policyContainer|, |interestGroupIdMap| and true.

--- a/spec.bs
+++ b/spec.bs
@@ -8418,9 +8418,9 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     1. [=list/Append=] |group|'s [=interest group/trusted bidding signals keys=] into
       |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=bidding compression group=].
-  1. Set |compressionGroup|'s [=bidding compression group/compression group id=] to |id|.
-  1. Set |compressionGroup|'s [=bidding compression group/partition=] to an empty [=list=].
+  1. Let |compressionGroup| be a [=bidding compression group=], whose
+	  [=bidding compression group/compression group id=] is |id|, and
+	  [=bidding compression group/partition=] is an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|'s [=bidding compression group/partition=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
@@ -8807,7 +8807,6 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
     1. Otherwise:
       1. Select a non-[=list/is empty|empty=] [=set/subset=] of |batcher|'s [=trusted scoring
         signals batcher/request map=][|key|], called |entriesToBatch|.
-      1. Set |entriesToBatch| to |batcher|'s [=trusted scoring signals batcher/request map=][|key|].
       1. [=map/Remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
       1. Let « |requestBody|, |renderUrlIdMap|, |context| » be the result of [=building batched
         trusted key value scoring signals request body=] for |entriesToBatch|.
@@ -8833,6 +8832,7 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
           1. If |scoringDataVersionMap| is not null:
             1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersionMap|
               [|entry|'s [=URL serializer|serialized=] [=trusted scoring signals request/render URL=]].
+          1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
       1. Otherwise, [=list/for each=] |entry| in |entriesToBatch|:
         1. Set |entry|'s [=trusted scoring signals request/reply=] to failure.
 

--- a/spec.bs
+++ b/spec.bs
@@ -6657,10 +6657,10 @@ To <dfn>process updateIfOlderThanMs</dfn> given an [=origin=] |buyer|, and an [=
 
 1. [=map/For each=] |igName| → |perIgData| of |perInterestGroupData|, the following steps should be
   done:
-  1. If |perIgData|'s [=bidding signals per interest group data/updateIfOlderThanMs=] is null,
+  1. If |perIgData|'s [=bidding signals per interest group data/update if older than ms=] is null,
     [=iteration/continue=].
   1. Let |updateIfOlderThan| be a [=duration=] of |perIgData|'s
-    [=bidding signals per interest group data/updateIfOlderThanMs=] milliseconds.
+    [=bidding signals per interest group data/update if older than ms=] milliseconds.
   1. Let |ig| be the [=interest group=] of the [=user agent=]'s [=interest group set=] whose
     [=interest group/owner=] is |buyer| and whose [=interest group/name=] is |igName|, or null if
     [=interest group set=] does not have such an interest group.
@@ -7571,9 +7571,9 @@ An <dfn export>interest group</dfn> is a [=struct=] with the following [=struct/
   :: A {{long}} integer, initially 0. Indicates the maximum trusted bidding signals fetch url length
     for the interest group. 0 means no limit.
   : <dfn>trusted bidding signals coordinator</dfn>
-  :: Null or an [=origin=]. This is used to specify where to obtain the public key used for
-    encryption and decryption in communication with a trusted bidding signal server running in a
-    Trust Execution Environment (TEE). When this field is specified, the request will be sent to
+  :: Null or an [=origin=], initially null. This is used to specify where to obtain the public key
+    used for encryption and decryption in communication with a trusted bidding signal server running
+    in a Trust Execution Environment (TEE). When this field is specified, the request will be sent to
     a trusted bidding signals server running in a TEE, and the value of
     [=interest group/trusted bidding signals url=] is ignored.
   : <dfn>user bidding signals</dfn>
@@ -7736,9 +7736,9 @@ An <dfn export>auction config</dfn> is a [=struct=] with the following [=struct/
   :: A {{long}} integer, initially 0. Indicates the maximum trusted scoring signals fetch url length
     for the auction config. 0 means no limit.
   : <dfn>trusted scoring signals coordinator</dfn>
-  :: Null or an [=origin=]. This is used to specify where to obtain the public key used for
-    encryption and decryption in communication with a trusted scoring signal server running in a
-    Trust Execution Environment (TEE). When this field is specified, the request will be sent to
+  :: Null or an [=origin=], initially null. This is used to specify where to obtain the public key
+    used for encryption and decryption in communication with a trusted scoring signal server running
+    in a Trust Execution Environment (TEE). When this field is specified, the request will be sent to
     a trusted scoring signals server running in a TEE, and the value of
     [=auction config/max trusted scoring signals url length=] is ignored.
   : <dfn>interest group buyers</dfn>
@@ -8174,12 +8174,35 @@ A <dfn>bidding signals per interest group data</dfn> is a [=struct=] with the fo
 [=struct/items=]:
 
 <dl dfn-for="bidding signals per interest group data">
-  : <dfn>updateIfOlderThanMs</dfn>
+  : <dfn>update if older than ms</dfn>
   :: Null or a {{double}}. If non-null, it is the [=duration=] in milliseconds after which the
     [=interest group=] is eligible for an [update](#interest-group-update), if it hasn't been joined
     or updated within that duration. When eligible, the update is performed either following a call
     to {{Navigator/runAdAuction()}}, for each of the passed {{AuctionAdConfig/interestGroupBuyers}},
     or explicitly by the {{Navigator/updateAdInterestGroups()}} method.
+</dl>
+
+A <dfn>compression group</dfn> is a collection of partitions that can be compressed together
+in the signals response. It's a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="compression group">
+  : <dfn>compression group id</dfn>
+  :: An integer indicates the index of this compression group.
+  : <dfn>partitions</dfn>
+  :: A [=list=] of [=partition=]. Contains all the partitions belong to this compression group.
+</dl>
+
+A <dfn>partition</dfn> is a collection of keys that can be processed together by the service
+without any potential privacy leakage. It's a [=struct=] with the following [=struct/items=]:
+
+<dl dfn-for="partition">
+  : <dfn>id</dfn>
+  :: An integer indicates the index of this partition.
+  : <dfn>namespace</dfn>
+  :: An empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of
+    [=strings=].
+  : <dfn>metadata</dfn>
+  :: An empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 </dl>
 
 <div algorithm>
@@ -8197,9 +8220,9 @@ To <dfn>append to a bidding signals per-interest group data map</dfn> given an [
     1. If |updateIfOlderThanMs| &lt; 600,000, set |updateIfOlderThanMs| to 600,000.
 
       Note: 600,000 milliseconds is 10 minutes.
-    1. Set |perGroupData|'s [=bidding signals per interest group data/updateIfOlderThanMs=] to
+    1. Set |perGroupData|'s [=bidding signals per interest group data/update if older than ms=] to
       |updateIfOlderThanMs|.
-  1. If |perGroupData|'s [=bidding signals per interest group data/updateIfOlderThanMs=] is not
+  1. If |perGroupData|'s [=bidding signals per interest group data/update if older than ms=] is not
     null, then [=map/set=] |destinationMap|[|sourceKey|] to |perGroupData|.
 
 </div>
@@ -8290,7 +8313,7 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
 
      Note: An interest group with no trusted signals keys requests would still fetch and process
      per-interest group data like priorityVector and
-     [=bidding signals per interest group data/updateIfOlderThanMs=], but it will get null passed in
+     [=bidding signals per interest group data/update if older than ms=], but it will get null passed in
      to its bidding function.
 
   1. If |ig|'s [=interest group/trusted bidding signals coordinator=] is null:
@@ -8347,7 +8370,7 @@ To <dfn>build trusted key value bidding signals request body</dfn> given a [=set
 an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
 |slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
 
-1. Let |compressionGroups| be an empty [=list=], whose [=map/values=] are [=maps=].
+1. Let |compressionGroups| be an empty [=list=], whose values are [=compression group=].
 1. Let |compressionGroupMap| be an empty [=map=], whose [=map/keys=] are integers and [=map/values=] are [=maps=].
 1. Let |compressionIdMap| be an empty [=map=], whose keys [=origins=] and [=map/values=] are integers.
 1. Let |interestGroupIdMap| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=tuples=]
@@ -8374,18 +8397,17 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. Set |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of |compressionGroupId|
     and |partitionId|.
   1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|:
-    1. Let |partition| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
-      [=maps=].
-    1. Set |partition|["id"] to |partitionId|.
-    1. Let |namespace| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
-      [=list=] of [=strings=].
+    1. Let |partition| be an empty [=partition=].
+    1. Set |partition|'s [=partition/id=] to |partitionId|.
+    1. Let |namespace| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=]
+      of [=strings=].
     1. Set |namespace|["interest_group_names"] to [|group|'s [=interest group/name=]].
     1. Set |namespace|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
-    1. Set |partition|["namespace"] to |namespace|.
+    1. Set |partition|'s [=partition/namespace=] to |namespace|.
     1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
     1. Set |metadata|["experiment_group_id"] to |experimentGroupId|.
     1. Set |metadata|[|slotSizeParams|[0]] to |slotSizeParams|[1].
-    1. Set |partition|["metadata"] to |metadata|.
+    1. Set |partition|'s [=partition/metadata=] to |metadata|.
     1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
   1. Otherwise:
     1. [=list/Append=] |group|'s [=interest group/name=] into |compressionGroupMap|[|compressionGroupId|]
@@ -8393,12 +8415,11 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     1. [=list/Append=] |group|'s [=interest group/trusted bidding signals keys=] into
       |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
-    [=lists=] of [=maps=].
-  1. Set |compressionGroup|["compression_group_id"] to |id|.
-  1. Set |compressionGroup|["partitions"] to an empty [=list=].
+  1. Let |compressionGroup| be an empty [=compression group=].
+  1. Set |compressionGroup|'s [=compression group/compression group id=] to |id|.
+  1. Set |compressionGroup|'s [=compression group/partition=] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
-    1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
+    1. [=list/Append=] |partition| to |compressionGroup|'s [=compression group/partition=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
 1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
@@ -8604,7 +8625,7 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 [=trusted scoring signals requests=] |entriesToBatch|:
 
 1. Let |firstRequest| be |entriesToBatch|[0].
-1. Let |compressionGroups| be an empty [=list=], whose [=map/values=] are [=maps=].
+1. Let |compressionGroups| be an empty [=list=], whose values are [=maps=].
 1. Let |compressionGroupMap| be an empty [=map=], whose [=map/keys=] are integers and keys are [=maps=].
 1. Let |compressionIdMap| be an empty [=map=], whose [=map/keys=] are [=tuples=] of ([=origin=],
   [=origin=]) and [=map/values=] are integers.

--- a/spec.bs
+++ b/spec.bs
@@ -2701,8 +2701,6 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
 an [=map=]-or-null |indexMap| whose keys are [=strings=] and values are [=tuples=] consisting of an
 interger and an integer , and a [=boolean=] |isBiddingSignal|:
 
-1. If |body| is null, return « null, null, null ».
-
 1. Let |request| be a new [=request=] with the following properties:
   :   [=request/URL=]
   ::  |url|
@@ -8409,7 +8407,7 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     :: |partitionId|
 
     : [=bidding partition/namespace=]
-    :: The [=ordered map=] «[ "interestGroupNames" → [|group|'s [=interest group/name=]],
+    :: The [=ordered map=] «[ "interestGroupNames" → « |group|'s [=interest group/name=] »,
       "biddingKeys" → |group|'s [=interest group/trusted bidding signals keys=] ]»
 
     : [=bidding partition/metadata=]
@@ -8452,9 +8450,10 @@ an [=origin=] |scriptOrigin|, an {{unsigned short}}-or-null |experimentGroupId|,
     1. Let « |requestBody|, |interestGroupIdMap|, |context| » be the result of [=building trusted
       key value bidding signals request body=] with |interestGroups|, |experimentGroupId|,
       |topLevelOrigin|, |slotSizeQueryParam|, |joiningOrigin| and |owner|.
-    1. Let « |partialTrustedBiddingSignals|, |partialPerInterestGroupData|, |dataVersion| » be the
-      result of [=fetching trusted key value signals=] with |signalsUrl|, |requestBody|, |context|,
-      |scriptOrigin|, |policyContainer|, |interestGroupIdMap| and true.
+    1. If |requestBody| is not null:
+      1. Let « |partialTrustedBiddingSignals|, |partialPerInterestGroupData|, |dataVersion| » be the
+        result of [=fetching trusted key value signals=] with |signalsUrl|, |requestBody|, |context|,
+        |scriptOrigin|, |policyContainer|, |interestGroupIdMap| and true.
     1. If |partialTrustedBiddingSignals| is not null:
       1. [=map/For each=] |key| → |value| in |partialTrustedBiddingSignals|, [=map/set=]
         |trustedBiddingSignalsBatcher|'s [=trusted bidding signals batcher/all trusted bidding
@@ -8684,11 +8683,11 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
     :: |partitionId|
 
     : [=scoring partition/namespace=]
-    :: The [=ordered map=] «[ "render_urls" → [|request|'s [=trusted scoring signals request/render URL=]],
-      "ad_component_render_urls" → |request|'s [=trusted scoring signals request/ad component URLs=] ]»
+    :: The [=ordered map=] «[ "renderUrls" → « |request|'s [=trusted scoring signals request/render URL=] »,
+      "adComponentRenderUrls" → |request|'s [=trusted scoring signals request/ad component URLs=] ]»
 
     : [=scoring partition/metadata=]
-    :: The [=ordered map=] «[ "experiment_group_id" → |firstRequest|'s [=trusted scoring signals request/seller experiment group id=] ]»
+    :: The [=ordered map=] «[ "experimentGroupId" → |firstRequest|'s [=trusted scoring signals request/seller experiment group id=] ]»
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
   1. Let |compressionGroup| be an [=scoring compression group=] whose [=scoring compression group/compression group id=]
     is |id| and [=scoring compression group/partition=] is an empty [=list=].
@@ -8806,6 +8805,8 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
         1. [=list/For each=] |entry| in |entriesToBatch|:
           1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
     1. Otherwise:
+      1. Select a non-[=list/is empty|empty=] [=set/subset=] of |batcher|'s [=trusted scoring
+        signals batcher/request map=][|key|], called |entriesToBatch|.
       1. Set |entriesToBatch| to |batcher|'s [=trusted scoring signals batcher/request map=][|key|].
       1. [=map/Remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
       1. Let « |requestBody|, |renderUrlIdMap|, |context| » be the result of [=building batched
@@ -8820,8 +8821,8 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
         1. If |allowCrossOriginTrustedScoringSignalsFrom| does not [=list/contain=]
           |baseUrl|'s [=url/origin=], set |baseUrl| to null.
       1. Let |result| be failure.
-      1. If |baseUrl| is not null:
-        1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersion|» be
+      1. If |baseUrl| and |requestBody| are not null:
+        1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersionMap|» be
           the result of [=fetching trusted key value signals=] with |baseUrl|, |requestBody|,
           |context|, |seller|, |entriesToBatch|[0]'s [=trusted scoring signals request/policy container=],
           |renderUrlIdMap| and false.
@@ -8829,9 +8830,10 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
           1. Set |result| to a new [=trusted scoring signals reply=]
           1. Set |result|'s [=trusted scoring signals reply/all trusted scoring signals=] to
             |allTrustedScoringSignals|.
+          1. [=list/For each=] |entry| in |entriesToBatch|:
+            1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersionMap|
+              [|entry|'s [=URL serializer|serialized=] [=trusted scoring signals request/render URL=]].
       1. [=list/For each=] |entry| in |entriesToBatch|:
-        1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersion|
-          [|entry|'s [=URL serializer|serialized=] [=trusted scoring signals request/render URL=]].
         1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -8367,8 +8367,10 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|:
     1. Let |partition| be an empty [=map=].
     1. Set |partition|["id"] to |partitionId|.
-    1. Set |partition|["interest_group_names"] to [|group|'s [=interest group/name=]].
-    1. Set |partition|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
+    1. Let |namespace| be an empty [=map=].
+    1. Set |namespace|["interest_group_names"] to [|group|'s [=interest group/name=]].
+    1. Set |namespace|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
+    1. Set |partition|["namespace"] to |namespace|.
     1. Let |metadata| be an empty [=map=].
     1. Set |metadata|["experiment_group_id"] to |experimentGroupId|.
     1. Set |metadata|[|slotSizeParams|[0]] to |slotSizeParams|[1].
@@ -8611,9 +8613,11 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
     of |compressionGroupId| and |partitionId|.
   1. Let |partition| be an empty [=map=].
   1. Set |partition|["id"] to |partitionId|.
-  1. Set |partition|["render_url"] to [|request|'s [=trusted scoring signals request/render URL=]].
-  1. Set |partition|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
+  1. Let |namespace| be an empty [=map=].
+  1. Set |namespace|["render_url"] to [|request|'s [=trusted scoring signals request/render URL=]].
+  1. Set |namespace|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
     component URLs=].
+  1. Set |partition|["namespace"] to |namespace|.
   1. Let |metadata| be an empty [=map=].
   1. Set |metadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
       request/seller experiment group id=].

--- a/spec.bs
+++ b/spec.bs
@@ -2712,23 +2712,23 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
   :   [=request/mode=]
   ::  "`cors`"
   :   [=request/referrer=]
-  :: "`no-referrer`"
+  ::  "`no-referrer`"
   :   [=request/credentials mode=]
   ::  "`omit`"
   :   [=request/redirect mode=]
-  :: "`error`"
+  ::  "`error`"
+  :   [=request/service-workers mode=]
+  ::  "`none`"
   :   [=request/policy container=]
   ::  A new [=policy container=] whose [=policy container/IP address space=] is |policyContainer|'s
     [=policy container/IP address space=]
 
-  Issue: One of the side-effects of a `null` client for this subresource request is it neuters all
-  service worker interceptions, despite not having to set the service workers mode.
 
 1. Let |resultList| be the result of deserializing |responseBody| using |context|. The
   deserialization method may follow that described in
   [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
 1. Let |signals| be null.
-1. Let |dataVersion| be an empty [=ordered map=], whose keys are [=strings=] and values are integers.
+1. Let |dataVersion| be an empty [=ordered map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers.
 1. Let |perInterestGroupData| be an [=ordered map=].
 1. [=Fetch=] |request| with [=fetch/useParallelQueue=] set to true, and
   [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
@@ -2745,16 +2745,16 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
             2<sup>32</sup>&minus;1, set |signals| to failure and return.
           1. Otherwise, set |dataVersion|[|name|] to |result|["dataVersion"].
       1. [=map/For each=] |key| → |value| in |result|["keys"]:
-        1. Set |siganls|[|key|] to |value|.
+        1. Set |signals|[|key|] to |value|.
     1. Otherwise:
       1. [=map/For each=] |url| → |value| in |result|["renderUrls"]:
-        1. Set |siganls|[|url|] to |value|.
+        1. Set |signals|[|url|] to |value|.
         1. If |result| [=map/contains=] `"dataVersion"`:
           1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
             2<sup>32</sup>&minus;1, set |signals| to failure and return.
           1. Otherwise, set |dataVersion|[|url|] to |result|["dataVersion"].
       1. [=map/For each=] |url| → |value| in |result|["adComponentRenderUrls"]:
-        1. Set |siganls|[|url|] to |value|.
+        1. Set |signals|[|url|] to |value|.
 1. Return « |signals|, |perInterestGroupData|, |dataVersion| ».
 
 </div>
@@ -3048,7 +3048,7 @@ a {{ReportingBrowserSignals}} |browserSignals|, a [=direct from seller signals=]
       <dd>|leadingBidInfo|'s [=leading bid info/bidding data version=] if it is not null,
         {{undefined}} otherwise.
       <dt>{{ReportWinBrowserSignals/adCost}}
-      <dd>[=Round a value|Rounded=] |winner|’s [=generated bid/ad cost=]
+      <dd>[=Round a value|Rounded=] |winner|'s [=generated bid/ad cost=]
       <dt>{{ReportWinBrowserSignals/seller}}
       <dd>[=serialization of an origin|Serialized=] |config|'s [=auction config/seller=]
       <dt>{{ReportWinBrowserSignals/madeHighestScoringOtherBid}}
@@ -5010,7 +5010,7 @@ A <dfn>decoded additional bid</dfn> is a [=struct=] with the following [=struct/
 
 *This first introductory paragraph is non-normative.*
 
-In online ad auctions for ad space, it’s sometimes useful to prevent showing an ad to certain
+In online ad auctions for ad space, it's sometimes useful to prevent showing an ad to certain
 audiences, a concept known as <dfn>negative targeting</dfn>. To facilitate [=negative targeting=] in
 Protected Audience [=auctions=], each [=additional bid=] is allowed to identify one or more
 [=negative interest groups=]. If the user has been joined to any of the identified
@@ -6694,7 +6694,7 @@ interface ProtectedAudience {
 <div algorithm>
 
 The <dfn for=ProtectedAudience method>queryFeatureSupport(feature)</dfn> method steps are:
-1. Let |featuresTable| be an [=ordered map=] whose keys are {{DOMString}}s and whose values are
+1. Let |featuresTable| be an [=ordered map=] whose [=map/keys=] are {{DOMString}}s and whose [=map/values=] are
    {{boolean}}s or {{long}}s, with the following entries:
     :   "adComponentsLimit"
     ::  40
@@ -7139,7 +7139,7 @@ response by either repeating the header or by specifying multiple hashes separat
 
 <div algorithm="ad auction fetch redirect patch">
 The following steps will be added to the [=HTTP fetch=] algorithm, immediately under the step "If
-<var ignore>internalResponse</var>’s [=status=] is a [=redirect status=]:"
+<var ignore>internalResponse</var>'s [=status=] is a [=redirect status=]:"
 
 1. [=header list/Delete=] "[:Ad-Auction-Signals:]" from |response|'s
   [=response/header list=].
@@ -8120,7 +8120,7 @@ a [=script fetcher=] |fetcher|:
     1. Set |fetcher|'s [=script fetcher/origins authorized for cross origin trusted signals=] to the
       result of [=parsing allowed trusted scoring signals origins=] given |response|'s [=response/
       header list=].
-    1. Let |bodyStream| be |response|’s [=response/body=]’s [=body/stream=].
+    1. Let |bodyStream| be |response|'s [=response/body=]'s [=body/stream=].
     1. Let |bodyReader| be result of [=ReadableStream/getting a reader=] from |bodyStream|.
     1. Let |successSteps| be a set of steps that take a [=byte sequence=] |responseBody|, and
       perform the following:
@@ -8336,7 +8336,7 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
     1. If |keyValueInterestGroups| [=map/contain=] |key|, [=set/Append=] |ig| to |keyValueInterestGroups|
       [|key|].
     1. Otherwise:
-      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=], whose values are [=strings=].
+      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=], whose [=map/values=] are [=strings=].
       1. [=set/Append=] |ig| to |keyValueInterestGroups| [|key|].
 
 </div>
@@ -8347,10 +8347,10 @@ To <dfn>build trusted key value bidding signals request body</dfn> given a [=set
 an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin|, a [=string=]
 |slotSizeQueryParam|, an [=origin=] |coordinator|, and an [=origin=] |owner|:
 
-1. Let |compressionGroups| be an empty [=list=], whose values are [=maps=].
-1. Let |compressionGroupMap| be an empty [=map=], whose keys are integers and values are [=maps=].
-1. Let |compressionIdMap| be an empty [=map=], whose keys [=origins=] and values are integers.
-1. Let |interestGroupIdMap| be an empty [=map=], whose keys are [=strings=] and values are [=tuples=]
+1. Let |compressionGroups| be an empty [=list=], whose [=map/values=] are [=maps=].
+1. Let |compressionGroupMap| be an empty [=map=], whose [=map/keys=] are integers and [=map/values=] are [=maps=].
+1. Let |compressionIdMap| be an empty [=map=], whose keys [=origins=] and [=map/values=] are integers.
+1. Let |interestGroupIdMap| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=tuples=]
   of (interger, integer).
 1. Let |slotSizeParams| be the result of [=strictly splitting=] |slotSizeQueryParam| on U+003D (=).
 1. Let |nextCompressionGroupId| be 0.
@@ -8362,8 +8362,8 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     1. Increment |nextCompressionGroupId| by 1.
   1. Let |compressionGroupId| be |compressionIdMap|[|joiningOrigin|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose keys are integers
-      and values are [=maps=].
+    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose [=map/keys=] are integers
+      and [=map/values=] are [=maps=].
   1. Set |executionMode| to |group|'s [=interest group/execution mode=].
   1. If |executionMode| equal to "`group-by-origin`", set |partitionId| to 0.
   1. Otherwise:
@@ -8374,15 +8374,15 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. Set |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of |compressionGroupId|
     and |partitionId|.
   1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|:
-    1. Let |partition| be an empty [=map=], whose keys are [=strings=] and values are integers or
+    1. Let |partition| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
       [=maps=].
     1. Set |partition|["id"] to |partitionId|.
-    1. Let |namespace| be an empty [=map=], whose keys are [=strings=] and values are [=strings=] or
+    1. Let |namespace| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
       [=list=] of [=strings=].
     1. Set |namespace|["interest_group_names"] to [|group|'s [=interest group/name=]].
     1. Set |namespace|["bidding_keys"] to |group|'s [=interest group/trusted bidding signals keys=].
     1. Set |partition|["namespace"] to |namespace|.
-    1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
+    1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
     1. Set |metadata|["experiment_group_id"] to |experimentGroupId|.
     1. Set |metadata|[|slotSizeParams|[0]] to |slotSizeParams|[1].
     1. Set |partition|["metadata"] to |metadata|.
@@ -8393,14 +8393,14 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     1. [=list/Append=] |group|'s [=interest group/trusted bidding signals keys=] into
       |compressionGroupMap|[|compressionGroupId|][|partitionId|]["bidding_keys"].
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=map=], whose keys are [=strings=] and values are integers or
+  1. Let |compressionGroup| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
     [=lists=] of [=maps=].
   1. Set |compressionGroup|["compression_group_id"] to |id|.
   1. Set |compressionGroup|["partitions"] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
-1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
+1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |topLevelOrigin| using [=component percent-encode set=].
 1. Set |metadata|["hostname"] to |hostname|.
@@ -8604,11 +8604,11 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 [=trusted scoring signals requests=] |entriesToBatch|:
 
 1. Let |firstRequest| be |entriesToBatch|[0].
-1. Let |compressionGroups| be an empty [=list=], whose values are [=maps=].
-1. Let |compressionGroupMap| be an empty [=map=], whose keys are integers and keys are [=maps=].
-1. Let |compressionIdMap| be an empty [=map=], whose keys are [=tuples=] of ([=origin=],
-  [=origin=]) and values are integers.
-1. Let |renderUrlIdMap| be an empty [=map=], whose keys are [=URLs=] and values are [=tuples=]
+1. Let |compressionGroups| be an empty [=list=], whose [=map/values=] are [=maps=].
+1. Let |compressionGroupMap| be an empty [=map=], whose [=map/keys=] are integers and keys are [=maps=].
+1. Let |compressionIdMap| be an empty [=map=], whose [=map/keys=] are [=tuples=] of ([=origin=],
+  [=origin=]) and [=map/values=] are integers.
+1. Let |renderUrlIdMap| be an empty [=map=], whose [=map/keys=] are [=URLs=] and [=map/values=] are [=tuples=]
   of (interger, integer).
 1. Let |nextCompressionGroupId| be 0.
 1. [=map/For each=] |request| of |entriesToBatch|:
@@ -8621,34 +8621,34 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
     1. Increase |nextCompressionGroupId| by 1.
   1. Let |compressionGroupId| be |compressionIdMap|[|mapKey|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose keys are integers
-      and values are [=maps=].
+    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose [=map/keys=] are integers
+      and [=map/values=] are [=maps=].
   1. Set |partitionId| to [=list/size=] of |compressionGroupMap|[|compressionGroupId|].
   1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
     of |compressionGroupId| and |partitionId|.
-  1. Let |partition| be an empty [=map=], whose keys are [=strings=] and values are [=strings=] or
+  1. Let |partition| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
       [=list=] of [=strings=].
   1. Set |partition|["id"] to |partitionId|.
-  1. Let |namespace| be an empty [=map=], whose keys are [=strings=] and values are [=strings=] or
+  1. Let |namespace| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
       [=list=] of [=strings=].
   1. Set |namespace|["render_url"] to [|request|'s [=trusted scoring signals request/render URL=]].
   1. Set |namespace|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
     component URLs=].
   1. Set |partition|["namespace"] to |namespace|.
-  1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
+  1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
   1. Set |metadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
       request/seller experiment group id=].
   1. Set |partition|["metadata"] to |metadata|.
   1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=map=], whose keys are [=strings=] and values are integers or
+  1. Let |compressionGroup| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
     [=lists=] of [=maps=].
   1. Set |compressionGroup|["compression_group_id"] to |id|.
   1. Set |compressionGroup|["partitions"] to an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|["partitions"].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
-1. Let |metadata| be an empty [=map=], whose keys and values are [=strings=].
+1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
 1. Let |hostname| be the result of [=string/UTF-8 percent-encoding=] the
   [=serialization of an origin|serialized=] |firstRequest|'s [=trusted scoring signals request/top
     level origin=] using [=component percent-encode set=].
@@ -8792,7 +8792,7 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
             |allTrustedScoringSignals|.
       1. [=list/For each=] |entry| in |entriesToBatch|:
         1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersion|
-          [|entry|'s [=trusted scoring signals request/render URL=]].
+          [|entry|'s [=URL serializer|serialized=] [=trusted scoring signals request/render URL=]].
         1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
 
 </div>
@@ -9300,8 +9300,8 @@ An <dfn>auction data buyer config</dfn> is a [=struct=] with the following [=str
 # Privacy Considerations # {#privacy-considerations}
 
 Protected Audience aims to advance the privacy of remarketing and custom audience
-advertising on the web, so naturally privacy considerations are paramount to Protected Audience’s
-design.  Partitioning data by site is the central mechanism to prevent joining a user’s identity
+advertising on the web, so naturally privacy considerations are paramount to Protected Audience's
+design.  Partitioning data by site is the central mechanism to prevent joining a user's identity
 across sites:
 - Interest group definitions come from just one site, the site that called
   {{Navigator/joinAdInterestGroup()}}.
@@ -9329,7 +9329,7 @@ Protected Audience involves the browser running untrusted JavaScript downloaded 
 parties, so security concerns are top of mind. Fortunately Protected Audience is a highly
 constrained API not attempting to be a general purpose execution environment. Execution of this
 JavaScript is controlled and limited as follows:
-- Protected Audience requires the origin of the scripts’ URLs to match that of the origin of the
+- Protected Audience requires the origin of the scripts' URLs to match that of the origin of the
   interest group owner, which is in turn required to match the origin of the context calling the
   {{Navigator/joinAdInterestGroup()}}.
 - URL schemes are required to be HTTPS.

--- a/spec.bs
+++ b/spec.bs
@@ -2696,10 +2696,10 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
 </div>
 
 <div algorithm>
-To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte sequence=] |body|, a [=string=]
-|context|, an [=origin=] |scriptOrigin|, a [=policy container=] |policyContainer|, an |indexMap| whose keys
-are [=strings=] and values are [=tuples=] consisting of an interger and an integer , and a [=boolean=]
-|isBiddingSignal|:
+To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte sequence=] |body|, a
+[=string=]-or-null |context|, an [=origin=] |scriptOrigin|, a [=policy container=] |policyContainer|,
+an [=map=]-or-null |indexMap| whose keys are [=strings=] and values are [=tuples=] consisting of an
+interger and an integer , and a [=boolean=] |isBiddingSignal|:
 
 1. If |body| is null, return « null, null, null ».
 
@@ -8396,8 +8396,8 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
     1. [=map/Set=] |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers
       and [=map/values=] are [=maps=].
-  1. If |group|'s [=interest group/execution mode=] is "`group-by-origin`", set |partitionId| to 0.
-  1. Otherwise:
+  1. Let |partitionId| be 0.
+  1. If |group|'s [=interest group/execution mode=] is not "`group-by-origin`":
     1. If |compressionGroupMap|[|compressionGroupId|] [=map/contains=] 0, set |partitionId| to
       [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
     1. Otherwise, set |partitionId| to [=list/size=] of |compressionGroupMap|[|joiningOrigin|] plus 1.
@@ -8409,7 +8409,7 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
     :: |partitionId|
 
     : [=bidding partition/namespace=]
-    :: The [=ordered map=] «[ "interestGroupNames" → « [|group|'s [=interest group/name=]],
+    :: The [=ordered map=] «[ "interestGroupNames" → [|group|'s [=interest group/name=]],
       "biddingKeys" → |group|'s [=interest group/trusted bidding signals keys=] ]»
 
     : [=bidding partition/metadata=]

--- a/spec.bs
+++ b/spec.bs
@@ -2701,7 +2701,7 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
 are [=strings=] and values are [=tuples=] consisting of an interger and an integer , and a [=boolean=]
 |isBiddingSignal|:
 
-1. If |body| is null, set |signals| to failure and return.
+1. If |body| is null, return « null, null, null ».
 
 1. Let |request| be a new [=request=] with the following properties:
   :   [=request/URL=]
@@ -2740,17 +2740,17 @@ are [=strings=] and values are [=tuples=] consisting of an interger and an integ
   [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
   and null, failure, or a [=byte sequence=] |responseBody|:
   1. If [=validate fetching response=] with |response|, |responseBody| and
-    "`message/ad-auction-trusted-signals-response`" returns false, set |signals| to failure and return.
+    "`message/ad-auction-trusted-signals-response`" returns false, return « null, null, null ».
   1. Let |resultList| be the result of deserializing |responseBody| using |context|. The
     deserialization method may follow that described in
     [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
   1. [=list/For each=] |result| in |resultList|:
     1. If |result| [=map/contains=] "`dataVersion`":
       1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
-        2<sup>32</sup>&minus;1, set |signals| to failure and return.
+        2<sup>32</sup>&minus;1, return « null, null, null ».
     1. If |isBiddingSignal| is true:
       1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
-        1. If |indexMap|[|name|] does not equal to |result|["index"], set |signals| to failure and return.
+        1. If |indexMap|[|name|] does not equal to |result|["index"], return « null, null, null ».
         1. [=map/Set=] |perInterestGroupData|[|name|] to |value|.
         1. If |result| [=map/contains=] "`dataVersion`", set |dataVersion|[|name|] to |result|["dataVersion"].
       1. [=map/For each=] |key| → |value| in |result|["keys"]:
@@ -8400,31 +8400,21 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
   1. Otherwise:
     1. If |compressionGroupMap|[|compressionGroupId|] [=map/contains=] 0, set |partitionId| to
       [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
-    1. Otherwise, set |partitionId| to sum [=list/size=] of |compressionGroupMap|[|joiningOrigin|]
-      and 1.
+    1. Otherwise, set |partitionId| to [=list/size=] of |compressionGroupMap|[|joiningOrigin|] plus 1.
   1. [=map/Set=] |interestGroupIdMap|[|group|'s [=interest group/name=]] to [=tuple=] of
     (|compressionGroupId|, |partitionId|).
-  1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|, Set
-    |compressionGroupMap|[|compressionGroupId|][|partitionId|] with the following [=struct/items=]:
-    : [=bidding partition=]
-    :: a [=struct=] with the following [=struct/items=]:
-      : [=bidding partition/id=]
-      :: an integer records the identifier of this [=bidding partition=].
+  1. If |compressionGroupMap|[|compressionGroupId|] does not [=map/contain=] |partitionId|, set
+    |compressionGroupMap|[|compressionGroupId|][|partitionId|] to a [=bidding partition=] with the following items:
+    : [=bidding partition/id=]
+    :: |partitionId|
 
-      : [=bidding partition/namespace=]
-      :: a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of [=strings=].
+    : [=bidding partition/namespace=]
+    :: "interest_group_names" → [|group|'s [=interest group/name=]]
+    :: "bidding_keys" → |group|'s [=interest group/trusted bidding signals keys=]
 
-      : [=bidding partition/metadata=]
-      :: a [=map=] whose [=map/keys=] and [=map/values=] are [=strings=].
-
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/namespace=]["interest_group_names"]
-      to [|group|'s [=interest group/name=]].
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/namespace=]["bidding_keys"] to
-      |group|'s [=interest group/trusted bidding signals keys=].
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/metadata=]["experiment_group_id"]
-      to |experimentGroupId|.
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=bidding partition/metadata=][|slotSizeParams|[0]] to
-      |slotSizeParams|[1].
+    : [=bidding partition/metadata=]
+    :: "experiment_group_id" → |experimentGroupId|
+    :: |slotSizeParams|[0] → |slotSizeParams|[1]
   1. Otherwise:
     1. [=list/Append=] |group|'s [=interest group/name=] into |compressionGroupMap|[|compressionGroupId|]
       [|partitionId|]["interest_group_names"].
@@ -8443,12 +8433,11 @@ an {{unsigned short}}-or-null |experimentGroupId|, an [=origin=] |topLevelOrigin
 1. Set |metadata|["hostname"] to |hostname|.
 1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |owner| and
   |coordinator|.
-1. If |keyInfo| is failure:
-  1. Return « null, null, and null ».
+1. If |keyInfo| is failure, then return « null, null, null ».
 1. Let (|requestBlob|, |context|) be the result of generating request with |keyInfo|, |metadata| and
   |compressionGroups|. The generation method may follow that described in 
   [Section 2.2.4 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-generating-a-request).
-1. Return |requestBlob|, |interestGroupIdMap| and |context|.
+1. Return « |requestBlob|, |interestGroupIdMap|, |context| ».
 
 </div>
 
@@ -8682,36 +8671,28 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   1. Let |mapKey| be a tuple of (|request|'s [=trusted scoring signals request/owner origin=],
     |request|'s [=trusted scoring signals request/joining origin=]).
   1. If |compressionIdMap| does not [=map/contain=] |mapKey|:
-    1. Set |compressionIdMap|[|mapKey|] to |nextCompressionGroupId|.
+    1. [=map/Set=] |compressionIdMap|[|mapKey|] to |nextCompressionGroupId|.
     1. Increment |nextCompressionGroupId| by 1.
   1. Let |compressionGroupId| be |compressionIdMap|[|mapKey|].
-  1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Set |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers
-  1. Let |partitionId| be [=list/size=] of |compressionGroupMap|[|compressionGroupId|].
+  1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|, then set
+    |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers.
+  1. Let |partitionId| be [=map/size=] of |compressionGroupMap|[|compressionGroupId|].
   1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
     of (|compressionGroupId|, |partitionId|).
-  1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] with the following [=struct/items=]:
-    : [=scoring partition=]
-    :: a [=struct=] with the following [=struct/items=]:
-      : [=scoring partition/id=]
-      :: an integer records the identifier of this [=scoring partition=].
+  1. [=map/Set=] |compressionGroupMap|[|compressionGroupId|][|partitionId|] to a [=scoring partition=] with the
+    following [=struct/items=]:
+    : [=scoring partition/id=]
+    :: |partitionId|
 
-      : [=scoring partition/namespace=]
-      :: a [=map=] whose [=map/keys=] are [=strings=] and [=map/values=] are [=list=] of [=strings=].
+    : [=scoring partition/namespace=]
+    :: "render_urls" → [|request|'s [=trusted scoring signals request/render URL=]]
+    :: "ad_component_render_urls" → [=trusted scoring signals request/ad component URLs=]
 
-      : [=scoring partition/metadata=]
-      :: a [=map=] whose [=map/keys=] and [=map/values=] are [=strings=].
-
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=scoring partition/namespace=]["render_urls"]
-      to [|request|'s [=trusted scoring signals request/render URL=]].
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=scoring partition/namespace=]["ad_component_render_urls"]
-      to |request|'s [=trusted scoring signals request/ad component URLs=].
-    1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|]'s [=scoring partition/metadata=]["experiment_group_id"]
-      to |firstRequest|'s [=trusted scoring signals request/seller experiment group id=].
+    : [=scoring partition/metadata=]
+    :: "experiment_group_id" → |firstRequest|'s [=trusted scoring signals request/seller experiment group id=]
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
-  1. Let |compressionGroup| be an empty [=scoring compression group=].
-  1. Set |compressionGroup|'s [=scoring compression group/compression group id=] to |id|.
-  1. Set |compressionGroup|'s [=bidding compression group/partition=] to an empty [=list=].
+  1. Let |compressionGroup| be an [=scoring compression group=] whose [=scoring compression group/compression group id=]
+    is |id| and [=scoring compression group/partition=] is an empty [=list=].
   1. [=list/For each=] |partition| in |group|'s [=map/values=]:
     1. [=list/Append=] |partition| to |compressionGroup|'s [=scoring compression group/partition=].
   1. [=list/Append=] |compressionGroup| to |compressionGroups|.
@@ -8723,8 +8704,7 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
 1. Let |keyInfo| be the result of [=looking up the server encryption key=] with |firstRequest|'s
   [=trusted scoring signals request/seller=] and |firstRequest|'s [=trusted scoring signals
   request/signal coordinator=].
-1. If |keyInfo| is failure:
-  1. Return « null, null, and null ».
+1. If |keyInfo| is failure, then return « null, null, null ».
 1. Let (|requestBlob|, |context|) be the result of generating request with |keyInfo|, |metadata| and
   |compressionGroups|. The generation method may follow that described in
   [Section 2.2.4 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-generating-a-request).
@@ -8738,8 +8718,6 @@ To <dfn>build batched trusted key value scoring signals request body</dfn> given
 [=trusted scoring signals requests=] |entriesToBatch|:
 
 1. Let |firstEntry| be |entriesToBatch|[0].
-1. Let |renderURLs| be an empty [=ordered set=] of [=strings=].
-1. Let |adComponentRenderURLs| be an empty [=ordered set=] of [=strings=].
 1. [=list/For each=] |entry| of |entriesToBatch|:
   1. [=Assert=] that |entry|'s [=trusted scoring signals request/base URL=] is equal to
     |firstEntry|'s [=trusted scoring signals request/base URL=].
@@ -8753,9 +8731,6 @@ To <dfn>build batched trusted key value scoring signals request body</dfn> given
     |firstEntry|'s [=trusted scoring signals request/seller script fetcher=].
   1. [=Assert=] that |entry|'s [=trusted scoring signals request/policy container=] is equal to
     |firstEntry|'s [=trusted scoring signals request/policy container=].
-  1. [=set/Append=] |entry|'s [=trusted scoring signals request/render URL=] to |renderURLs|.
-  1. [=list/Extend=] |adComponentRenderURLs| with |entry|'s [=trusted scoring signals request/
-    ad component URLs=].
 1. Return the result of [=building trusted key value scoring signals request body=] with
    |entriesToBatch|.
 
@@ -8814,8 +8789,6 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
         1. Let |seller| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller=].
         1. Let |scriptFetcher| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller
           script fetcher=].
-        1. Let |policyContainer| be |entriesToBatch|[0]'s [=trusted scoring signals request/policy
-          container=].
         1. If |fullSignalsUrl|'s [=url/origin=] is not [=same origin=] with |seller| then:
           1. Let |allowCrossOriginTrustedScoringSignalsFrom| be the result of [=wait for cross origin
             trusted scoring signals authorization from a fetcher=] given |scriptFetcher|.
@@ -8825,7 +8798,7 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
         1. If |fullSignalsUrl| is not null:
           1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersion|» be
             the result of [=fetching trusted signals=] with |fullSignalsUrl|, |seller|,
-            |policyContainer|, and false.
+            |entriesToBatch|[0]'s [=trusted scoring signals request/policy container=], and false.
           1. If |allTrustedScoringSignals| is an [=ordered map=]:
             1. Set |result| to a new [=trusted scoring signals reply=]
             1. Set |result|'s [=trusted scoring signals reply/all trusted scoring signals=] to
@@ -8835,15 +8808,13 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
           1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
     1. Otherwise:
       1. Set |entriesToBatch| to |batcher|'s [=trusted scoring signals batcher/request map=][|key|].
-      1. [=map/remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
+      1. [=map/Remove=] |key| from |batcher|'s [=trusted scoring signals batcher/request map=].
       1. Let « |requestBody|, |renderUrlIdMap|, |context| » be the result of [=building batched
         trusted key value scoring signals request body=] for |entriesToBatch|.
       1. Let |baseUrl| be |entriesToBatch|[0]'s [=trusted scoring signals request/base url=].
       1. Let |seller| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller=].
       1. Let |scriptFetcher| be |entriesToBatch|[0]'s [=trusted scoring signals request/seller
         script fetcher=].
-      1. Let |policyContainer| be |entriesToBatch|[0]'s [=trusted scoring signals request/policy
-        container=].
       1. If |baseUrl|'s [=url/origin=] is not [=same origin=] with |seller| then:
         1. Let |allowCrossOriginTrustedScoringSignalsFrom| be the result of [=wait for cross origin
           trusted scoring signals authorization from a fetcher=] given |scriptFetcher|.
@@ -8853,7 +8824,8 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
       1. If |baseUrl| is not null:
         1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersion|» be
           the result of [=fetching trusted key value signals=] with |baseUrl|, |requestBody|,
-          |context|, |seller|, |policyContainer|, |renderUrlIdMap| and false.
+          |context|, |seller|, |entriesToBatch|[0]'s [=trusted scoring signals request/policy container=],
+          |renderUrlIdMap| and false.
         1. If |allTrustedScoringSignals| is an [=ordered map=]:
           1. Set |result| to a new [=trusted scoring signals reply=]
           1. Set |result|'s [=trusted scoring signals reply/all trusted scoring signals=] to

--- a/spec.bs
+++ b/spec.bs
@@ -2697,8 +2697,9 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
 
 <div algorithm>
 To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte sequence=] |body|, a [=string=]
-|context|, an [=origin=] |scriptOrigin|, a [=policy container=] |policyContainer|, an |indexMap|, and a
-[=boolean=] |isBiddingSignal|:
+|context|, an [=origin=] |scriptOrigin|, a [=policy container=] |policyContainer|, an |indexMap| whose keys
+are [=strings=] and values are [=tuples=] consisting of an interger and an integer , and a [=boolean=]
+|isBiddingSignal|:
 
 1. Let |request| be a new [=request=] with the following properties:
   :   [=request/URL=]
@@ -2710,8 +2711,8 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
   :   [=request/origin=]
   ::  |scriptOrigin|
   :   [=request/header list=]
-  ::  «`Content-Type`: `message/ad-auction-trusted-signals-request`»
-  ::  «`Accept`: `message/ad-auction-trusted-signals-response`»
+  ::  «`Content-Type`: `message/ad-auction-trusted-signals-request`,
+       `Accept`: `message/ad-auction-trusted-signals-response`»
   :   [=request/client=]
   ::  `null`
   :   [=request/mode=]
@@ -2729,6 +2730,7 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
     [=policy container/IP address space=]
 
 1. Let |signals| be null.
+1. Let |signalsMap| be an empty [=map=], whose keys are [=strings=] and values are [=maps=].
 1. Let |dataVersion| be an empty [=ordered map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers.
 1. Let |perInterestGroupData| be an [=ordered map=] whose [=map/keys=] are [=interest group/name=] [=strings=]
   and whose [=map/values=] are [=bidding signals per interest group data=].
@@ -2741,25 +2743,23 @@ To <dfn>fetch trusted key value signals</dfn> given a [=URL=] |url|, a [=byte se
     deserialization method may follow that described in
     [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
   1. [=list/For each=] |result| in |resultList|:
+    1. If |result| [=map/contains=] "`dataVersion`":
+      1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
+        2<sup>32</sup>&minus;1, set |signals| to failure and return.
     1. If |isBiddingSignal| is true:
       1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
         1. If |indexMap|[|name|] does not equal to |result|["index"], set |signals| to failure and return.
         1. [=map/Set=] |perInterestGroupData|[|name|] to |value|.
-        1. If |result| [=map/contain=] "dataVersion":
-          1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
-            2<sup>32</sup>&minus;1, set |signals| to failure and return.
-          1. Otherwise, set |dataVersion|[|name|] to |result|["dataVersion"].
+        1. If |result| [=map/contains=] "`dataVersion`", set |dataVersion|[|name|] to |result|["dataVersion"].
       1. [=map/For each=] |key| → |value| in |result|["keys"]:
-        1. Set |signals|[|key|] to |value|.
+        1. Set |signalsMap|[|key|] to |value|.
     1. Otherwise:
       1. [=map/For each=] |url| → |value| in |result|["renderUrls"]:
-        1. Set |signals|[|url|] to |value|.
-        1. If |result| [=map/contains=] `"dataVersion"`:
-          1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
-            2<sup>32</sup>&minus;1, set |signals| to failure and return.
-          1. Otherwise, set |dataVersion|[|url|] to |result|["dataVersion"].
+        1. Set |signalsMap|[|url|] to |value|.
+        1. If |result| [=map/contains=] `"dataVersion"`, set |dataVersion|[|url|] to |result|["dataVersion"].
       1. [=map/For each=] |url| → |value| in |result|["adComponentRenderUrls"]:
-        1. Set |signals|[|url|] to |value|.
+        1. Set |signalsMap|[|url|] to |value|.
+1. If |signalsMap| is not empty, set |signals| to |signalsMap|.
 1. Return « |signals|, |perInterestGroupData|, |dataVersion| ».
 
 </div>
@@ -8365,9 +8365,7 @@ To <dfn>batch or fetch trusted bidding signals</dfn> given a [=trusted bidding s
     1. Let |key| be [=tuple=] of (|ig|'s [=interest group/joining origin=], |ig|'s [=interest group/owner=]).
     1. If |keyValueInterestGroups| [=map/contains=] |key|, [=set/append=] |ig| to
       |keyValueInterestGroups|[|key|].
-    1. Otherwise:
-      1. Let |keyValueInterestGroups|[|key|] be an empty [=set=], whose [=set/items=] are [=strings=].
-      1. [=set/Append=] |ig| to |keyValueInterestGroups|[|key|].
+    1. Otherwise, set |keyValueInterestGroups|[|key|] to a [=set=] « |ig| ».
 
 </div>
 
@@ -8450,11 +8448,11 @@ an [=origin=] |scriptOrigin|, an {{unsigned short}}-or-null |experimentGroupId|,
 |topLevelOrigin|, a [=string=] |slotSizeQueryParam|, and a [=policy container=] |policyContainer|:
 
   1. If |signalsUrl| is null, return.
-  1. [=map/For each=] (|joining_origin|, |owner|) → |interestGroups| of [=trusted bidding signals
+  1. [=map/For each=] (|joiningOrigin|, |owner|) → |interestGroups| of [=trusted bidding signals
     batcher/key value interest groups=]:
     1. Let « |requestBody|, |interestGroupIdMap|, |context| » be the result of [=building trusted
       key value bidding signals request body=] with |interestGroups|, |experimentGroupId|,
-      |topLevelOrigin|, |slotSizeQueryParam|, |joining_origin| and |owner|.
+      |topLevelOrigin|, |slotSizeQueryParam|, |joiningOrigin| and |owner|.
     1. Let « |partialTrustedBiddingSignals|, |partialPerInterestGroupData|, |dataVersion| » be the
       result of [=fetching trusted key value signals=] with |signalsUrl|, |requestBody|, |context|,
       |scriptOrigin|, |policyContainer|, |interestGroupIdMap| and true.
@@ -8642,20 +8640,17 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   of (interger, integer).
 1. Let |nextCompressionGroupId| be 0.
 1. [=map/For each=] |request| of |entriesToBatch|:
-  1. Let |partitionId| be an integer.
-  1. Set |joiningOrigin| to |group|'s [=interest group/joining origin=].
-  1. Let |ownerOrigin| be |request|'s [=trusted scoring signals request/owner origin=].
-  1. Let |mapKey| be a tuple of |ownerOrigin| and |joiningOrigin|.
+  1. Let |mapKey| be a tuple of (|request|'s [=trusted scoring signals request/owner origin=],
+    |request|'s [=trusted scoring signals request/joining origin=]).
   1. If |compressionIdMap| does not [=map/contain=] |mapKey|:
     1. Set |compressionIdMap|[|mapKey|] to |nextCompressionGroupId|.
-    1. Increase |nextCompressionGroupId| by 1.
+    1. Increment |nextCompressionGroupId| by 1.
   1. Let |compressionGroupId| be |compressionIdMap|[|mapKey|].
   1. If |compressionGroupMap| does not [=map/contain=] |compressionGroupId|:
-    1. Let |compressionGroupMap|[|compressionGroupId|] be an empty [=map=], whose [=map/keys=] are integers
-      and [=map/values=] are [=maps=].
-  1. Set |partitionId| to [=list/size=] of |compressionGroupMap|[|compressionGroupId|].
+    1. Set |compressionGroupMap|[|compressionGroupId|] to an empty [=map=], whose [=map/keys=] are integers
+  1. Let |partitionId| be [=list/size=] of |compressionGroupMap|[|compressionGroupId|].
   1. Set |renderUrlIdMap|[|request|'s [=trusted scoring signals request/render URL=]] to [=tuple=]
-    of |compressionGroupId| and |partitionId|.
+    of (|compressionGroupId|, |partitionId|).
   1. Let |partition| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are [=strings=] or
       [=list=] of [=strings=].
   1. Set |partition|["id"] to |partitionId|.
@@ -8665,10 +8660,10 @@ To <dfn>build trusted key value scoring signals request body</dfn> given a non-e
   1. Set |namespace|["ad_component_render_urls"] to |request|'s [=trusted scoring signals request/ad
     component URLs=].
   1. Set |partition|["namespace"] to |namespace|.
-  1. Let |metadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
-  1. Set |metadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
+  1. Let |partitionMetadata| be an empty [=map=], whose [=map/keys=] and [=map/values=] are [=strings=].
+  1. Set |partitionMetadata|["experiment_group_id"] to |firstRequest|'s [=trusted scoring signals
       request/seller experiment group id=].
-  1. Set |partition|["metadata"] to |metadata|.
+  1. Set |partition|["metadata"] to |partitionMetadata|.
   1. Set |compressionGroupMap|[|compressionGroupId|][|partitionId|] to |partition|.
 1. [=map/For each=] |id| → |group| in |compressionGroupMap|:
   1. Let |compressionGroup| be an empty [=map=], whose [=map/keys=] are [=strings=] and [=map/values=] are integers or
@@ -8700,8 +8695,7 @@ To <dfn>build batched trusted key value scoring signals request body</dfn> given
 
 1. Let |firstEntry| be |entriesToBatch|[0].
 1. Let |renderURLs| be an empty [=ordered set=] of [=strings=].
-1. Let |adComponentRenderURLs| be an empty [=ordered set=] of [=strings=]
-  |adComponentRenderURLs|
+1. Let |adComponentRenderURLs| be an empty [=ordered set=] of [=strings=].
 1. [=list/For each=] |entry| of |entriesToBatch|:
   1. [=Assert=] that |entry|'s [=trusted scoring signals request/base URL=] is equal to
     |firstEntry|'s [=trusted scoring signals request/base URL=].

--- a/spec.bs
+++ b/spec.bs
@@ -2738,17 +2738,17 @@ interger and an integer , and a [=boolean=] |isBiddingSignal|:
   [=fetch/processResponseConsumeBody=] set to the following steps given a [=response=] |response|
   and null, failure, or a [=byte sequence=] |responseBody|:
   1. If [=validate fetching response=] with |response|, |responseBody| and
-    "`message/ad-auction-trusted-signals-response`" returns false, return « null, null, null ».
+    "`message/ad-auction-trusted-signals-response`" returns false, return « failure, null, null ».
   1. Let |resultList| be the result of deserializing |responseBody| using |context|. The
     deserialization method may follow that described in
     [Section 2.3.6 of the Protected Audience Key Value Services](https://privacysandbox.github.io/draft-ietf-protected-audience-key-value-service/draft-ietf-protected-audience-key-value-services.html#name-parsing-a-response).
   1. [=list/For each=] |result| in |resultList|:
     1. If |result| [=map/contains=] "`dataVersion`":
       1. If |result|["dataVersion"] is not an integer, or is less than 0 or more than
-        2<sup>32</sup>&minus;1, return « null, null, null ».
+        2<sup>32</sup>&minus;1, return « failure, null, null ».
     1. If |isBiddingSignal| is true:
       1. [=map/For each=] |name| → |value| in |result|["interestGroupNames"]:
-        1. If |indexMap|[|name|] does not equal to |result|["index"], return « null, null, null ».
+        1. If |indexMap|[|name|] does not equal to |result|["index"], return « failure, null, null ».
         1. [=map/Set=] |perInterestGroupData|[|name|] to |value|.
         1. If |result| [=map/contains=] "`dataVersion`", [=map/set=] |dataVersion|[|name|] to |result|["dataVersion"].
       1. [=map/For each=] |key| → |value| in |result|["keys"]:
@@ -8820,21 +8820,21 @@ To <dfn>batch and fetch trusted scoring signals</dfn> given a [=trusted scoring 
           trusted scoring signals authorization from a fetcher=] given |scriptFetcher|.
         1. If |allowCrossOriginTrustedScoringSignalsFrom| does not [=list/contain=]
           |baseUrl|'s [=url/origin=], set |baseUrl| to null.
-      1. Let |result| be failure.
-      1. If |baseUrl| and |requestBody| are not null:
-        1. Let «|allTrustedScoringSignals|, <var ignore>ignored</var>, |scoringDataVersionMap|» be
-          the result of [=fetching trusted key value signals=] with |baseUrl|, |requestBody|,
-          |context|, |seller|, |entriesToBatch|[0]'s [=trusted scoring signals request/policy container=],
-          |renderUrlIdMap| and false.
-        1. If |allTrustedScoringSignals| is an [=ordered map=]:
-          1. Set |result| to a new [=trusted scoring signals reply=]
+      1. Let |allTrustedScoringSignals| be failure.
+      1. If |baseUrl| and |requestBody| are not null, let «|allTrustedScoringSignals|, <var ignore>ignored</var>,
+        |scoringDataVersionMap|» be the result of [=fetching trusted key value signals=] with |baseUrl|, |requestBody|,
+        |context|, |seller|, |entriesToBatch|[0]'s [=trusted scoring signals request/policy container=], |renderUrlIdMap|
+        and false.
+      1. If |allTrustedScoringSignals| is an [=ordered map=]:
+        1. [=list/For each=] |entry| in |entriesToBatch|:
+          1. Let |result| be a new [=trusted scoring signals reply=].
           1. Set |result|'s [=trusted scoring signals reply/all trusted scoring signals=] to
             |allTrustedScoringSignals|.
-          1. [=list/For each=] |entry| in |entriesToBatch|:
+          1. If |scoringDataVersionMap| is not null:
             1. Set |result|'s [=trusted scoring signals reply/data version=] to |scoringDataVersionMap|
               [|entry|'s [=URL serializer|serialized=] [=trusted scoring signals request/render URL=]].
-      1. [=list/For each=] |entry| in |entriesToBatch|:
-        1. Set |entry|'s [=trusted scoring signals request/reply=] to |result|.
+      1. Otherwise, [=list/for each=] |entry| in |entriesToBatch|:
+        1. Set |entry|'s [=trusted scoring signals request/reply=] to failure.
 
 </div>
 


### PR DESCRIPTION
Bidding signals:
- GenerateBidInterestGroup
- joinAdInterestGroup(group) method steps
- build an interest group passed to generateBid
- update interest groups
- estimated size of an interest group
- 14.1. Interest group
- 14.6. Trusted bidding signals batcher

Scoring signals:
- AuctionAdConfig
- validate and convert auction ad config
- 14.3. Auction config
- 14.7. Trusted scoring signals batcher

General methods:
- fetch trusted key value signals
- Feature Detection
- Update CORS preflight header


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xtlsheep/turtledove/pull/1340.html" title="Last updated on Dec 19, 2024, 3:03 PM UTC (d613bc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1340/b022c88...xtlsheep:d613bc0.html" title="Last updated on Dec 19, 2024, 3:03 PM UTC (d613bc0)">Diff</a>