### PR TITLE
[Spec] Align with IETF spec on some details

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3120,6 +3120,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
 1. Let |bidDebugReportingInfo| be a new [=bid debug reporting info=].
 1. [=list/For each=] |key| → |maybeDebugReportUrl| in |response|'s
   [=server auction response/component win debugging only reports=]:
+  1. If |maybeDebugReportUrl|'s [=url/scheme=] is not "`https`", then [=iteration/continue=].
   1. If |key|'s [=server auction debug report key/from seller=] is true:
     1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/component seller=] to |seller|.
     1. If |key|'s [=server auction debug report key/is debug win=] is true, then set
@@ -3136,7 +3137,7 @@ a [=list=] of [=interest groups=] |bidIgs|, and a [=reporting context map=]
     1. Otherwise, set |bidDebugReportingInfo|'s
       [=bid debug reporting info/bidder debug loss report url=] to |maybeDebugReportUrl|.
 1. Set |bidDebugReportingInfo|'s [=bid debug reporting info/server filtered debugging only reports=]
-  to [=server auction response/server filtered debugging only reports=].
+  to |response|'s [=server auction response/server filtered debugging only reports=].
 1. Let |reportingContext| be |reportingContextMap|[|auctionConfig|].
 1. Set |reportingContext|'s [=reporting context/debug reporting info=] to
   |bidDebugReportingInfo|.
@@ -3559,7 +3560,7 @@ A <dfn>server auction response</dfn> is a [=struct=] that contains auction resul
     auction result and should always be reported.
   : <dfn>component win debugging only reports</dfn>
   :: A [=map=] whose [=map/keys=] are [=server auction debug report keys=], and whose [=map/values=]
-    are [=lists=] of [=urls=].
+    are [=urls=].
   : <dfn>server filtered debugging only reports</dfn>
   :: A [=map=] whose [=map/keys=] are [=origins=] and whose [=map/values=] are [=lists=] of [=urls=].
 </dl>


### PR DESCRIPTION
for B&A debug reports handling:
1. Add check about if debug report url is https in w3c spec
2. [=component win debug reports=][key] is a single url, not a list of urls. Although the w3c spec defined it as a list, but was used as a single URL anyways. Change to align with IETF spec as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/qingxinwu/turtledove/pull/1371.html" title="Last updated on Dec 18, 2024, 4:28 PM UTC (b36e6f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1371/c741073...qingxinwu:b36e6f2.html" title="Last updated on Dec 18, 2024, 4:28 PM UTC (b36e6f2)">Diff</a>