### PR TITLE
Remove Bidding Signals Format "V1" support

### DIFF
--- a/FLEDGE.md
+++ b/FLEDGE.md
@@ -765,8 +765,6 @@ The response from the server should be a JSON object of the form:
 }
 ```
 
-and the server must include the HTTP response header `X-fledge-bidding-signals-format-version: 2`.  If the server does not include the header, the response will assumed to be an in older format, where the response is only the contents of the `keys` dictionary.
-
 The value of each key that an interest group has in its `trustedBiddingSignalsKeys` list will be passed from the `keys` dictionary to the interest group's generateBid() function as the `trustedBiddingSignals` parameter. Values missing from the JSON object will be set to null. If the JSON download fails, or there are no `trustedBiddingSignalsKeys` or `trustedBiddingSignalsURL` in the interest group, then the `trustedBiddingSignals` argument to generateBid() will be null.
 
 The `perInterestGroupData` dictionary contains optional data for interest groups whose names were included in the request URL. The `priorityVector` will be used to calculate the final priority for an interest group, if that interest group has `enableBiddingSignalsPrioritization` set to true in its definition. Otherwise, it's only used to filter out interest groups, if the dot product with `prioritySignals` is negative. See [Filtering and Prioritizing Interest Groups](#35-filtering-and-prioritizing-interest-groups) for more information.

--- a/spec.bs
+++ b/spec.bs
@@ -2658,8 +2658,6 @@ To <dfn>fetch WebAssembly</dfn> given a [=URL=] |url| and an [=environment setti
 
 The <dfn http-header><code>Data-Version</code></dfn> HTTP response header is a
 [=structured header=] whose value must be an [=structured header/integer=].
-The <dfn http-header><code>X-fledge-bidding-signals-format-version</code></dfn> HTTP response header
-is a [=structured header=] whose value must be an [=structured header/integer=].
 
 <div algorithm>
 To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |scriptOrigin|, a
@@ -2690,7 +2688,6 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
 
   1. Let |signals| be null.
   1. Let |dataVersion| be null.
-  1. Let |formatVersion| be null.
   1. Let |perInterestGroupData| be an [=ordered map=] whose [=map/keys=] are [=interest group/name=]
     [=strings=] and whose [=map/values=] are [=bidding signals per interest group data=].
   1. [=Fetch=] |request| with [=fetch/useParallelQueue=] set to true, and
@@ -2704,20 +2701,16 @@ To <dfn>fetch trusted signals</dfn> given a [=URL=] |url|, an [=origin=] |script
     1. If |dataVersion| is not null:
       1. If |dataVersion| is not an integer, or is less than 0 or more than 2<sup>32</sup>&minus;1,
         set |signals| to failure and return.
-    1. If |isBiddingSignal| is true, then set |formatVersion| to the result of
-      [=header list/getting a structured field value=] given
-      [:X-fledge-bidding-signals-format-version:] and "`item`" from |headers|.
     1. Set |signals| to the result of [=parsing JSON bytes to an Infra value=] |responseBody|.
   1. Wait for |signals| to be set.
   1. If |signals| is a parsing exception, or if |signals| is not an [=ordered map=], return « null,
     null, null ».
-  1. If |formatVersion| is 2:
-    1. If |signals|["`keys`"] does not [=map/exist=], return « null, null ».
-    1. Set |signals| to |signals|["`keys`"].
-    1. If |signals| is not an [=ordered map=], return « null, null ».
-    1. If |signals|["`perInterestGroupData`"] [=map/exists=] and is an [=ordered map=]:
-      1. [=Assert=] |isBiddingSignal| is true.
-      1. Let |perInterestGroupData| be |signals|["`perInterestGroupData`"].
+  1. If |signals|["`keys`"] does not [=map/exist=], return « null, null ».
+  1. Set |signals| to |signals|["`keys`"].
+  1. If |signals| is not an [=ordered map=], return « null, null ».
+  1. If |signals|["`perInterestGroupData`"] [=map/exists=] and is an [=ordered map=]:
+    1. [=Assert=] |isBiddingSignal| is true.
+    1. Let |perInterestGroupData| be |signals|["`perInterestGroupData`"].
   1. [=map/For each=] |key| → |value| of |signals|:
     1. [=map/Set=] |signals|[|key|] to the result of [=serializing an Infra value to a JSON string=]
       given |value|.


### PR DESCRIPTION
This removes mention of the Trusted Bidding Signals V1 format, as well as the "Bidding-Signals-Format-Version: 2" header, as there's no plan for a version 3, and "version 2" can be easily confused with the KVv2 API.  All responses will be assumed to be version 2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MattMenke2/turtledove/pull/1390.html" title="Last updated on Jan 28, 2025, 6:31 PM UTC (e8a8a0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/turtledove/1390/b3808be...MattMenke2:e8a8a0e.html" title="Last updated on Jan 28, 2025, 6:31 PM UTC (e8a8a0e)">Diff</a>