### PR TITLE
[Spec] Add client side support of selected reporting id for B&A

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3098,7 +3098,6 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
     [=interest group ad/render url=], then set |winningAd| to |ad|, and [=iteration/break=].
 1. Return failure if any of the following conditions hold:
   * |winningAd| is null;
-  * the result of running [=query generated bid k-anonymity count=] with |winningAd| is false;
   * |response|'s [=server auction response/buyer and seller reporting id=] is not null and not
     |winningAd|'s [=interest group ad/buyer and seller reporting ID=];
   * |response|'s [=server auction response/buyer reporting id=] is not null and not
@@ -3464,7 +3463,7 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
   :: Null or a [=string=]. When not null, this will be verified with the winning bid's
     [=generated bid/ad=]'s [=interest group ad/buyer and seller reporting ID=].
   : <dfn>selected buyer and seller reporting id</dfn>
-  :: Null or a [=string=]. When not null, this will be verified with the winning bid's
+  :: Null or a [=string=], initially null. When not null, this will be verified with the winning bid's
     [=generated bid/ad=]'s [=interest group ad/selectable buyer and seller reporting IDs=].
   : error
   :: Null or [=string=]. When not null, contains an error message from the
@@ -6405,15 +6404,14 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
     1. If |ad|'s [=interest group ad/render url=] does not equal |adUrl|, [=iteration/continue=].
     1. If |ad|'s [=interest group ad/size group=] is null and |adSize| is null, set |maybeMatchingAd|
       to |ad|, and [=iteration/break=].
-    1. If one of |ad|'s [=interest group ad/size group=] |adSize| is null, set |maybeMatchingAd| to
-      |ad|, and [=iteration/break=].
+    1. If one of |ad|'s [=interest group ad/size group=] OR |adSize| is null, set |maybeMatchingAd|
+      to |ad|, and [=iteration/break=].
 
       Note: When only one of the two ads has a size specification, they are considered matching. The
         caller is responsible for discarding the extraneous size information.
     1. [=list/For each=] |igSize| in (|ig|'s [=interest group/size groups=])[|ad|'s
        [=interest group ad/size group=]]:
       1. If |igSize| equals |adSize|, set |maybeMatchingAd| to |ad|, and [=iteration/break=].
-  1. If 
   1. Return null.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -3086,6 +3086,8 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
     |winningAd|'s [=interest group ad/buyer and seller reporting ID=];
   * |response|'s [=server auction response/buyer reporting id=] is not null and not
     |winningAd|'s [=interest group ad/buyer reporting ID=].
+  * |response|'s [=server auction response/selected buyer and seller reporting ID=] is not null and
+    not |winningAd|'s [=interest group ad/selected buyer and seller reporting ID=].
 1. Let |winningAdDescriptor| be a new [=ad descriptor=] whose [=ad descriptor/url=] is
    |response|'s [=server auction response/ad render url=].
 1. Let |winningAdComponents| be a new [=list=] of [=ad descriptors=].
@@ -3418,6 +3420,9 @@ from an auction executed on the trusted auction server. It has the following [=s
   : <dfn>buyer and seller reporting id</dfn>
   :: Null or a [=string=]. When not null, this will be verified with the winning bid's
     [=generated bid/ad=]'s [=interest group ad/buyer and seller reporting ID=].
+  : <dfn>selected buyer and seller reporting id</dfn>
+  :: Null or a [=string=]. When not null, this will be verified with the winning bid's
+    [=generated bid/ad=]'s [=interest group ad/selected buyer and seller reporting ID=].  
   : error
   :: Null or [=string=]. When not null, contains an error message from the
      auction executed on the trusted auction server. May be used to provide

--- a/spec.bs
+++ b/spec.bs
@@ -3082,12 +3082,14 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
     [=interest group ad/render url=], then set |winningAd| to |ad|, and [=iteration/break=].
 1. Return failure if any of the following conditions hold:
   * |winningAd| is null;
+  * the result of running [=query generated bid k-anonymity count=] with |winningAd| is false;
   * |response|'s [=server auction response/buyer and seller reporting id=] is not null and not
     |winningAd|'s [=interest group ad/buyer and seller reporting ID=];
   * |response|'s [=server auction response/buyer reporting id=] is not null and not
-    |winningAd|'s [=interest group ad/buyer reporting ID=].
-  * |response|'s [=server auction response/selected buyer and seller reporting ID=] is not null and
-    not |winningAd|'s [=interest group ad/selected buyer and seller reporting ID=].
+    |winningAd|'s [=interest group ad/buyer reporting ID=];
+  * |response|'s [=server auction response/selected buyer and seller reporting ID=] is not null,
+    |winningAd|'s [=interest group ad/selectable buyer and seller reporting IDs=] is not null and it
+    does not [=list/contain=] |response|'s [=server auction response/selected buyer and seller reporting ID=].
 1. Let |winningAdDescriptor| be a new [=ad descriptor=] whose [=ad descriptor/url=] is
    |response|'s [=server auction response/ad render url=].
 1. Let |winningAdComponents| be a new [=list=] of [=ad descriptors=].
@@ -3447,7 +3449,7 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
     [=generated bid/ad=]'s [=interest group ad/buyer and seller reporting ID=].
   : <dfn>selected buyer and seller reporting id</dfn>
   :: Null or a [=string=]. When not null, this will be verified with the winning bid's
-    [=generated bid/ad=]'s [=interest group ad/selected buyer and seller reporting ID=].  
+    [=generated bid/ad=]'s [=interest group ad/selectable buyer and seller reporting IDs=].
   : error
   :: Null or [=string=]. When not null, contains an error message from the
      auction executed on the trusted auction server. May be used to provide
@@ -5365,9 +5367,10 @@ from querying the server during an auction.
           [=ad descriptor/url=].
         1. If [=query k-anonymity cache=] for |componentAdHashCode| returns false, return false.
     1. If |bid|'s [=generated bid/selected buyer and seller reporting ID=] is not null:
-      1. Let |reportingHashCode| be the result of [=query reporting ID k-anonymity count=] with the |bid|'s [=generated bid/interest group=],
-        the |bid|'s [=generated bid/ad=], and the |bid|'s [=generated bid/selected buyer and seller reporting ID=].
-      1. If [=query k-anonymity cache=] for |reportingHashCode| returns false, return false.
+      1. Let |isKAnon| the result of running [=query reporting ID k-anonymity count=] with |bid|'s
+        [=generated bid/interest group=], |bid|'s [=generated bid/ad=], and |bid|'s
+        [=generated bid/selected buyer and seller reporting ID=].
+      1. If |isKAnon| is false, return false.
     1. Return true.
 </div>
 
@@ -6110,10 +6113,11 @@ Each {{InterestGroupBiddingScriptRunnerGlobalScope}} has a
 </dl>
 
 <div algorithm>
-To <dfn>convert one or many GenerateBidOutputs to a list of generated bids</dfn> given a ({{GenerateBidOutput}} or [=sequence=]<{{GenerateBidOutput}}>)
-|oneOrManyBids|, an {{unsigned short}} |multiBidLimit|, an [=interest group=] |ig|, a [=currency tag=] |expectedCurrency|, a [=boolean=]
-
+To <dfn>convert one or many GenerateBidOutputs to a list of generated bids</dfn> given a
+({{GenerateBidOutput}} or [=sequence=]<{{GenerateBidOutput}}>) |oneOrManyBids|, an {{unsigned short}}
+|multiBidLimit|, an [=interest group=] |ig|, a [=currency tag=] |expectedCurrency|, a [=boolean=]
 |isComponentAuction| and a [=boolean=] |groupHasAdComponents|:
+
   1. Let |bidSequence| be [=sequence=]<{{GenerateBidOutput}}>.
   1. If the [=specific type=] of |oneOrManyBids| is {{GenerateBidOutput}}, then set |bidSequence| to « |oneOrManyBids| ».
   1. Otherwise, set |bidSequence| to |oneOrManyBids|.
@@ -6267,16 +6271,23 @@ To <dfn>convert GenerateBidOutput to generated bid</dfn> given a {{GenerateBidOu
 
   1. Let |adUrl| be |adDescriptor|'s [=ad descriptor/url=].
   1. If |adUrl|'s [=url/scheme=] is not "`https`", return null.
+  1. Let |maybeMatchingAd| be an [=interest group ad=]-or null, set to null.
   1. Let |adSize| be |adDescriptor|'s [=ad descriptor/size=].
   1. Let |adList| be |ig|'s [=interest group/ad components=] if |isComponent|, otherwise |ig|'s
      [=interest group/ads=].
   1. [=list/For each=] |ad| in |adList|:
     1. If |ad|'s [=interest group ad/render url=] does not equal |adUrl|, [=iteration/continue=].
-    1. If |ad|'s [=interest group ad/size group=] is null, return |ad|.
-    1. If |adSize| is null, return |ad|.
+    1. If |ad|'s [=interest group ad/size group=] is null and |adSize| is null, set |maybeMatchingAd|
+      to |ad|, and [=iteration/break=].
+    1. If one of |ad|'s [=interest group ad/size group=] |adSize| is null, set |maybeMatchingAd| to
+      |ad|, and [=iteration/break=].
+
+      Note: When only one of the two ads has a size specification, they are considered matching. The
+        caller is responsible for discarding the extraneous size information.
     1. [=list/For each=] |igSize| in (|ig|'s [=interest group/size groups=])[|ad|'s
        [=interest group ad/size group=]]:
-      1. If |igSize| equals |adSize|, return |ad|.
+      1. If |igSize| equals |adSize|, set |maybeMatchingAd| to |ad|, and [=iteration/break=].
+  1. If 
   1. Return null.
 </div>
 


### PR DESCRIPTION
Add handling of selected reporting id from B&A response.
K-anon check of it will be handled in a separate PR for B&A response k-anon handling.

Also fix a bug in finding matching ad to make it align with implementation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1348.html" title="Last updated on Dec 2, 2024, 4:02 PM UTC (3f63b2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1348/64a99ce...qingxinwu:3f63b2d.html" title="Last updated on Dec 2, 2024, 4:02 PM UTC (3f63b2d)">Diff</a>