### PR TITLE
[Spec] Explicitly set service worker mode to none

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2591,17 +2591,16 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url| and an [=environment setti
     :   [=request/mode=]
     ::  "`no-cors`"
     :   [=request/referrer=]
-    :: "`no-referrer`"
+    ::  "`no-referrer`"
     :   [=request/credentials mode=]
     ::  "`omit`"
     :   [=request/redirect mode=]
-    :: "`error`"
+    ::  "`error`"
+    :   [=request/service-workers mode=]
+    ::  "`none`"
     :   [=request/policy container=]
     ::  A new [=policy container=] whose [=policy container/IP address space=] is |settings|'s
       [=environment settings object/policy container=]'s [=policy container/IP address space=]
-
-    Issue: One of the side-effects of a `null` client for this subresource request is it neuters all
-    service worker interceptions, despite not having to set the service workers mode.
 
     Issue: Stop using "`no-cors`" mode where possible
     (<a href="https://github.com/WICG/turtledove/issues/667">WICG/turtledove#667</a>).
@@ -2638,17 +2637,16 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
     :   [=request/mode=]
     ::  "`cors`"
     :   [=request/referrer=]
-    :: "`no-referrer`"
+    ::  "`no-referrer`"
     :   [=request/credentials mode=]
     ::  "`omit`"
     :   [=request/redirect mode=]
-    :: "`error`"
+    ::  "`error`"
+    :   [=request/service-workers mode=]
+    ::  "`none`"
     :   [=request/policy container=]
     ::  A new [=policy container=] whose [=policy container/IP address space=] is |policyContainer|'s
       [=policy container/IP address space=]
-
-    Issue: One of the side-effects of a `null` client for this subresource request is it neuters all
-    service worker interceptions, despite not having to set the service workers mode.
 
   1. Let |signals| be null.
   1. Let |dataVersion| be null.
@@ -2763,17 +2761,16 @@ To <dfn>send report</dfn> given a [=URL=] |url|, and an [=environment settings o
     :   [=request/mode=]
     ::  "`no-cors`"
     :   [=request/referrer=]
-    :: "`no-referrer`"
+    ::  "`no-referrer`"
     :   [=request/credentials mode=]
     ::  "`omit`"
     :   [=request/redirect mode=]
-    :: "`error`"
+    ::  "`error`"
+    :   [=request/service-workers mode=]
+    ::  "`none`"
     :   [=request/policy container=]
     ::  A new [=policy container=] whose [=policy container/IP address space=] is |settings|'s
       [=environment settings object/policy container=]'s [=policy container/IP address space=]
-
-    Issue: One of the side-effects of a `null` client for this subresource request is it neuters
-    all service worker interceptions, despite not having to set the service workers mode.
 
     Issue: Stop using "`no-cors`" mode where possible
     (<a href="https://github.com/WICG/turtledove/issues/667">WICG/turtledove#667</a>).
@@ -4068,17 +4065,16 @@ Initial implementation of this specification defines
     :   [=request/mode=]
     ::  "`no-cors`"
     :   [=request/referrer=]
-    :: "`no-referrer`"
+    ::  "`no-referrer`"
     :   [=request/credentials mode=]
     ::  "`omit`"
     :   [=request/redirect mode=]
-    :: "`error`"
+    ::  "`error`"
+    :   [=request/service-workers mode=]
+    ::  "`none`"
     :   [=request/policy container=]
     ::  A new [=policy container=] whose [=policy container/IP address space=] is |settings|'s
       [=environment settings object/policy container=]'s [=policy container/IP address space=]
-
-    Issue: One of the side-effects of a `null` client for this subresource request is it neuters
-    all service worker interceptions, despite not having to set the service workers mode.
 
     Issue: Stop using "`no-cors`" mode where possible
     (<a href="https://github.com/WICG/turtledove/issues/667">WICG/turtledove#667</a>).
@@ -6528,17 +6524,16 @@ navigating to another page. Some implementations, such as Chromium, have chosen 
       :   [=request/mode=]
       ::  "`no-cors`"
       :   [=request/referrer=]
-      :: "`no-referrer`"
+      ::  "`no-referrer`"
       :   [=request/credentials mode=]
       ::  "`omit`"
       :   [=request/redirect mode=]
-      :: "`error`"
+      ::  "`error`"
+      :   [=request/service-workers mode=]
+      ::  "`none`"
       :   [=request/policy container=]
       ::  A new [=policy container=] whose [=policy container/IP address space=] is |policyContainer|'s
         [=policy container/IP address space=]
-
-      Issue: One of the side-effects of a `null` client for this subresource request is it neuters
-      all service worker interceptions, despite not having to set the service workers mode.
 
       Issue: Stop using "`no-cors`" mode where possible
       (<a href="https://github.com/WICG/turtledove/issues/667">WICG/turtledove#667</a>).
@@ -7080,11 +7075,11 @@ To <dfn>check interest group permissions</dfn> given an [=origin=] |ownerOrigin|
   :   [=request/mode=]
   ::  "`cors`"
   :   [=request/referrer=]
-  :: "`no-referrer`"
+  ::  "`no-referrer`"
   :   [=request/credentials mode=]
   ::  "`omit`"
   :   [=request/redirect mode=]
-  :: "`error`"
+  ::  "`error`"
   :   [=request/service-workers mode=]
   ::  `none`
   :   [=request/policy container=]
@@ -8239,12 +8234,11 @@ a [=script fetcher=] |fetcher|:
     ::  "`omit`"
     :   [=request/redirect mode=]
     ::  "`error`"
+    :   [=request/service-workers mode=]
+    ::  "`none`"
     :   [=request/policy container=]
     ::  A new [=policy container=] whose [=policy container/IP address space=] is |settings|'s
       [=environment settings object/policy container=]'s [=policy container/IP address space=]
-
-    Issue: One of the side-effects of a `null` client for this subresource request is it neuters all
-    service worker interceptions, despite not having to set the service workers mode.
 
     Issue: Stop using "`no-cors`" mode where possible
     (<a href="https://github.com/WICG/turtledove/issues/667">WICG/turtledove#667</a>).


### PR DESCRIPTION
Set requests' service worker mode to null,  instead of using a note to explain the service working mode being null when client is set to null.
It first came from[ this comment](https://github.com/WICG/turtledove/pull/1246#discussion_r1707733830)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/pull/1351.html" title="Last updated on Dec 1, 2024, 10:32 PM UTC (5e3091e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1351/4a5cbfb...5e3091e.html" title="Last updated on Dec 1, 2024, 10:32 PM UTC (5e3091e)">Diff</a>