### PR TITLE
[Explainer] Remove web bundle directFromSellerSignals

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -24,7 +24,7 @@ See [the Protected Audience API specification](https://wicg.github.io/turtledove
     - [2.3 Scoring Bids](#23-scoring-bids)
     - [2.4 Scoring Bids in Component Auctions](#24-scoring-bids-in-component-auctions)
     - [2.5 Additional Trusted Signals (directFromSellerSignals)](#25-additional-trusted-signals-directfromsellersignals)
-      - [2.5.1 Using Response Headers](#252-using-response-headers)
+      - [2.5.1 Using Response Headers](#251-using-response-headers)
   - [3. Buyers Provide Ads and Bidding Functions (BYOS for now)](#3-buyers-provide-ads-and-bidding-functions-byos-for-now)
     - [3.1 Fetching Real-Time Data from a Trusted Server](#31-fetching-real-time-data-from-a-trusted-server)
       - [3.1.1 Cross-Origin Trusted Server Signals](#311-cross-origin-trusted-server-signals)
@@ -1554,7 +1554,7 @@ Note that the key fields are used by the browser both to verify the signature, a
 
 The browser ensures, using TLS, the authenticity and integrity of information provided to the auction through calls made directly to an ad tech's servers. This guarantee is not provided for data passed in `runAdAuction()`. To account for this, additional bids use the same HTTP response header interception mechanism that's already in use for the [Bidding & Auction response blob](FLEDGE_browser_bidding_and_auction_API.md#step-3-get-response-blobs-to-browser) and `directFromSellerSignals`.
 
-Servers return additional bids to the browser using the `Ad-Auction-Additional-Bid` response header of some `fetch()` request or `iframe` navigation, together with the `additionalBids` field on `navigator.runAdAuction()`. This uses the same syntax as that used to convey `directFromSellerSignals` [using response headers](#252-using-response-headers).
+Servers return additional bids to the browser using the `Ad-Auction-Additional-Bid` response header of some `fetch()` request or `iframe` navigation, together with the `additionalBids` field on `navigator.runAdAuction()`. This uses the same syntax as that used to convey `directFromSellerSignals` [using response headers](#251-using-response-headers).
 
 To request additional bids using a [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) call made by some script on the page (including in a subframe), specify an extra option, `{adAuctionHeaders: true}`:
 


### PR DESCRIPTION
Header-based directFromSellerSignals (directFromSellerSignalsHeaderAdSlot), which replaces web bundle directFromSellerSignals, is unaffected.

Usage of web bundle directFromSellerSignals is extremely low: https://chromestatus.com/metrics/feature/timeline/popularity/5034.

The feature was originally requested in https://github.com/WICG/turtledove/issues/119, and the header-based version was requested in https://github.com/WICG/turtledove/issues/119#issuecomment-1274013176.

Blink I2D&R thread: https://groups.google.com/a/chromium.org/g/blink-dev/c/t9gHiTwV370

Chromium removal bug: https://crbug.com/384481095