### PR TITLE
[PMT-Explainer] Update Private model training explainer.

### DIFF
--- a/PA_private_model_training.md
+++ b/PA_private_model_training.md
@@ -76,7 +76,7 @@ function reportAggregateWin(aggregateWinSignals, modelingSignalsConfig, <reportW
 
 ## Payload format
 
-The POST request payload will be encoded using the [CBOR](https://cbor.io/) with the following format:
+The POST request payload will be encoded using [CBOR](https://cbor.io/) with the following format:
 
 ```javascript
 {

--- a/PA_private_model_training.md
+++ b/PA_private_model_training.md
@@ -90,7 +90,7 @@ The POST request payload will be encoded using [CBOR](https://cbor.io/) with the
 ```
 
 ### Shared info
-`shared_info` is used for privacy budgeting purposes, used as authenticated data in the encrypted payload. Similar to aggregatable reports in Private Aggregation API.
+`shared_info` is used for privacy budgeting purposes, used as authenticated data in the encrypted payload. Similar to aggregatable reports in Private Aggregation API. `shared_info` will have the following format:
 
 ```javascript
   "shared_info": {


### PR DESCRIPTION
This revision solidifies some areas of the Private Model Training API explainer, resolving some previously pending design considerations. 