### PR TITLE
[Spec] Add private aggregation support for B&A response

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3149,7 +3149,8 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
   :: |response|'s [=server auction response/interest group owner=]
   : [=reporting bid key/bid identifier=]
   :: |response|'s [=server auction response/interest group name=]
-1. [=Handle server response private aggregation fields=] given |response| and |requestContext|.
+1. [=Handle server response private aggregation fields=] given |response|, |requestContext| and
+  |reportingId|.
 1. Let |winningBid| be a new [=generated bid=] with the following [=struct/items=]:
   : [=generated bid/reporting id=]
   :: |reportingId|
@@ -3251,11 +3252,27 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
 
 <div algorithm>
 To <dfn>handle server response private aggregation fields</dfn> given a [=server auction response=]
-|response|, and a [=reporting context=] |reportingContext|:
+|response|, a [=reporting context=] |reportingContext|, and a [=reporting bid key=] |reportingId|:
 
 1. [=Assert=] that these steps are running [=in parallel=].
-1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |response|'s
-  [=server auction response/component win private aggregation contributions=]:
+1. [=Commit server response private aggregation contributions=] given |response|'s
+  [=server auction response/component win private aggregation contributions=], |reportingContext|,
+  |reportingId| and false.
+1. [=Commit server response private aggregation contributions=] given |response|'s
+  [=server auction response/server filtered private aggregation reserved contributions=],
+  |reportingContext|, |reportingId| and true.
+1. [=Commit server response private aggregation contributions=] given |response|'s
+  [=server auction response/server filtered private aggregation non reserved contributions=],
+  |reportingContext|, |reportingId| and true.
+
+</div>
+
+<div algorithm>
+To <dfn>commit server response private aggregation contributions</dfn> given a
+[=server auction response=] |contributionsMap|, a [=reporting context=] |reportingContext|, a
+[=reporting bid key=] |reportingId| and a [=boolean=] |serverFiltered|:
+
+1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |contributionsMap|:
   1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
   1. Let |scopingDetails| be a new [=scoping details=] with the [=struct/items=]:
     : <a spec="private-aggregation-api" for="scoping details">get batching scope steps</a>
@@ -3283,53 +3300,9 @@ To <dfn>handle server response private aggregation fields</dfn> given a [=server
         :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
           for="scoping details">get debug scope steps</a>.
         : [=on event contribution entry/worklet function=]
-        :: "`generate-bid`" (it does not matter for server returned contribution)
-        : [=on event contribution entry/origin=]
-        :: |reportingOrigin|
-    1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
-      |eventToContributionsMap|[|event|] to « |entry| ».
-    1. Otherwise, [=list/append=] |eventToContributionsMap|[|event|] with |entry|.
-1. [=Commit private aggregation contributions=] given |eventToContributionsMap|, |reportingId| and
-  |reportingContext|.
-1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |response|'s
-  [=server auction response/server filtered private aggregation reserved contributions=]:
-  1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
-  1. [=list/For each=] |contribution| of |contributions|:
-    1. Let |entry| be a new [=on event contribution entry=] with the items:
-        : [=on event contribution entry/contribution=]
-        :: |contribution|
-        : [=on event contribution entry/batching scope=]
-        :: |batchingScope|
-        : [=on event contribution entry/debug scope=]
-        :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
-          for="scoping details">get debug scope steps</a>.
-        : [=on event contribution entry/worklet function=]
-        :: "`generate-bid`" (it does not matter for server returned contribution)
+        :: "`generate-bid`" (it does not matter for server returned contributions)
         : [=on event contribution entry/server filtered=]
-        :: true
-        : [=on event contribution entry/origin=]
-        :: |reportingOrigin|
-    1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
-      |eventToContributionsMap|[|event|] to « |entry| ».
-    1. Otherwise, [=list/append=] |eventToContributionsMap|[|event|] with |entry|.
-1. [=Commit private aggregation contributions=] given |eventToContributionsMap|, |reportingId| and
-  |reportingContext|.
-1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |response|'s
-  [=server auction response/server filtered private aggregation non reserved contributions=]:
-  1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
-  1. [=list/For each=] |contribution| of |contributions|:
-    1. Let |entry| be a new [=on event contribution entry=] with the items:
-        : [=on event contribution entry/contribution=]
-        :: |contribution|
-        : [=on event contribution entry/batching scope=]
-        :: |batchingScope|
-        : [=on event contribution entry/debug scope=]
-        :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
-          for="scoping details">get debug scope steps</a>.
-        : [=on event contribution entry/worklet function=]
-        :: "`generate-bid`" (it does not matter for server returned contribution)
-        : [=on event contribution entry/server filtered=]
-        :: true
+        :: |serverFiltered|
         : [=on event contribution entry/origin=]
         :: |reportingOrigin|
     1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set

--- a/spec.bs
+++ b/spec.bs
@@ -3268,9 +3268,10 @@ To <dfn>handle server response private aggregation fields</dfn> given a [=server
 </div>
 
 <div algorithm>
-To <dfn>commit server response private aggregation contributions</dfn> given a
-[=server auction response=] |contributionsMap|, a [=reporting context=] |reportingContext|, a
-[=reporting bid key=] |reportingId| and a [=boolean=] |serverFiltered|:
+To <dfn>commit server response private aggregation contributions</dfn> given a [=map=] from a
+[=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event contribution entries=]
+|contributionsMap|, a [=reporting context=] |reportingContext|, a [=reporting bid key=]
+|reportingId| and a [=boolean=] |serverFiltered|:
 
 1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |contributionsMap|:
   1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
@@ -3291,6 +3292,12 @@ To <dfn>commit server response private aggregation contributions</dfn> given a
     Note: Each non-reserved |event| will have a different [=batching scope=]
         that is created later.
   1. [=list/For each=] |contribution| of |contributions|:
+    1. [=Assert=] |contribution|["{{PAExtendedHistogramContribution/bucket}}"] is a {{bigint}} and
+      is [=set/contained=] in [=the exclusive range|the range=] 0 to 2<sup>128</sup>, exclusive.
+    1. [=Assert=] |contribution|["{{PAExtendedHistogramContribution/value}}"] is a {{long}}.
+
+      Note: All {{PAExtendedHistogramContribution/bucket}} and {{PAExtendedHistogramContribution/value}}
+        have been calculated on server side already.
     1. Let |entry| be a new [=on event contribution entry=] with the items:
         : [=on event contribution entry/contribution=]
         :: |contribution|
@@ -3307,7 +3314,7 @@ To <dfn>commit server response private aggregation contributions</dfn> given a
         :: |reportingOrigin|
     1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
       |eventToContributionsMap|[|event|] to « |entry| ».
-    1. Otherwise, [=list/append=] |eventToContributionsMap|[|event|] with |entry|.
+    1. Otherwise, [=list/append=] |entry| to |eventToContributionsMap|[|event|].
 1. [=Commit private aggregation contributions=] given |eventToContributionsMap|, |reportingId| and
   |reportingContext|.
 
@@ -3545,17 +3552,17 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
   : <dfn>component win private aggregation contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are ([=reporting bid key=], [=string=]), and whose [=map/values=]
-    are [=lists=] of [=on event contribution entries=]. Private aggregation contributions from
-    winners of component auctions run on trusted auction servers. These need to be filtered by the
-    client based on the top level auction's outcome.
+  :: A [=map=] whose [=map/keys=] are [=tuples=] of ([=reporting bid key=], [=string=]), and whose
+    [=map/values=] are [=lists=] of [=on event contribution entries=]. Private aggregation
+    contributions from winners of component auctions run on trusted auction servers. These need to
+    be filtered by the client based on the top level auction's outcome.
   : <dfn>server filtered private aggregation reserved contributions</dfn>
-  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
+  :: A [=map=] from a [=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
     contribution entries=]. Server filtered private aggregation contributions with reserved event
     types (already set to "reserved.always"), which are not dependent on the final auction result and
     should always be reported.
   : <dfn>server filtered private aggregation non reserved contributions</dfn>
-  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
+  :: A [=map=] from a [=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
     contribution entries=]. Server filtered private aggregation contributions with non reserved event
     types, which are not dependent on the final auction result and should always be reported.
   : <dfn>component win debugging only reports</dfn>
@@ -4565,14 +4572,12 @@ an [=auction config=] |auctionConfig| and a [=reporting context=] |reportingCont
   set |sellerOnceRep| to a random [=set/item=] of [=reporting context/seller participants=].
 1. [=map/For each=] (|bidId|, |event|) → |contributions| of |reportingContext|'s
   [=reporting context/private aggregation on event contributions=]:
-  1. If |event| does not [=string/start with=] "`reserved.`":
-    1. [=list/For each=] |onEventEntry| of |contributions|:
-      1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false and |bidId| is
-        not |winnerId|, then [=list/remove=] |onEventEntry| from |contributions|.
-  1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false:
-    1. If |event| is "`reserved.win`" and |bidId| is not |winnerId|, then [=iteration/continue=].
-    1. If |event| is "`reserved.loss`" and |bidId| is |winnerId|, [=iteration/continue=].
   1. [=list/For each=] |onEventEntry| of |contributions|:
+    1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false,
+      [=iteration/continue=] if any of the following conditions hold:
+      * |event| is "`reserved.win`" and |bidId| is not |winnerId|;
+      * |event| does not [=string/start with=] "`reserved.`" and |bidId| is not |winnerId|;
+      * |event| is "`reserved.loss`" and |bidId| is |winnerId|.
     1. If |event| is "`reserved.once`":
       1. If |onEventEntry|'s [=on event contribution entry/worklet function=] is [=worklet function/
         generate-bid=]:

--- a/spec.bs
+++ b/spec.bs
@@ -3070,17 +3070,28 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
      equals |componentAd|. If there is no matching element, return failure.
   1. [=list/Append=] a new [=ad descriptor=] whose [=ad descriptor/url=] is
      |componentAd| to |winningAdComponents|.
+1. Let |reportingContext| be |reportingContextMap|[|auctionConfig|].
+1. Let |reportingId| be a [=reporting bid key=] with the following [=struct/items=]:
+  : [=reporting bid key/context=]
+  :: |reportingContext|
+  : [=reporting bid key/source=]
+  :: [=reporting bid source/bidding-and-auction-services=]
+  : [=reporting bid key/bidder origin=]
+  :: |response|'s [=server auction response/interest group owner=]
+  : [=reporting bid key/bid identifier=]
+  :: |response|'s [=server auction response/interest group name=]
+1. [=Commit private aggregation contributions=] given |response|'s
+  [=server auction response/component win private aggregation contributions=], |reportingId| and
+  |reportingContext|.
+1. [=Commit private aggregation contributions=] given |response|'s
+  [=server auction response/server filtered private aggregation reserved contributions=],
+  |reportingId| and |reportingContext|.
+1. [=Commit private aggregation contributions=] given |response|'s
+  [=server auction response/server filtered private aggregation non reserved contributions=],
+  |reportingId| and |reportingContext|.
 1. Let |winningBid| be a new [=generated bid=] with the following [=struct/items=]:
   : [=generated bid/reporting id=]
-  :: A [=reporting bid key=] with the following [=struct/items=]:
-    : [=reporting bid key/context=]
-    :: |reportingContextMap|[|auctionConfig|]
-    : [=reporting bid key/source=]
-    :: [=reporting bid source/bidding-and-auction-services=]
-    : [=reporting bid key/bidder origin=]
-    :: |response|'s [=server auction response/interest group owner=]
-    : [=reporting bid key/bid identifier=]
-    :: |response|'s [=server auction response/interest group name=]
+  :: |reportingId|
   : [=generated bid/bid=]
   :: |response|'s [=server auction response/bid=]
   : [=generated bid/bid in seller currency=]
@@ -3403,15 +3414,20 @@ from an auction executed on the trusted auction server. It has the following [=s
   :: Null or [=server auction reporting info=].
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
-  : <dfn>component win private aggregation reports</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction debug report keys=], and whose [=map/values=]
-    are [=lists=] of [=urls=].
-  : <dfn>server filtered private aggregation reserved reports</dfn>
+  : <dfn>component win private aggregation contributions</dfn>
+  :: A [=map=] whose [=map/keys=] are ([=reporting bid key=], [=string=]), and whose [=map/values=]
+    are [=lists=] of [=on event contribution entries=]. Private aggregation contributions from
+    winners of component auctions run on trusted auction servers. These need to be filtered by the
+    client based on the top level auction's outcome.
+  : <dfn>server filtered private aggregation reserved contributions</dfn>
   :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
-    contribution entries=].
-  : <dfn>server filtered private aggregation non reserved reports</dfn>
+    contribution entries=]. Server filtered private aggregation contributions with reserved event
+    types (already set to "reserved.always"), which are not dependent on the final auction result and
+    should always be reported.
+  : <dfn>server filtered private aggregation non reserved contributions</dfn>
   :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
-    contribution entries=].
+    contribution entries=]. Server filtered private aggregation contributions with non reserved event
+    types, which are not dependent on the final auction result and should always be reported.
 </dl>
 
 A <dfn>server auction reporting info</dfn> is a [=struct=] with the following [=struct/items=]:
@@ -3628,12 +3644,6 @@ A <dfn>reporting context</dfn> is a [=struct=] with the following [=struct/items
     Note: Does not include [=batching scopes=] for contributions conditional on
         non-reserved events.
   : <dfn>private aggregation on event contributions</dfn>
-  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
-    contribution entries=].
-  : <dfn>server filtered private aggregation reserved</dfn>
-  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
-    contribution entries=].
-  : <dfn>server filtered private aggregation non reserved</dfn>
   :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
     contribution entries=].
   : <dfn>private aggregation allowed</dfn>
@@ -4087,8 +4097,7 @@ A signal base value is one of the following:
 : "<dfn><code>bid-reject-reason</code></dfn>"
 :: The numeric value is an integer representing the reason a bid was rejected.
 
-    Note: this mapping to an integer is defined in [=determine a signal's
-        numeric value=].
+    Note: this mapping to an integer is defined in [=determine a signal's numeric value=].
 
 </dl>
 
@@ -4105,6 +4114,9 @@ An on event contribution entry is a [=struct=] with the following items:
 :: A [=debug details=] or null (default null)
 : <dfn>worklet function</dfn>
 :: A [=worklet function=].
+: <dfn>server filtered</dfn>
+:: A [=boolean=], initially false. Only set to true when the contribution is already filtered by the
+  trusted auction server before sent back to the client.
 
 </dl>
 
@@ -4220,6 +4232,7 @@ To <dfn>process the Private Aggregation contributions</dfn> given an [=auction c
 <div algorithm>
 To <dfn>process the Private Aggregation contributions for an auction</dfn> given
 an [=auction config=] |auctionConfig| and a [=reporting context=] |reportingContext|:
+
 1. If |auctionConfig|'s [=auction config/aborted=] is true, return.
 1. Let |winnerId| be |reportingContext|'s [=reporting context/winner reporting id=]
 1. Let |leadingBidInfo| be |reportingContext|'s [=reporting context/local leader info=].
@@ -4229,10 +4242,13 @@ an [=auction config=] |auctionConfig| and a [=reporting context=] |reportingCont
 1. Let |sellerOnceRep| be null.
 1. If |reportingContext|'s [=reporting context/seller participants=] [=set/is not empty=],
   set |sellerOnceRep| to a random [=set/item=] of [=reporting context/seller participants=].
-1. [=map/For each=] (|bidId|, |event|) → |contributions| of
-  |reportingContext|'s [=reporting context/private aggregation on event contributions=]:
-  1. If |event| is "`reserved.win`" or does not [=string/start with=] "`reserved.`":
-    1. If |bidId| is not |winnerId|, [=iteration/continue=].
+1. [=map/For each=] (|bidId|, |event|) → |contributions| of |reportingContext|'s
+  [=reporting context/private aggregation on event contributions=]:
+  1. If |event| does not [=string/start with=] "`reserved.`":
+    1. [=list/For each=] |onEventEntry| of |contributions|:
+      1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false and |bidId| is
+        not |winnerId|, then [=list/remove=] |onEventEntry| from |contributions|.
+  1. If |event| is "`reserved.win`" and |bidId| is not |winnerId|, then [=iteration/continue=].
   1. If |event| is "`reserved.loss`" and |bidId| is |winnerId|, [=iteration/continue=].
   1. [=list/For each=] |onEventEntry| of |contributions|:
     1. If |event| is "`reserved.once`":

--- a/spec.bs
+++ b/spec.bs
@@ -3149,15 +3149,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
   :: |response|'s [=server auction response/interest group owner=]
   : [=reporting bid key/bid identifier=]
   :: |response|'s [=server auction response/interest group name=]
-1. [=Commit private aggregation contributions=] given |response|'s
-  [=server auction response/component win private aggregation contributions=], |reportingId| and
-  |reportingContext|.
-1. [=Commit private aggregation contributions=] given |response|'s
-  [=server auction response/server filtered private aggregation reserved contributions=],
-  |reportingId| and |reportingContext|.
-1. [=Commit private aggregation contributions=] given |response|'s
-  [=server auction response/server filtered private aggregation non reserved contributions=],
-  |reportingId| and |reportingContext|.
+1. [=Handle server response private aggregation fields=] given |response| and |requestContext|.
 1. Let |winningBid| be a new [=generated bid=] with the following [=struct/items=]:
   : [=generated bid/reporting id=]
   :: |reportingId|
@@ -3254,6 +3246,97 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
      |updateIfOlderThan|, set |ig|'s [=interest group/next update after=] to the
      [=current coarsened wall time=] + |updateIfOlderThan|.
 1. Return |winningBidInfo|.
+
+</div>
+
+<div algorithm>
+To <dfn>handle server response private aggregation fields</dfn> given a [=server auction response=]
+|response|, and a [=reporting context=] |reportingContext|:
+
+1. [=Assert=] that these steps are running [=in parallel=].
+1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |response|'s
+  [=server auction response/component win private aggregation contributions=]:
+  1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
+  1. Let |scopingDetails| be a new [=scoping details=] with the [=struct/items=]:
+    : <a spec="private-aggregation-api" for="scoping details">get batching scope steps</a>
+    :: An algorithm that performs the following steps:
+        1. If |coordinator| is null, set |coordinator| to the [=default aggregation coordinator=].
+        1. Return the result of running [=get or create a batching scope=] given |reportingOrigin|,
+          |coordinator| and |reportingContext|.
+    : <a spec="private-aggregation-api" for="scoping details">get debug scope steps</a>
+    :: An algorithm that returns a new [=debug scope=].
+
+  1. Let |batchingScope| be null.
+  1. If |event| [=string/starts with=] "`reserved.`", set |batchingScope| to the
+    result of running |scopingDetails|' <a spec="private-aggregation-api" for="scoping details">
+    get batching scope steps</a>.
+
+    Note: Each non-reserved |event| will have a different [=batching scope=]
+        that is created later.
+  1. [=list/For each=] |contribution| of |contributions|:
+    1. Let |entry| be a new [=on event contribution entry=] with the items:
+        : [=on event contribution entry/contribution=]
+        :: |contribution|
+        : [=on event contribution entry/batching scope=]
+        :: |batchingScope|
+        : [=on event contribution entry/debug scope=]
+        :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
+          for="scoping details">get debug scope steps</a>.
+        : [=on event contribution entry/worklet function=]
+        :: "`generate-bid`" (it does not matter for server returned contribution)
+        : [=on event contribution entry/origin=]
+        :: |reportingOrigin|
+    1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
+      |eventToContributionsMap|[|event|] to « |entry| ».
+    1. Otherwise, [=list/append=] |eventToContributionsMap|[|event|] with |entry|.
+1. [=Commit private aggregation contributions=] given |eventToContributionsMap|, |reportingId| and
+  |reportingContext|.
+1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |response|'s
+  [=server auction response/server filtered private aggregation reserved contributions=]:
+  1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
+  1. [=list/For each=] |contribution| of |contributions|:
+    1. Let |entry| be a new [=on event contribution entry=] with the items:
+        : [=on event contribution entry/contribution=]
+        :: |contribution|
+        : [=on event contribution entry/batching scope=]
+        :: |batchingScope|
+        : [=on event contribution entry/debug scope=]
+        :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
+          for="scoping details">get debug scope steps</a>.
+        : [=on event contribution entry/worklet function=]
+        :: "`generate-bid`" (it does not matter for server returned contribution)
+        : [=on event contribution entry/server filtered=]
+        :: true
+        : [=on event contribution entry/origin=]
+        :: |reportingOrigin|
+    1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
+      |eventToContributionsMap|[|event|] to « |entry| ».
+    1. Otherwise, [=list/append=] |eventToContributionsMap|[|event|] with |entry|.
+1. [=Commit private aggregation contributions=] given |eventToContributionsMap|, |reportingId| and
+  |reportingContext|.
+1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |response|'s
+  [=server auction response/server filtered private aggregation non reserved contributions=]:
+  1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
+  1. [=list/For each=] |contribution| of |contributions|:
+    1. Let |entry| be a new [=on event contribution entry=] with the items:
+        : [=on event contribution entry/contribution=]
+        :: |contribution|
+        : [=on event contribution entry/batching scope=]
+        :: |batchingScope|
+        : [=on event contribution entry/debug scope=]
+        :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
+          for="scoping details">get debug scope steps</a>.
+        : [=on event contribution entry/worklet function=]
+        :: "`generate-bid`" (it does not matter for server returned contribution)
+        : [=on event contribution entry/server filtered=]
+        :: true
+        : [=on event contribution entry/origin=]
+        :: |reportingOrigin|
+    1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
+      |eventToContributionsMap|[|event|] to « |entry| ».
+    1. Otherwise, [=list/append=] |eventToContributionsMap|[|event|] with |entry|.
+1. [=Commit private aggregation contributions=] given |eventToContributionsMap|, |reportingId| and
+  |reportingContext|.
 
 </div>
 
@@ -3555,10 +3638,13 @@ The <dfn for=Navigator method>getInterestGroupAdAuctionData(|configIDL|)</dfn> m
   1. Set |config|'s [=auction data config/encryption key=] to |key|.
   1. Set |config|'s [=auction data config/encryption key id=] to |keyId|.
   1. Let |igMap| be a new [=map=] whose [=map/keys=] are [=origins=] and [=map/values=] are [=lists=].
+  1. Let |igPAggCoordinatorMap| be a new [=map=] whose [=map/keys=] are tuples of ([=origins=], [=strings=])
+    and [=map/values=] are [=origins=].
   1. Let |startTime| be a [=moment=] equal to the [=current coarsened wall time=].
   1. [=list/For each=] |ig| of the [=user agent=]'s [=interest group set=]:
     1. If |ig|'s [=interest group/ads=] is null or [=list/is empty=], [=iteration/continue=].
     1. Let |owner| be |ig|'s [=interest group/owner=].
+    1. Let |name| be |ig|'s [=interest group/name=].
     1. If |config|'s [=auction data config/per buyer config=] [=map/is not empty=] and
        |config|'s [=auction data config/per buyer config=][|owner|] does not
        [=map/exist=], then [=iteration/continue=].
@@ -3566,7 +3652,8 @@ The <dfn for=Navigator method>getInterestGroupAdAuctionData(|configIDL|)</dfn> m
     1. Let |ads| be a new [=list=].
     1. [=list/For each=] |ad| in |ig|'s [=interest group/ads=], [=list/append=] |ad|'s [=interest group ad/ad render ID=] to |ads|.
     1. Let |components| be a new [=list=].
-    1. [=list/For each=] |component| in |ig|'s [=interest group/ad components=], [=list/append=] |component|'s [=interest group ad/ad render ID=] to |components|.
+    1. [=list/For each=] |component| in |ig|'s [=interest group/ad components=], [=list/append=]
+      |component|'s [=interest group ad/ad render ID=] to |components|.
     1. Let |prevWins| be a new <code>[=sequence=]<[=server auction previous win=]></code>.
     1. [=list/For each=] |prevWin| of |ig|'s [=interest group/previous wins=] for all days within the
       the last 30 days:
@@ -3591,7 +3678,7 @@ The <dfn for=Navigator method>getInterestGroupAdAuctionData(|configIDL|)</dfn> m
       :: |prevWins|
     1. Let |serverIg| be a new [=server auction interest group=] with the following [=struct/items=]:
       : [=server auction interest group/name=]
-      :: |ig|'s [=interest group/name=]
+      :: |name|
       : [=server auction interest group/bidding signals keys=]
       :: |ig|'s [=interest group/trusted bidding signals keys=]
       : [=server auction interest group/user bidding signals=]
@@ -3605,11 +3692,13 @@ The <dfn for=Navigator method>getInterestGroupAdAuctionData(|configIDL|)</dfn> m
       : [=server auction interest group/priority=]
       :: |ig|'s [=interest group/priority=]
     1. [=list/Append=] |serverIg| to |igMap|[|owner|].
+    1. If |ig|'s [=interest group/Private Aggregation coordinator=] is not null, then [=map/set=]
+      |igPAggCoordinatorMap|[(|owner|, |name|)] to it.
   1. Let |result| be a new {{AdAuctionData}}.
   1. Let |requestId| be the [=string representation=] of a [=version 4 UUID=].
   1. [=map/Set=] |result|["{{AdAuctionData/requestId}}"] to |requestId|.
-  1. Let (|requestBlob|, |context|) be the result of serializing |igMap| using
-     |config|. The serialization method may follow that described in
+  1. Let (|requestBlob|, |context|) be the result of serializing |igMap| with |config| and
+     |igPAggCoordinatorMap|. The serialization method may follow that described in
      [Section 2.2.4 of Bidding and Auction Services](https://privacysandbox.github.io/draft-ietf-bidding-and-auction-services/draft-ietf-bidding-and-auction-services.html#name-generating-a-request).
   1. Set |result|["{{AdAuctionData/request}}"] to |requestBlob|.
   1. [=Queue a global task=] on the [=DOM manipulation task source=], given |global|, to
@@ -4449,7 +4538,7 @@ runs; this method exists as an abstraction to help add that.
 </div>
 
 <div algorithm>
-To <dfn>commit private aggregation contributions</dfn> given an [=Private Aggregation
+To <dfn>commit private aggregation contributions</dfn> given a [=Private Aggregation
 contributions=] |onEventMap|, a [=reporting bid key=] |bidKey|, and a [=reporting context=]
 |reportingContext|:
   1. [=map/For each=] |event| → |contributions| of |onEventMap|:
@@ -4507,8 +4596,9 @@ an [=auction config=] |auctionConfig| and a [=reporting context=] |reportingCont
     1. [=list/For each=] |onEventEntry| of |contributions|:
       1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false and |bidId| is
         not |winnerId|, then [=list/remove=] |onEventEntry| from |contributions|.
-  1. If |event| is "`reserved.win`" and |bidId| is not |winnerId|, then [=iteration/continue=].
-  1. If |event| is "`reserved.loss`" and |bidId| is |winnerId|, [=iteration/continue=].
+  1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false:
+    1. If |event| is "`reserved.win`" and |bidId| is not |winnerId|, then [=iteration/continue=].
+    1. If |event| is "`reserved.loss`" and |bidId| is |winnerId|, [=iteration/continue=].
   1. [=list/For each=] |onEventEntry| of |contributions|:
     1. If |event| is "`reserved.once`":
       1. If |onEventEntry|'s [=on event contribution entry/worklet function=] is [=worklet function/
@@ -6072,6 +6162,8 @@ event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
         reserved event types are added later.
 1. If |event| is "`reserved.once`" and |function| is [=worklet function/report-result=] or
   [=worklet function/report-win=], [=exception/throw=] a {{TypeError}}.
+1. If |event| does not [=string/start with=] "`reserved.`", and |function| is "`scoreAd()`" or
+  "`report-result`", return.
 1. Let |bucket| be |contribution|["{{PAExtendedHistogramContribution/bucket}}"].
 1. If |bucket| is a {{PASignalValue}}:
     1. If |bucket|["{{PASignalValue/baseValue}}"] is not a valid [=signal base

--- a/spec.bs
+++ b/spec.bs
@@ -1861,13 +1861,13 @@ and a [=real time reporting contributions map=] |realTimeContributionsMap|:
           [=get direct from seller signals for a seller=] given |topLevelDirectFromSellerSignals|.
         1. Set |topLevelDirectFromSellerSignalsRetrieved| to true.
       1. If |compWinnerInfo|'s [=leading bid info/leading bid=] is not null, then run
-        [=score and rank a bid=] with |auctionConfig|, |reportingContextMap|[auctionConfig],
+        [=score and rank a bid=] with |auctionConfig|, |reportingContextMap|[|auctionConfig|],
         |compWinnerInfo|'s [=leading bid info/leading bid=], |leadingBidInfo|,
         |decisionLogicFetcher|, |trustedScoringSignalsBatcher|, null, "top-level-auction", null,
         and |topLevelOrigin|.
       1. If |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=]
         is not null, then run [=score and rank a bid=] with |auctionConfig|, |reportingContextMap|[
-        auctionConfig], |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=],
+        |auctionConfig|], |compWinnerInfo|'s [=leading bid info/leading non-k-anon-enforced bid=],
         |leadingBidInfo|, |decisionLogicFetcher|, |trustedScoringSignalsBatcher|,
         |topLevelDirectFromSellerSignalsForSeller|, null, "top-level-auction", null, |topLevelOrigin|,
         and |realTimeContributionsMap|.
@@ -3403,6 +3403,15 @@ from an auction executed on the trusted auction server. It has the following [=s
   :: Null or [=server auction reporting info=].
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
+  : <dfn>component win private aggregation reports</dfn>
+  :: A [=map=] whose [=map/keys=] are [=server auction debug report keys=], and whose [=map/values=]
+    are [=lists=] of [=urls=].
+  : <dfn>server filtered private aggregation reserved reports</dfn>
+  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
+    contribution entries=].
+  : <dfn>server filtered private aggregation non reserved reports</dfn>
+  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
+    contribution entries=].
 </dl>
 
 A <dfn>server auction reporting info</dfn> is a [=struct=] with the following [=struct/items=]:
@@ -3619,6 +3628,12 @@ A <dfn>reporting context</dfn> is a [=struct=] with the following [=struct/items
     Note: Does not include [=batching scopes=] for contributions conditional on
         non-reserved events.
   : <dfn>private aggregation on event contributions</dfn>
+  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
+    contribution entries=].
+  : <dfn>server filtered private aggregation reserved</dfn>
+  :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
+    contribution entries=].
+  : <dfn>server filtered private aggregation non reserved</dfn>
   :: A [=map=] from a tuple of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
     contribution entries=].
   : <dfn>private aggregation allowed</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -3269,28 +3269,22 @@ To <dfn>handle server response private aggregation fields</dfn> given a [=server
 
 <div algorithm>
 To <dfn>commit server response private aggregation contributions</dfn> given a [=map=] from a
-[=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event contribution entries=]
+[=server auction pagg contribution key=] to a [=list=] of [=on event contribution entries=]
 |contributionsMap|, a [=reporting context=] |reportingContext|, and a [=reporting bid key=]
 |reportingId|:
 
-1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |contributionsMap|:
+1. [=map/For each=] |key| → |contributions| of |contributionsMap|:
+  1. Let |reportingOrigin| be |key|'s [=server auction pagg contribution key/reporting origin=].
+  1. Let |event| be |key|'s [=server auction pagg contribution key/event=].
+  1. Let |coordinator| be |key|'s [=server auction pagg contribution key/coordinator=].
+  1. If |coordinator| is null, set |coordinator| to the [=default aggregation coordinator=].
   1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
-  1. Let |scopingDetails| be a new [=scoping details=] with the [=struct/items=]:
-    : <a spec="private-aggregation-api" for="scoping details">get batching scope steps</a>
-    :: An algorithm that performs the following steps:
-        1. If |coordinator| is null, set |coordinator| to the [=default aggregation coordinator=].
-        1. Return the result of running [=get or create a batching scope=] given |reportingOrigin|,
-          |coordinator| and |reportingContext|.
-    : <a spec="private-aggregation-api" for="scoping details">get debug scope steps</a>
-    :: An algorithm that returns a new [=debug scope=].
-
   1. Let |batchingScope| be null.
   1. If |event| [=string/starts with=] "`reserved.`", set |batchingScope| to the
-    result of running |scopingDetails|' <a spec="private-aggregation-api" for="scoping details">
-    get batching scope steps</a>.
+    result of running [=get or create a batching scope=] given |reportingOrigin|, |coordinator| and
+    |reportingContext|.
 
-    Note: Each non-reserved |event| will have a different [=batching scope=]
-        that is created later.
+    Note: Each non-reserved |event| will have a different [=batching scope=] that is created later.
   1. [=list/For each=] |contribution| of |contributions|:
     1. [=Assert=] |contribution|["{{PAExtendedHistogramContribution/bucket}}"] is a {{bigint}} and
       is [=set/contained=] in [=the exclusive range|the range=] 0 to 2<sup>128</sup>, exclusive.
@@ -3304,8 +3298,7 @@ To <dfn>commit server response private aggregation contributions</dfn> given a [
         : [=on event contribution entry/batching scope=]
         :: |batchingScope|
         : [=on event contribution entry/debug scope=]
-        :: The result of running |scopingDetails|' <a spec="private-aggregation-api"
-          for="scoping details">get debug scope steps</a>.
+        :: A new [=debug scope=].
         : [=on event contribution entry/worklet function=]
         :: "`generate-bid`" (it does not matter for server returned contributions)
         : [=on event contribution entry/origin=]
@@ -3550,19 +3543,20 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
   : <dfn>component win private aggregation contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=tuples=] of ([=reporting bid key=], [=string=]), and whose
+  :: A [=map=] whose [=map/keys=] are [=server auction pagg contribution keys=], and whose
     [=map/values=] are [=lists=] of [=on event contribution entries=]. Private aggregation
     contributions from winners of component auctions run on trusted auction servers. These need to
     be filtered by the client based on the top level auction's outcome.
   : <dfn>server filtered private aggregation reserved contributions</dfn>
-  :: A [=map=] from a [=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
-    contribution entries=]. Server filtered private aggregation contributions with reserved event
-    types (already set to "reserved.always"), which are not dependent on the final auction result and
-    should always be reported.
+  :: A [=map=] whose [=map/keys=] are [=server auction pagg contribution keys=], and whose
+    [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
+    aggregation contributions with reserved event types (already set to "reserved.always"), which
+    are not dependent on the final auction result and should always be reported.
   : <dfn>server filtered private aggregation non reserved contributions</dfn>
-  :: A [=map=] from a [=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event
-    contribution entries=]. Server filtered private aggregation contributions with non reserved event
-    types, which are not dependent on the final auction result and should always be reported.
+  :: A [=map=] whose [=map/keys=] are [=server auction pagg contribution keys=], and whose
+    [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
+    aggregation contributions with non reserved event types, which are not dependent on the final
+    auction result and should always be reported.
   : <dfn>component win debugging only reports</dfn>
   :: A [=map=] whose [=map/keys=] are [=server auction debug report keys=], and whose [=map/values=]
     are [=lists=] of [=urls=].
@@ -3585,6 +3579,16 @@ a <dfn>server auction debug report key</dfn> is a [=struct=] with the following 
   :: A [=boolean=].
   : <dfn>is debug win</dfn>
   :: A [=boolean=].
+</dl>
+
+a <dfn>server auction pagg contribution key</dfn> is a [=struct=] with the following [=struct/items=]:
+<dl dfn-for="server auction pagg contribution key">
+  : <dfn>reporting origin</dfn>
+  :: The [=origin=] of the script that contributed the contribution.
+  : <dfn>coordinator</dfn>
+  :: Null or an [=aggregation coordinator=].
+  : <dfn>event</dfn>
+  :: A [=string=].
 </dl>
 
 <div algorithm="getInterestGroupAdAuctionData()">
@@ -6134,8 +6138,6 @@ event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
         reserved event types are added later.
 1. If |event| is "`reserved.once`" and |function| is [=worklet function/report-result=] or
   [=worklet function/report-win=], [=exception/throw=] a {{TypeError}}.
-1. If |event| does not [=string/start with=] "`reserved.`", and |function| is "`scoreAd()`" or
-  "`report-result`", return.
 1. Let |bucket| be |contribution|["{{PAExtendedHistogramContribution/bucket}}"].
 1. If |bucket| is a {{PASignalValue}}:
     1. If |bucket|["{{PASignalValue/baseValue}}"] is not a valid [=signal base
@@ -6166,6 +6168,8 @@ event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
 
     Note: It is not currently possible to set a non-default filtering ID max
         bytes for Protected Audience.
+1. If |event| does not [=string/start with=] "`reserved.`", and |function| is
+  [=worklet function/score-ad=] or [=worklet function/report-result=], return.
 1. Let |batchingScope| be null.
 1. If |event| [=string/starts with=] "`reserved.`", set |batchingScope| to the
     result of running |scopingDetails|' <a spec="private-aggregation-api" for="scoping details">

--- a/spec.bs
+++ b/spec.bs
@@ -3269,14 +3269,14 @@ To <dfn>handle server response private aggregation fields</dfn> given a [=server
 
 <div algorithm>
 To <dfn>commit server response private aggregation contributions</dfn> given a [=map=] from a
-[=server auction pagg contribution key=] to a [=list=] of [=on event contribution entries=]
+[=server auction PAgg contribution key=] to a [=list=] of [=on event contribution entries=]
 |contributionsMap|, a [=reporting context=] |reportingContext|, and a [=reporting bid key=]
 |reportingId|:
 
 1. [=map/For each=] |key| → |contributions| of |contributionsMap|:
-  1. Let |reportingOrigin| be |key|'s [=server auction pagg contribution key/reporting origin=].
-  1. Let |event| be |key|'s [=server auction pagg contribution key/event=].
-  1. Let |coordinator| be |key|'s [=server auction pagg contribution key/coordinator=].
+  1. Let |reportingOrigin| be |key|'s [=server auction PAgg contribution key/reporting origin=].
+  1. Let |event| be |key|'s [=server auction PAgg contribution key/event=].
+  1. Let |coordinator| be |key|'s [=server auction PAgg contribution key/coordinator=].
   1. If |coordinator| is null, set |coordinator| to the [=default aggregation coordinator=].
   1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
   1. Let |batchingScope| be null.
@@ -3543,17 +3543,17 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
   : <dfn>component win private aggregation contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction pagg contribution keys=], and whose
+  :: A [=map=] whose [=map/keys=] are [=server auction PAgg contribution keys=], and whose
     [=map/values=] are [=lists=] of [=on event contribution entries=]. Private aggregation
     contributions from winners of component auctions run on trusted auction servers. These need to
     be filtered by the client based on the top level auction's outcome.
   : <dfn>server filtered private aggregation reserved contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction pagg contribution keys=], and whose
+  :: A [=map=] whose [=map/keys=] are [=server auction PAgg contribution keys=], and whose
     [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
     aggregation contributions with reserved event types (already set to "reserved.always"), which
     are not dependent on the final auction result and should always be reported.
   : <dfn>server filtered private aggregation non reserved contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction pagg contribution keys=], and whose
+  :: A [=map=] whose [=map/keys=] are [=server auction PAgg contribution keys=], and whose
     [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
     aggregation contributions with non reserved event types, which are not dependent on the final
     auction result and should always be reported.
@@ -3581,8 +3581,8 @@ a <dfn>server auction debug report key</dfn> is a [=struct=] with the following 
   :: A [=boolean=].
 </dl>
 
-a <dfn>server auction pagg contribution key</dfn> is a [=struct=] with the following [=struct/items=]:
-<dl dfn-for="server auction pagg contribution key">
+a <dfn>server auction PAgg contribution key</dfn> is a [=struct=] with the following [=struct/items=]:
+<dl dfn-for="server auction PAgg contribution key">
   : <dfn>reporting origin</dfn>
   :: The [=origin=] of the script that contributed the contribution.
   : <dfn>coordinator</dfn>

--- a/spec.bs
+++ b/spec.bs
@@ -3257,21 +3257,21 @@ To <dfn>handle server response private aggregation fields</dfn> given a [=server
 1. [=Assert=] that these steps are running [=in parallel=].
 1. [=Commit server response private aggregation contributions=] given |response|'s
   [=server auction response/component win private aggregation contributions=], |reportingContext|,
-  |reportingId| and false.
+  and |reportingId|.
 1. [=Commit server response private aggregation contributions=] given |response|'s
   [=server auction response/server filtered private aggregation reserved contributions=],
-  |reportingContext|, |reportingId| and true.
+  |reportingContext|, and |reportingId|.
 1. [=Commit server response private aggregation contributions=] given |response|'s
   [=server auction response/server filtered private aggregation non reserved contributions=],
-  |reportingContext|, |reportingId| and true.
+  |reportingContext|, and |reportingId|.
 
 </div>
 
 <div algorithm>
 To <dfn>commit server response private aggregation contributions</dfn> given a [=map=] from a
 [=tuple=] of ([=reporting bid key=], [=string=]) to a [=list=] of [=on event contribution entries=]
-|contributionsMap|, a [=reporting context=] |reportingContext|, a [=reporting bid key=]
-|reportingId| and a [=boolean=] |serverFiltered|:
+|contributionsMap|, a [=reporting context=] |reportingContext|, and a [=reporting bid key=]
+|reportingId|:
 
 1. [=map/For each=] (|reportingOrigin|, |coordinator|, |event|) → |contributions| of |contributionsMap|:
   1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
@@ -3308,8 +3308,6 @@ To <dfn>commit server response private aggregation contributions</dfn> given a [
           for="scoping details">get debug scope steps</a>.
         : [=on event contribution entry/worklet function=]
         :: "`generate-bid`" (it does not matter for server returned contributions)
-        : [=on event contribution entry/server filtered=]
-        :: |serverFiltered|
         : [=on event contribution entry/origin=]
         :: |reportingOrigin|
     1. If |eventToContributionsMap|[|event|] does not [=map/exist=], set
@@ -4350,9 +4348,6 @@ An on event contribution entry is a [=struct=] with the following items:
 :: A [=debug details=] or null (default null)
 : <dfn>worklet function</dfn>
 :: A [=worklet function=].
-: <dfn>server filtered</dfn>
-:: A [=boolean=], initially false. Only set to true when the contribution is already filtered by the
-  trusted auction server before sent back to the client.
 : <dfn>origin</dfn>
 :: The [=origin=] of the script that contributed the entry.
 
@@ -4573,8 +4568,7 @@ an [=auction config=] |auctionConfig| and a [=reporting context=] |reportingCont
 1. [=map/For each=] (|bidId|, |event|) → |contributions| of |reportingContext|'s
   [=reporting context/private aggregation on event contributions=]:
   1. [=list/For each=] |onEventEntry| of |contributions|:
-    1. If |onEventEntry|'s [=on event contribution entry/server filtered=] is false,
-      [=iteration/continue=] if any of the following conditions hold:
+    1. [=iteration/Continue=] if any of the following conditions hold:
       * |event| is "`reserved.win`" and |bidId| is not |winnerId|;
       * |event| does not [=string/start with=] "`reserved.`" and |bidId| is not |winnerId|;
       * |event| is "`reserved.loss`" and |bidId| is |winnerId|.

--- a/spec.bs
+++ b/spec.bs
@@ -3269,14 +3269,14 @@ To <dfn>handle server response private aggregation fields</dfn> given a [=server
 
 <div algorithm>
 To <dfn>commit server response private aggregation contributions</dfn> given a [=map=] from a
-[=server auction PAgg contribution key=] to a [=list=] of [=on event contribution entries=]
+[=server auction private aggregation contribution key=] to a [=list=] of [=on event contribution entries=]
 |contributionsMap|, a [=reporting context=] |reportingContext|, and a [=reporting bid key=]
 |reportingId|:
 
 1. [=map/For each=] |key| → |contributions| of |contributionsMap|:
-  1. Let |reportingOrigin| be |key|'s [=server auction PAgg contribution key/reporting origin=].
-  1. Let |event| be |key|'s [=server auction PAgg contribution key/event=].
-  1. Let |coordinator| be |key|'s [=server auction PAgg contribution key/coordinator=].
+  1. Let |reportingOrigin| be |key|'s [=server auction private aggregation contribution key/reporting origin=].
+  1. Let |event| be |key|'s [=server auction private aggregation contribution key/event=].
+  1. Let |coordinator| be |key|'s [=server auction private aggregation contribution key/coordinator=].
   1. If |coordinator| is null, set |coordinator| to the [=default aggregation coordinator=].
   1. Let |eventToContributionsMap| be a new [=Private Aggregation contributions=].
   1. Let |batchingScope| be null.
@@ -3543,18 +3543,18 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
   : <dfn>component seller reporting</dfn>
   :: Null or [=server auction reporting info=].
   : <dfn>component win private aggregation contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction PAgg contribution keys=], and whose
-    [=map/values=] are [=lists=] of [=on event contribution entries=]. Private aggregation
+  :: A [=map=] whose [=map/keys=] are [=server auction private aggregation contribution keys=], and
+    whose [=map/values=] are [=lists=] of [=on event contribution entries=]. Private aggregation
     contributions from winners of component auctions run on trusted auction servers. These need to
     be filtered by the client based on the top level auction's outcome.
   : <dfn>server filtered private aggregation reserved contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction PAgg contribution keys=], and whose
-    [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
+  :: A [=map=] whose [=map/keys=] are [=server auction private aggregation contribution keys=], and
+    whose [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
     aggregation contributions with reserved event types (already set to "reserved.always"), which
     are not dependent on the final auction result and should always be reported.
   : <dfn>server filtered private aggregation non reserved contributions</dfn>
-  :: A [=map=] whose [=map/keys=] are [=server auction PAgg contribution keys=], and whose
-    [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
+  :: A [=map=] whose [=map/keys=] are [=server auction private aggregation contribution keys=], and
+    whose [=map/values=] are [=lists=] of [=on event contribution entries=]. Server filtered private
     aggregation contributions with non reserved event types, which are not dependent on the final
     auction result and should always be reported.
   : <dfn>component win debugging only reports</dfn>
@@ -3581,8 +3581,9 @@ a <dfn>server auction debug report key</dfn> is a [=struct=] with the following 
   :: A [=boolean=].
 </dl>
 
-a <dfn>server auction PAgg contribution key</dfn> is a [=struct=] with the following [=struct/items=]:
-<dl dfn-for="server auction PAgg contribution key">
+a <dfn>server auction private aggregation contribution key</dfn> is a [=struct=] with the following
+[=struct/items=]:
+<dl dfn-for="server auction private aggregation contribution key">
   : <dfn>reporting origin</dfn>
   :: The [=origin=] of the script that contributed the contribution.
   : <dfn>coordinator</dfn>


### PR DESCRIPTION
Client side support of private aggregation reports for auctions run on bidding and auction service.
Also fix a bug that non-reserved events should be ignored for seller scripts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1344.html" title="Last updated on Dec 17, 2024, 2:58 PM UTC (8a955e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1344/15c2623...qingxinwu:8a955e6.html" title="Last updated on Dec 17, 2024, 2:58 PM UTC (8a955e6)">Diff</a>