### PR TITLE
Spec: add glue for Private Aggregation's per-context contribution limits

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -100,7 +100,7 @@ spec: private-aggregation-api; urlPrefix: https://patcg-individual-drafts.github
     for: pre-specified report parameters
       text: context ID
       text: filtering ID max bytes
-      text: requested max contributions
+      text: max contributions
     text: set the pre-specified report parameters for a batching scope
 spec: Shared Storage API; urlPrefix: https://wicg.github.io/shared-storage
   type: dfn
@@ -4829,11 +4829,11 @@ an [=auction config=] |auctionConfig| and a [=reporting context=] |reportingCont
       :: null
       : [=pre-specified report parameters/filtering ID max bytes=]
       :: [=default filtering ID max bytes=]
-      : <var ignore>requested max contributions</var>
-      :: |auctionConfig|'s [=auction config/requested max contributions=]
+      : <var ignore>max contributions</var>
+      :: |auctionConfig|'s [=auction config/max contributions=]
 
-        Issue: Remove the `ignore` tag on <var ignore>requested max
-               contributions</var> once Private Aggregation's [PR
+        Issue: Remove the `ignore` tag on <var ignore>max contributions</var>
+               once Private Aggregation's [PR
                #164](https://github.com/patcg-individual-drafts/private-aggregation-api/pull/164)
                is merged.
 
@@ -8361,7 +8361,7 @@ An <dfn export>auction config</dfn> is a [=struct=] with the following [=struct/
   :: A [=map=] from [=strings=] to {{AuctionReportBuyersConfig}}s. For buyer metrics delegated to be
     reported to the seller via the [Private Aggregation API](https://github.com/patcg-individual-drafts/private-aggregation-api),
     this determines how each metric bucket is chosen inside the buyer's space, and how to scale it.
-  : <dfn>requested max contributions</dfn>
+  : <dfn>max contributions</dfn>
   :: Null or a positive integer. Used to override [Private Aggregation
     API](https://github.com/patcg-individual-drafts/private-aggregation-api)'s
     default number of contributions per report.


### PR DESCRIPTION
Explainer: https://github.com/patcg-individual-drafts/private-aggregation-api/pull/146

Spec change: https://github.com/patcg-individual-drafts/private-aggregation-api/pull/164


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmcardle/turtledove/pull/1378.html" title="Last updated on Jan 10, 2025, 9:14 PM UTC (df4f34a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1378/7f754f0...dmcardle:df4f34a.html" title="Last updated on Jan 10, 2025, 9:14 PM UTC (df4f34a)">Diff</a>