### PR TITLE
Remove padding from base64url hash examples

### DIFF
--- a/FLEDGE_browser_bidding_and_auction_API.md
+++ b/FLEDGE_browser_bidding_and_auction_API.md
@@ -88,18 +88,18 @@ Response blobs can also be retrieved using an `iframe` navigation by specifying 
 For each response blob sent back to the browser, the seller’s server attaches a response header containing the base64url encoded (RFC 4648 section 5) SHA-256 hash of the response blob:
 
 ```
-Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0=
+Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0
 ```
 
 Multiple hashes can be included in a response by either repeating the
 header or by specifying multiple hashes separated by a `,` character. So
 ```
-Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0=,9UTB-u-WshX66Xqz5DNCpEK9z-x5oCS5SXvgyeoRB1k=
+Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0,9UTB-u-WshX66Xqz5DNCpEK9z-x5oCS5SXvgyeoRB1k
 ```
 is equivalent to
 ```
-Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0=
-Ad-Auction-Result: 9UTB-u-WshX66Xqz5DNCpEK9z-x5oCS5SXvgyeoRB1k=
+Ad-Auction-Result: ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0
+Ad-Auction-Result: 9UTB-u-WshX66Xqz5DNCpEK9z-x5oCS5SXvgyeoRB1k
 ```
 and both versions should be accepted.
 


### PR DESCRIPTION
This padding is not necessary and not usually part of base64url encoded bytes. Removing the padding to make it harder for people to confuse them with base64url encoded bytes.