### PR TITLE
PMT API surface updates

### DIFF
--- a/PA_private_model_training.md
+++ b/PA_private_model_training.md
@@ -38,8 +38,8 @@ function generateBid(...) {
 
 ## Configuring the encrypted payload and emitting it in `reportWin`
 
-In order to avoid the length (and other metadata) about the payload being a privacy leak vector, it cannot be configured based on protected cross-site data (e.g. from within `generateBid`). We propose enabling this kind of configuration from within `reportWin`.
-
+In order to avoid the length (and other metadata) about the payload being a privacy leak vector, it cannot be configured based on protected cross-site data (e.g. from within `generateBid`). We propose enabling this kind of configuration from within `reportWin`,
+which will configure a new function (`reportAggregateWin`) to run. This new function will have access to the `aggregateWinSignals` returned from `generateBid`.
 
 ```javascript
 function reportWin(...) {


### PR DESCRIPTION
This PR fixes #1356 by allowing for processing modeling signals in `reportWin` out of the critical bidding path. This is beneficial for latency in cases where generating the encrypted modeling signals vector may impact auction latency.

Additionally, the new API unlocks the possibility to use PAA with sensitive (i.e. previously readable only within `generateBid`) data outside of the critical path.

Finally, the API is simplified in that we don't overload the `modelingSignals` output of `generateBid` anymore. We also
slightly backtrack on having the payload format be a raw Uint8 array, since we aren't quite ready to commit to that and we are investigating alternatives.


Feedback welcome!